### PR TITLE
Explicit template specialization is not supported under GCC yet

### DIFF
--- a/TheForceEngine/TFE_FileSystem/filestream.cpp
+++ b/TheForceEngine/TFE_FileSystem/filestream.cpp
@@ -249,8 +249,7 @@ void FileStream::flush()
 }
 
 //internal
-template <>	//template specialization for the string type since it has to be handled differently.
-void FileStream::readType<std::string>(std::string* ptr, u32 count)
+void FileStream::readTypeStr(std::string* ptr, u32 count)
 {
 	assert(m_mode == MODE_READ || m_mode == MODE_READWRITE);
 	assert(count <= 256);
@@ -275,8 +274,8 @@ void FileStream::readType(T* ptr, u32 count)
 	readBuffer(ptr, sizeof(T), count);
 }
 
-template <>	//template specialization for the string type since it has to be handled differently.
-void FileStream::writeType<std::string>(const std::string* ptr, u32 count)
+
+void FileStream::writeTypeStr(const std::string* ptr, u32 count)
 {
 	assert(m_mode == MODE_WRITE || m_mode == MODE_READWRITE);
 	assert(m_file);	// TODO: Add Archive support.

--- a/TheForceEngine/TFE_FileSystem/filestream.h
+++ b/TheForceEngine/TFE_FileSystem/filestream.h
@@ -42,7 +42,7 @@ public:
 	void read(u64* ptr, u32 count=1) override { readType(ptr, count); }
 	void read(f32* ptr, u32 count=1) override { readType(ptr, count); }
 	void read(f64* ptr, u32 count=1) override { readType(ptr, count); }
-	void read(std::string* ptr, u32 count=1) override { readType(ptr, count); }
+	void read(std::string* ptr, u32 count=1) override { readTypeStr(ptr, count); }
 	u32  readBuffer(void* ptr, u32 size, u32 count=1) override;
 
 	void write(const s8*  ptr, u32 count=1)  override { writeType(ptr, count); }
@@ -55,7 +55,7 @@ public:
 	void write(const u64* ptr, u32 count=1)  override { writeType(ptr, count); }
 	void write(const f32* ptr, u32 count=1) override { writeType(ptr, count); }
 	void write(const f64* ptr, u32 count=1) override { writeType(ptr, count); }
-	void write(const std::string* ptr, u32 count=1) override { writeType(ptr, count); }
+	void write(const std::string* ptr, u32 count=1) override { writeTypeStr(ptr, count); }
 	void writeBuffer(const void* ptr, u32 size, u32 count=1) override;
 
 	void writeString(const char* fmt, ...) override;
@@ -64,14 +64,12 @@ private:
 	template <typename T>
 	void readType(T* ptr, u32 count);
 
-	template <>
-	void readType<std::string>(std::string* ptr, u32 count);
+	void readTypeStr(std::string* ptr, u32 count);
 
 	template <typename T>
 	void writeType(const T* ptr, u32 count);
 
-	template <>
-	void writeType<std::string>(const std::string* ptr, u32 count);
+	void writeTypeStr(const std::string* ptr, u32 count);
 
 private:
 	FILE*    m_file;

--- a/TheForceEngine/TFE_FileSystem/memorystream.cpp
+++ b/TheForceEngine/TFE_FileSystem/memorystream.cpp
@@ -168,8 +168,7 @@ void MemoryStream::writeString(const char* fmt, ...)
 }
 
 //internal
-template <>	//template specialization for the string type since it has to be handled differently.
-void MemoryStream::readType<std::string>(std::string* ptr, u32 count)
+void MemoryStream::readTypeStr(std::string* ptr, u32 count)
 {
 	assert(count <= 256);
 	//first read the length.
@@ -192,8 +191,7 @@ void MemoryStream::readType(T* ptr, u32 count)
 	readBuffer(ptr, sizeof(T), count);
 }
 
-template <>	//template specialization for the string type since it has to be handled differently.
-void MemoryStream::writeType<std::string>(const std::string* ptr, u32 count)
+void MemoryStream::writeTypeStr(const std::string* ptr, u32 count)
 {
 	assert(m_memory);
 	assert(count <= 256);

--- a/TheForceEngine/TFE_FileSystem/memorystream.h
+++ b/TheForceEngine/TFE_FileSystem/memorystream.h
@@ -45,7 +45,7 @@ public:
 	void read(u64* ptr, u32 count=1) override { readType(ptr, count); }
 	void read(f32* ptr, u32 count=1) override { readType(ptr, count); }
 	void read(f64* ptr, u32 count=1) override { readType(ptr, count); }
-	void read(std::string* ptr, u32 count=1) override { readType(ptr, count); }
+	void read(std::string* ptr, u32 count=1) override { readTypeStr(ptr, count); }
 	u32  readBuffer(void* ptr, u32 size, u32 count=1) override;
 
 	void write(const s8*  ptr, u32 count=1)  override { writeType(ptr, count); }
@@ -58,7 +58,7 @@ public:
 	void write(const u64* ptr, u32 count=1)  override { writeType(ptr, count); }
 	void write(const f32* ptr, u32 count=1) override { writeType(ptr, count); }
 	void write(const f64* ptr, u32 count=1) override { writeType(ptr, count); }
-	void write(const std::string* ptr, u32 count=1) override { writeType(ptr, count); }
+	void write(const std::string* ptr, u32 count=1) override { writeTypeStr(ptr, count); }
 	void writeBuffer(const void* ptr, u32 size, u32 count=1) override;
 
 	void writeString(const char* fmt, ...) override;
@@ -67,14 +67,12 @@ private:
 	template <typename T>
 	void readType(T* ptr, u32 count);
 
-	template <>
-	void readType<std::string>(std::string* ptr, u32 count);
+	void readTypeStr(std::string* ptr, u32 count);
 
 	template <typename T>
 	void writeType(const T* ptr, u32 count);
 
-	template <>
-	void writeType<std::string>(const std::string* ptr, u32 count);
+	void writeTypeStr(const std::string* ptr, u32 count);
 
 	void resizeBuffer(size_t newSize);
 


### PR DESCRIPTION
This patch removes the explicit template specialization by simply naming these methods and calling them explicitly as the caller is not templated so it doesnt affect the code path.

For more info see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85282

Note I have a fork on github starting to add CMakeLists and trying to build on linux over here: https://github.com/philberty/theforceengine