### PR TITLE
Y-shearing camera formula

### DIFF
--- a/TheForceEngine/TFE_Jedi/Math/core_math.h
+++ b/TheForceEngine/TFE_Jedi/Math/core_math.h
@@ -268,6 +268,12 @@ namespace TFE_Jedi
 		return sinf(scale * angle);
 	}
 
+	inline f32 tanFlt(f32 angle)
+	{
+		const f32 scale = 2.0f * PI / 16384.0f;
+		return tanf(scale * angle);
+	}
+
 	void computeTransformFromAngles_Float(f32 yaw, f32 pitch, f32 roll, f32* transform);
 
 	inline u32 previousPowerOf2(u32 x)

--- a/TheForceEngine/TFE_Jedi/Renderer/RClassic_Float/rclassicFloat.cpp
+++ b/TheForceEngine/TFE_Jedi/Renderer/RClassic_Float/rclassicFloat.cpp
@@ -67,7 +67,7 @@ namespace RClassic_Float
 
 		s_rcfltState.cameraYaw = yaw;
 		s_rcfltState.cameraPitch = pitch;
-		const f32 pitchOffsetScale = 226.0f * s_rcfltState.focalLenAspect/160.0f;	// half_width / sin(360*2047/16384)
+		const f32 pitchOffsetScale = s_rcfltState.focalLenAspect;	// half_width / sin(360*2047/16384)
 
 		s_xOffset = -camX;
 		s_zOffset = -camZ;
@@ -76,8 +76,8 @@ namespace RClassic_Float
 		s_rcfltState.negSinYaw = -s_rcfltState.sinYaw;
 		if (s_maxPitch != s_rcfltState.cameraPitch)
 		{
-			f32 sinPitch = sinFlt(s_rcfltState.cameraPitch);
-			f32 pitchOffset = sinPitch * pitchOffsetScale;
+			f32 tanPitch = tanFlt(s_rcfltState.cameraPitch);
+			f32 pitchOffset = tanPitch * pitchOffsetScale;
 			s_rcfltState.projOffsetY = s_rcfltState.projOffsetYBase + pitchOffset;
 			s_screenYMidFlt = s_screenYMidBase + (s32)floorf(pitchOffset);
 


### PR DESCRIPTION
This changes the formula used to calculate the viewport offset during Y-shearing to that of `tan(pitch)` instead of `sin(pitch)`, and also modifies `pitchOffsetScale` to be equal to `s_rcfltState.focalLenAspect`.

Close to the pitch of 0, sine and tangent are pretty much the same, but for higher angles, they begin to diverge. The point of using tan here is to be able to map the pitch to any (unbounded) offset, with the angle of 90 ° corresponding to infinity (yes, this is what should happen if you look right above or below).

Adjustments might be made to `pitchOffsetScale`, and possible the pitch range (but that seems to be preserved). Based on my older tests, `pitchOffsetScale` should be `1 / tan(fov)`, but I am not sure how that maps to the variables used by the renderer, so I am leaving it be for now.