### PR TITLE
WIP (DO NOT MERGE): Switch away from relative mouse mode in menus

### DIFF
--- a/TheForceEngine/TFE_DarkForces/GameUI/escapeMenu.cpp
+++ b/TheForceEngine/TFE_DarkForces/GameUI/escapeMenu.cpp
@@ -223,6 +223,9 @@ namespace TFE_DarkForces
 
 	void escapeMenu_open(u8* framebuffer, u8* palette)
 	{
+		TFE_Input::enableRelativeMode(false);
+		TFE_Input::enableOSCursor(false); // Cursor will be drawn by us
+
 		// TFE
 		reticle_enable(false);
 
@@ -249,6 +252,9 @@ namespace TFE_DarkForces
 
 		// TFE
 		reticle_enable(true);
+
+		TFE_Input::enableRelativeMode(true);
+		TFE_Input::enableOSCursor(false);
 	}
 
 	JBool escapeMenu_isOpen()
@@ -508,11 +514,7 @@ namespace TFE_DarkForces
 		EscapeMenuAction action = escapeMenu_updateUI();
 		if (action != ESC_CONTINUE)
 		{
-			s_emState.escMenuOpen = JFALSE;
-			resumeLevelSound();
-
-			// TFE
-			reticle_enable(true);
+			escapeMenu_close();
 		}
 
 		escapeMenu_draw(JTRUE, JTRUE);

--- a/TheForceEngine/TFE_DarkForces/GameUI/menu.cpp
+++ b/TheForceEngine/TFE_DarkForces/GameUI/menu.cpp
@@ -37,7 +37,6 @@ namespace TFE_DarkForces
 	///////////////////////////////////////////
 	void menu_init()
 	{
-		TFE_Input::enableRelativeMode(false);
 	}
 
 	void menu_destroy()
@@ -96,29 +95,12 @@ namespace TFE_DarkForces
 
 		s32 mx, my;
 		TFE_Input::getMousePos(&mx, &my);
-		TFE_System::logWrite(LOG_MSG, "Menu", "Native mouse pos %d, %d", mx, my);
-		TFE_System::logWrite(LOG_MSG, "Menu", "canvas bounds %d, %d, %d, %d", bounds.left, bounds.top, bounds.right, bounds.bottom);
-		TFE_System::logWrite(LOG_MSG, "Menu", "Menu display rect %d, %d, %d, %d", displayRect.left, displayRect.top, displayRect.right, displayRect.bottom);
-#if 0
-		s_cursorPosAccum = { 12*mx/10, my };	// Account for 320x200 in 4:3 scaling.
 
-		if (displayInfo.width >= displayInfo.height)
-		{
-			s_cursorPos.x = clamp(s_cursorPosAccum.x * (s32)height / (s32)displayInfo.height, 0, (s32)width - 3);
-			s_cursorPos.z = clamp(s_cursorPosAccum.z * (s32)height / (s32)displayInfo.height, 0, (s32)height - 3);
-		}
-		else
-		{
-			s_cursorPos.x = clamp(s_cursorPosAccum.x * (s32)width / (s32)displayInfo.width, 0, (s32)width - 3);
-			s_cursorPos.z = clamp(s_cursorPosAccum.z * (s32)width / (s32)displayInfo.width, 0, (s32)height - 3);
-		}
-#else
 		s_cursorPosAccum = {
 			interpolate(mx, displayRect.left, displayRect.right, bounds.left, bounds.right),
 			interpolate(my, displayRect.top, displayRect.bottom, bounds.top, bounds.bottom),
 		};
 		s_cursorPos = s_cursorPosAccum;
-#endif
 	}
 
 	void menu_resetCursor()
@@ -137,6 +119,8 @@ namespace TFE_DarkForces
 
 	u8* menu_startupDisplay()
 	{
+		TFE_Input::enableRelativeMode(false);
+		TFE_Input::enableOSCursor(false); // Cursor will be drawn by us
 		vfb_setResolution(320, 200);
 		return vfb_getCpuBuffer();
 	}

--- a/TheForceEngine/TFE_DarkForces/GameUI/pda.cpp
+++ b/TheForceEngine/TFE_DarkForces/GameUI/pda.cpp
@@ -117,6 +117,9 @@ namespace TFE_DarkForces
 	///////////////////////////////////////////
 	void pda_start(const char* levelName)
 	{
+		TFE_Input::enableRelativeMode(false);
+		TFE_Input::enableOSCursor(false); // Cursor will be drawn by us
+
 		// TFE
 		reticle_enable(false);
 		s_mouseAccum = { 0 };
@@ -240,6 +243,9 @@ namespace TFE_DarkForces
 			TFE_Jedi::renderer_setType(RendererType(graphics->rendererIndex));
 			TFE_Jedi::renderer_setLimits();
 		}
+
+		TFE_Input::enableRelativeMode(true);
+		TFE_Input::enableOSCursor(false);
 	}
 			
 	void pda_update()

--- a/TheForceEngine/TFE_DarkForces/darkForcesMain.cpp
+++ b/TheForceEngine/TFE_DarkForces/darkForcesMain.cpp
@@ -735,6 +735,9 @@ namespace TFE_DarkForces
 			}  break;
 			case GMODE_MISSION:
 			{
+				TFE_Input::enableRelativeMode(true);
+				TFE_Input::enableOSCursor(false);
+
 				sound_levelStart();
 
 				bitmap_setAllocator(s_levelRegion);

--- a/TheForceEngine/TFE_Input/input.cpp
+++ b/TheForceEngine/TFE_Input/input.cpp
@@ -32,6 +32,7 @@ namespace TFE_Input
 	s32 s_mousePos[2] = { 0 };
 
 	bool s_relativeMode = false;
+	bool s_osCursorEnabled = true;
 
 	static const char* const* s_controllerAxisNames;
 	static const char* const* s_controllerButtonNames;
@@ -139,6 +140,11 @@ namespace TFE_Input
 	void enableRelativeMode(bool enable)
 	{
 		s_relativeMode = enable;
+	}
+
+	void enableOSCursor(bool enable)
+	{
+		s_osCursorEnabled = enable;
 	}
 	
 	// Buffered Input
@@ -328,6 +334,11 @@ namespace TFE_Input
 	bool relativeModeEnabled()
 	{
 		return s_relativeMode;
+	}
+
+	bool osCursorEnabled()
+	{
+		return s_osCursorEnabled;
 	}
 
 	// Buffered Input

--- a/TheForceEngine/TFE_Input/input.h
+++ b/TheForceEngine/TFE_Input/input.h
@@ -36,6 +36,7 @@ namespace TFE_Input
 	void setMousePos(s32 x, s32 y);
 
 	void enableRelativeMode(bool enable);
+	void enableOSCursor(bool enable);
 
 	// Buffered Input
 	void setBufferedInput(const char* text);
@@ -55,6 +56,7 @@ namespace TFE_Input
 	bool mouseDown(MouseButton button);
 	bool mousePressed(MouseButton button);
 	bool relativeModeEnabled();
+	bool osCursorEnabled();
 	void clearKeyPressed(KeyboardCode key);
 	void clearAccumulatedMouseMove();
 	// Buffered Input

--- a/TheForceEngine/main.cpp
+++ b/TheForceEngine/main.cpp
@@ -654,6 +654,7 @@ int main(int argc, char* argv[])
 	u32 frame = 0u;
 	bool showPerf = false;
 	bool relativeMode = false;
+	bool osCursorVisible = true;
 	TFE_System::logWrite(LOG_MSG, "Progam Flow", "The Force Engine Game Loop Started");
 	while (s_loop && !TFE_System::quitMessagePosted())
 	{
@@ -664,6 +665,17 @@ int main(int argc, char* argv[])
 		{
 			relativeMode = enableRelative;
 			SDL_SetRelativeMouseMode(relativeMode ? SDL_TRUE : SDL_FALSE);
+
+			// XXX: When relative mode is disabled, SDL will show the OS cursor.
+			// This line causes the OS cursor to be hidden again if it should be invisible.
+			osCursorVisible = true;
+		}
+
+		bool enableOSCursor = TFE_Input::osCursorEnabled();
+		if (osCursorVisible != enableOSCursor)
+		{
+			osCursorVisible = enableOSCursor;
+			SDL_ShowCursor(osCursorVisible ? 1 : 0);
 		}
 
 		// System events


### PR DESCRIPTION
In this branch, The Force Engine will switch away from relative mouse mode when opening the agent menu, the escape menu and the PDA. This makes the cursor acceleration and sensitivity behave identically to the operating system when a menu is active.

This branch is not suitable for merging. It has the following known issues:
- The OS cursor becomes visible in addition to the game cursor.
- Cursor might be positioned wrong in some screen configurations, such as widescreen.

I'll need guidance to solve these issues.