### PR TITLE
add command-line support for changing the midi device

### DIFF
--- a/TheForceEngine/TFE_Audio/midiDevice.cpp
+++ b/TheForceEngine/TFE_Audio/midiDevice.cpp
@@ -29,6 +29,16 @@ namespace TFE_MidiDevice
 		s_midiout->setErrorCallback(midiErrorCallback);
 		s_openPort = -1;
 
+		u32 device_count = getDeviceCount();
+		for (u32 i = 0; i < device_count; i++)
+		{
+			auto buffer = new char[255];
+			getDeviceName(i, buffer, 255);
+			auto deviceName = std::string(buffer);
+			std::string logString = "Midi Device " + std::to_string(i) + ": " + deviceName;
+			TFE_System::logWrite(LOG_MSG, "Startup", logString.c_str());
+		}
+
 		return true;
 	}
 

--- a/TheForceEngine/TFE_Audio/midiPlayer.cpp
+++ b/TheForceEngine/TFE_Audio/midiPlayer.cpp
@@ -78,7 +78,8 @@ namespace TFE_MidiPlayer
 		TFE_System::logWrite(LOG_MSG, "Startup", "TFE_MidiPlayer::init");
 
 		bool res = TFE_MidiDevice::init();
-		TFE_MidiDevice::selectDevice(0);
+		TFE_Settings_Sound* soundSettings = TFE_Settings::getSoundSettings();
+		TFE_MidiDevice::selectDevice(soundSettings->midiPort);
 		s_runMusicThread.store(true);
 
 		MUTEX_INITIALIZE(&s_mutex);
@@ -92,7 +93,6 @@ namespace TFE_MidiPlayer
 		CCMD("setMusicVolume", setMusicVolumeConsole, 1, "Sets the music volume, range is 0.0 to 1.0");
 		CCMD("getMusicVolume", getMusicVolumeConsole, 0, "Get the current music volume where 0 = silent, 1 = maximum.");
 
-		TFE_Settings_Sound* soundSettings = TFE_Settings::getSoundSettings();
 		setVolume(soundSettings->musicVolume);
 		setMaximumNoteLength();
 

--- a/TheForceEngine/TFE_Settings/settings.h
+++ b/TheForceEngine/TFE_Settings/settings.h
@@ -127,6 +127,7 @@ struct TFE_Settings_Sound
 	f32 cutsceneMusicVolume = 1.0f;
 	bool use16Channels = false;
 	bool disableSoundInMenus = false;
+	u32 midiPort = 0;
 };
 
 struct TFE_Game

--- a/TheForceEngine/main.cpp
+++ b/TheForceEngine/main.cpp
@@ -910,5 +910,11 @@ void parseOption(const char* name, const std::vector<const char*>& values, bool 
 				s_startupGame = Game_Dark_Forces;
 			}
 		}
+		else if (strcasecmp(name, "midi") == 0 && values.size() >= 1) // Directly load a game, skipping the titlescreen.
+		{
+			const char* midiDev = values[0];
+			TFE_System::logWrite(LOG_MSG, "CommandLine", "Selected midi device: %s", midiDev);
+			TFE_Settings::getSoundSettings()->midiPort = atoi(midiDev);
+		}	
 	}
 }


### PR DESCRIPTION
This PR adds a command-line parameter which allows the selection of a midi device other than the default.

The workflow with this solution is as follows:

- Start the engine
- All available midi devices with their port number are logged
- Get the desired port number from the logs
- Restart the engine using the command line parameter "--midi X", whereas X is the port number

I know that it would be better to have it configurable in the settings, but I only have very basic C++ knowledge :)