### PR TITLE
Added MIDI Device Selection in Sound Settings

### DIFF
--- a/TheForceEngine/TFE_Audio/midiDevice.cpp
+++ b/TheForceEngine/TFE_Audio/midiDevice.cpp
@@ -58,6 +58,11 @@ namespace TFE_MidiDevice
 		buffer[copyLength] = 0;
 	}
 
+	std::string getDeviceNameStr(u32 index) {
+		if (index > getDeviceCount()) { return ""; }
+		std::string name = s_midiout->getPortName(index);
+		return name;
+	}
 	void selectDevice(u32 index)
 	{
 		if (!s_midiout) { return; }

--- a/TheForceEngine/TFE_Audio/midiDevice.h
+++ b/TheForceEngine/TFE_Audio/midiDevice.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <TFE_System/types.h>
+#include <string>
 
 namespace TFE_MidiDevice
 {
@@ -8,6 +9,7 @@ namespace TFE_MidiDevice
 
 	u32  getDeviceCount();
 	void getDeviceName(u32 index, char* buffer, u32 maxLength);
+	std::string getDeviceNameStr(u32 index);
 	void selectDevice(u32 index);
 
 	void sendMessage(const u8* msg, u32 size);

--- a/TheForceEngine/TFE_Audio/midiPlayer.cpp
+++ b/TheForceEngine/TFE_Audio/midiPlayer.cpp
@@ -73,12 +73,12 @@ namespace TFE_MidiPlayer
 	void setMusicVolumeConsole(const ConsoleArgList& args);
 	void getMusicVolumeConsole(const ConsoleArgList& args);
 
-	bool init()
+	bool init(int devIndex)
 	{
 		TFE_System::logWrite(LOG_MSG, "Startup", "TFE_MidiPlayer::init");
 
 		bool res = TFE_MidiDevice::init();
-		TFE_MidiDevice::selectDevice(0);
+		TFE_MidiDevice::selectDevice(devIndex);
 		s_runMusicThread.store(true);
 
 		MUTEX_INITIALIZE(&s_mutex);

--- a/TheForceEngine/TFE_Audio/midiPlayer.h
+++ b/TheForceEngine/TFE_Audio/midiPlayer.h
@@ -4,7 +4,7 @@ struct GMidiAsset;
 
 namespace TFE_MidiPlayer
 {
-	bool init();
+	bool init(int devIndex);
 	void destroy();
 	
 	///////////////////////////////////////////////////////////

--- a/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
+++ b/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
@@ -3,6 +3,7 @@
 #include "profilerView.h"
 #include "modLoader.h"
 #include <TFE_Audio/audioSystem.h>
+#include <TFE_Audio/midiDevice.h>
 #include <TFE_Audio/midiPlayer.h>
 #include <TFE_DarkForces/config.h>
 #include <TFE_Game/reticle.h>
@@ -2231,6 +2232,26 @@ namespace TFE_FrontEndUI
 
 		TFE_Audio::setVolume(sound->soundFxVolume);
 		TFE_MidiPlayer::setVolume(sound->musicVolume);
+
+		int MIDI_DeviceCount = TFE_MidiDevice::getDeviceCount();
+		const char* MIDI_Devices;
+		std::string MIDI_DevicesStr;
+		
+		for (int i = 0; i < MIDI_DeviceCount; i++) {
+			MIDI_DevicesStr += TFE_MidiDevice::getDeviceNameStr(i) + '\0';
+		}
+		MIDI_Devices = &MIDI_DevicesStr[0];
+		
+		static s32 s_currentMidiDeviceIndex;
+		ImGui::LabelText("##ConfigLabel", "MIDI Device");
+		ImGui::LabelText("##ConfigLabel", "# of devices: %i", TFE_MidiDevice::getDeviceCount());
+		ImGui::SetNextItemWidth(512.0f);
+		static int MIDI_CurrentDevIndex = TFE_Settings::getSoundSettings()->midiDevice;
+
+
+		if (ImGui::Combo("##MIDI Device", &MIDI_CurrentDevIndex, MIDI_Devices, IM_ARRAYSIZE(MIDI_Devices))) {
+			sound->midiDevice = MIDI_CurrentDevIndex;
+		}
 	}
 
 	void pickCurrentResolution()

--- a/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
+++ b/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
@@ -2246,8 +2246,7 @@ namespace TFE_FrontEndUI
 		
 		ImGui::Dummy(ImVec2(0.0f, 20.0f));
 
-		ImGui::LabelText("##ConfigLabel", "MIDI Device");
-		ImGui::LabelText("##ConfigLabel", "# of devices: %i", TFE_MidiDevice::getDeviceCount());
+		ImGui::LabelText("##ConfigLabel", "MIDI Output Device");
 		ImGui::SetNextItemWidth(512.0f);
 		static int MIDI_CurrentDevIndex = TFE_Settings::getSoundSettings()->midiDevice;
 

--- a/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
+++ b/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
@@ -2199,6 +2199,8 @@ namespace TFE_FrontEndUI
 		*floatValue = clamp(f32(percValue) * 0.01f, 0.0f, 1.0f);
 	}
 
+
+	static bool MIDI_ShowDevChangeAlert;
 	void configSound()
 	{
 		TFE_Settings_Sound* sound = TFE_Settings::getSoundSettings();
@@ -2242,6 +2244,8 @@ namespace TFE_FrontEndUI
 		}
 		MIDI_Devices = &MIDI_DevicesStr[0];
 		
+		ImGui::Dummy(ImVec2(0.0f, 20.0f));
+
 		ImGui::LabelText("##ConfigLabel", "MIDI Device");
 		ImGui::LabelText("##ConfigLabel", "# of devices: %i", TFE_MidiDevice::getDeviceCount());
 		ImGui::SetNextItemWidth(512.0f);
@@ -2250,7 +2254,15 @@ namespace TFE_FrontEndUI
 
 		if (ImGui::Combo("##MIDI Device", &MIDI_CurrentDevIndex, MIDI_Devices, IM_ARRAYSIZE(MIDI_Devices))) {
 			sound->midiDevice = MIDI_CurrentDevIndex;
+			MIDI_ShowDevChangeAlert = true;
 		}
+
+		ImGui::Dummy(ImVec2(0.0f, 20.0f));
+
+		ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.78f, 0.75f, 0.12f, 1.0f));
+		if(MIDI_ShowDevChangeAlert)
+			ImGui::TextWrapped("WARNING: You must restart the game for the changes to the active MIDI device to take effect.");
+		ImGui::PopStyleColor();
 	}
 
 	void pickCurrentResolution()

--- a/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
+++ b/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
@@ -2254,14 +2254,16 @@ namespace TFE_FrontEndUI
 
 		if (ImGui::Combo("##MIDI Device", &MIDI_CurrentDevIndex, MIDI_Devices, MIDI_DeviceCount)) {
 			sound->midiDevice = MIDI_CurrentDevIndex;
+			TFE_MidiPlayer::destroy();
+			TFE_MidiPlayer::init(MIDI_CurrentDevIndex);
 			MIDI_ShowDevChangeAlert = true;
 		}
 
 		ImGui::Dummy(ImVec2(0.0f, 20.0f));
 
-		ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.78f, 0.75f, 0.12f, 1.0f));
+		ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.17f, 0.68f, 1.0f, 1.0f));
 		if(MIDI_ShowDevChangeAlert)
-			ImGui::TextWrapped("WARNING: You must restart the game for the changes to the active MIDI device to take effect.");
+			ImGui::TextWrapped("NOTE: MIDI Instruments may be incorrect until the game is restarted.");
 		ImGui::PopStyleColor();
 	}
 

--- a/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
+++ b/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
@@ -749,6 +749,7 @@ namespace TFE_FrontEndUI
 			}
 			if (s_menuRetState != APP_STATE_MENU && ImGui::Button("Exit to Menu", sideBarButtonSize))
 			{
+				MIDI_ShowDevChangeAlert = false;
 				s_menuRetState = APP_STATE_MENU;
 
 				s_subUI = FEUI_NONE;
@@ -2200,7 +2201,6 @@ namespace TFE_FrontEndUI
 	}
 
 
-	static bool MIDI_ShowDevChangeAlert;
 	void configSound()
 	{
 		TFE_Settings_Sound* sound = TFE_Settings::getSoundSettings();
@@ -2253,10 +2253,13 @@ namespace TFE_FrontEndUI
 
 
 		if (ImGui::Combo("##MIDI Device", &MIDI_CurrentDevIndex, MIDI_Devices, MIDI_DeviceCount)) {
-			sound->midiDevice = MIDI_CurrentDevIndex;
-			TFE_MidiPlayer::destroy();
-			TFE_MidiPlayer::init(MIDI_CurrentDevIndex);
-			MIDI_ShowDevChangeAlert = true;
+			if (MIDI_CurrentDevIndex != TFE_Settings::getSoundSettings()->midiDevice) {
+				sound->midiDevice = MIDI_CurrentDevIndex;
+				TFE_MidiPlayer::destroy();
+				TFE_MidiPlayer::init(MIDI_CurrentDevIndex);
+				if(s_menuRetState != APP_STATE_MENU)
+					MIDI_ShowDevChangeAlert = true;
+			}
 		}
 
 		ImGui::Dummy(ImVec2(0.0f, 20.0f));

--- a/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
+++ b/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
@@ -2242,7 +2242,6 @@ namespace TFE_FrontEndUI
 		}
 		MIDI_Devices = &MIDI_DevicesStr[0];
 		
-		static s32 s_currentMidiDeviceIndex;
 		ImGui::LabelText("##ConfigLabel", "MIDI Device");
 		ImGui::LabelText("##ConfigLabel", "# of devices: %i", TFE_MidiDevice::getDeviceCount());
 		ImGui::SetNextItemWidth(512.0f);

--- a/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
+++ b/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
@@ -2252,7 +2252,7 @@ namespace TFE_FrontEndUI
 		static int MIDI_CurrentDevIndex = TFE_Settings::getSoundSettings()->midiDevice;
 
 
-		if (ImGui::Combo("##MIDI Device", &MIDI_CurrentDevIndex, MIDI_Devices, IM_ARRAYSIZE(MIDI_Devices))) {
+		if (ImGui::Combo("##MIDI Device", &MIDI_CurrentDevIndex, MIDI_Devices, MIDI_DeviceCount)) {
 			sound->midiDevice = MIDI_CurrentDevIndex;
 			MIDI_ShowDevChangeAlert = true;
 		}

--- a/TheForceEngine/TFE_FrontEndUI/frontEndUi.h
+++ b/TheForceEngine/TFE_FrontEndUI/frontEndUi.h
@@ -28,6 +28,8 @@ struct ImFont;
 
 namespace TFE_FrontEndUI
 {
+	static bool MIDI_ShowDevChangeAlert;
+
 	void init();
 	void initConsole();
 	void shutdown();

--- a/TheForceEngine/TFE_Settings/settings.cpp
+++ b/TheForceEngine/TFE_Settings/settings.cpp
@@ -374,6 +374,7 @@ namespace TFE_Settings
 		writeKeyValue_Float(settings, "cutsceneMusicVolume", s_soundSettings.cutsceneMusicVolume);
 		writeKeyValue_Bool(settings, "use16Channels", s_soundSettings.use16Channels);
 		writeKeyValue_Bool(settings, "disableSoundInMenus", s_soundSettings.disableSoundInMenus);
+		writeKeyValue_Int(settings, "midiDevice", s_soundSettings.midiDevice);
 	}
 
 	void writeGameSettings(FileStream& settings)
@@ -725,6 +726,10 @@ namespace TFE_Settings
 		else if (strcasecmp("disableSoundInMenus", key) == 0)
 		{
 			s_soundSettings.disableSoundInMenus = parseBool(value);
+		}
+		else if (strcasecmp("midiDevice", key) == 0)
+		{
+			s_soundSettings.midiDevice = parseInt(value);
 		}
 	}
 

--- a/TheForceEngine/TFE_Settings/settings.h
+++ b/TheForceEngine/TFE_Settings/settings.h
@@ -127,6 +127,7 @@ struct TFE_Settings_Sound
 	f32 cutsceneMusicVolume = 1.0f;
 	bool use16Channels = false;
 	bool disableSoundInMenus = false;
+	u32 midiDevice = 0;
 };
 
 struct TFE_Game

--- a/TheForceEngine/main.cpp
+++ b/TheForceEngine/main.cpp
@@ -612,7 +612,7 @@ int main(int argc, char* argv[])
 	}
 	TFE_FrontEndUI::initConsole();
 	TFE_Audio::init(s_nullAudioDevice);
-	TFE_MidiPlayer::init();
+	TFE_MidiPlayer::init(TFE_Settings::getSoundSettings()->midiDevice);
 	TFE_Polygon::init();
 	TFE_Image::init();
 	TFE_Palette::createDefault256();


### PR DESCRIPTION
Added the ability to select a different MIDI output device, so that you can use a Roland SoundCanvas.

https://youtu.be/zA4txQuixS0

![image](https://user-images.githubusercontent.com/4075634/209894531-e80f6913-3339-4a1b-873b-f4cf3ec431ee.png)
