### PR TITLE
Move from critical section to SRWLocks

### DIFF
--- a/TheForceEngine/TFE_System/Threads/Win32/mutexWin32.cpp
+++ b/TheForceEngine/TFE_System/Threads/Win32/mutexWin32.cpp
@@ -2,23 +2,23 @@
 
 MutexWin32::MutexWin32() : Mutex()
 { 
-	InitializeCriticalSection(&C); 
+	InitializeSRWLock(&C);
 }
 
 MutexWin32::~MutexWin32()
 { 
-	DeleteCriticalSection(&C); 
+ 
 }
 
 s32 MutexWin32::lock()
 { 
-	EnterCriticalSection(&C); 
+	AcquireSRWLockExclusive(&C);
 	return 0; 
 }
 
 s32 MutexWin32::unlock()
 { 
-	LeaveCriticalSection(&C); 
+	ReleaseSRWLockExclusive(&C);
 	return 0; 
 }
 

--- a/TheForceEngine/TFE_System/Threads/Win32/mutexWin32.h
+++ b/TheForceEngine/TFE_System/Threads/Win32/mutexWin32.h
@@ -12,5 +12,5 @@ public:
 	virtual s32 unlock();
 
 private:
-	mutable CRITICAL_SECTION C;
+	SRWLOCK C;
 };


### PR DESCRIPTION
SRWLocks are smaller (8b vs 40b for critical section) and faster to lock/unlock