### PR TITLE
RClassic_GPU: modelGPU refinements

### DIFF
--- a/TheForceEngine/TFE_Asset/modelAsset_jedi.cpp
+++ b/TheForceEngine/TFE_Asset/modelAsset_jedi.cpp
@@ -269,6 +269,10 @@ namespace TFE_Model_Jedi
 	{
 		// Memory will get freed with the memory region automatically.
 		s_models[pool].clear();
+		
+		// free the memory of each models' drawId object
+		std::for_each(s_modelList[pool].begin(), s_modelList[pool].end(),
+				[](JediModel *m){ if (m->drawId) free(m->drawId); });
 		s_modelList[pool].clear();
 		s_modelNames[pool].clear();
 	}

--- a/TheForceEngine/TFE_Asset/modelAsset_jedi.cpp
+++ b/TheForceEngine/TFE_Asset/modelAsset_jedi.cpp
@@ -348,7 +348,7 @@ namespace TFE_Model_Jedi
 		model->textureCount = 0;
 		model->textures = nullptr;
 		model->radius = 0;
-		model->drawId = -1;	// invalid ID initially.
+		model->drawId = nullptr;	// invalid ID initially.
 
 		// Check to see if the name has an underscore.
 		// If so, set the "isBridge" field.

--- a/TheForceEngine/TFE_Asset/modelAsset_jedi.h
+++ b/TheForceEngine/TFE_Asset/modelAsset_jedi.h
@@ -65,7 +65,7 @@ struct JediModel
 	s32 textureCount;
 	TextureData** textures;
 	s32 radius;
-	s32 drawId;		// TFE: Added for the GPU renderer.
+	void* drawId;		// TFE: Added for the GPU renderer.
 };
 
 namespace TFE_Model_Jedi

--- a/TheForceEngine/TFE_Jedi/Renderer/RClassic_GPU/modelGPU.cpp
+++ b/TheForceEngine/TFE_Jedi/Renderer/RClassic_GPU/modelGPU.cpp
@@ -60,13 +60,13 @@ namespace TFE_Jedi
 
 	struct ModelDraw
 	{
-		s32 modelId;
 		Vec3f posWS;
 		Vec2f lightData;
 		Vec4f textureOffsets;
 		f32 transform[9];
 		u32 portalInfo;
-		void* obj;
+		void *modelId;
+		void *obj;
 	};
 
 	static const AttributeMapping c_modelAttrMapping[] =
@@ -257,7 +257,7 @@ namespace TFE_Jedi
 		mgpu->indexStart = (s32)curIdxSize;
 		mgpu->polyCount = model->vertexCount * 2;
 		mgpu->shader = MGPU_SHADER_HOLOGRAM;
-		model->drawId = s_models.size();
+		model->drawId = (void *)mgpu;
 		s_models.push_back(mgpu);
 
 		return true;
@@ -284,7 +284,7 @@ namespace TFE_Jedi
 		mgpu->indexStart = *s_curIndexStart;
 		mgpu->polyCount = ((s32)s_indexData.size() - (*s_curIndexStart)) / 3;
 		mgpu->shader = s_modelTrans ? MGPU_SHADER_TRANS : MGPU_SHADER_SOLID;
-		s_curModel->drawId = s_models.size();	// step 1
+		s_curModel->drawId = (void *)mgpu;	// step 1
 		s_models.push_back(mgpu);		// step 2
 
 		// Add vertices.
@@ -670,12 +670,12 @@ namespace TFE_Jedi
 	void model_add(void* obj, JediModel* model, Vec3f posWS, fixed16_16* transform, f32 ambient, Vec2f floorOffset, Vec2f ceilOffset, u32 portalInfo)
 	{
 		// Make sure the model has been assigned a GPU ID.
-		if (!model || model->drawId < 0)
+		if (!model || !model->drawId)
 		{
 			return;
 		}
 
-		ModelGPU* modelGPU = s_models[model->drawId];
+		ModelGPU* modelGPU = (ModelGPU *)model->drawId;
 		ModelDraw *drawItem = new ModelDraw;
 		if (!drawItem)
 			return;
@@ -727,7 +727,7 @@ namespace TFE_Jedi
 			for (auto it = s_modelDrawList[s].begin(); it != s_modelDrawList[s].end(); it++)
 			{
 				ModelDraw *drawItem = *it;
-				const ModelGPU* model = s_models[drawItem->modelId];
+				const ModelGPU *model = (ModelGPU *)drawItem->modelId;
 				const u32 portalInfo[] = { drawItem->portalInfo, drawItem->portalInfo };
 
 				// Per-draw shader variables.

--- a/TheForceEngine/TFE_Jedi/Renderer/RClassic_GPU/modelGPU.cpp
+++ b/TheForceEngine/TFE_Jedi/Renderer/RClassic_GPU/modelGPU.cpp
@@ -708,8 +708,8 @@ namespace TFE_Jedi
 		Shader* shader = s_modelShaders;
 		for (s32 s = 0; s < MGPU_SHADER_COUNT; s++, shader++)
 		{
-			s32 listCount = s_modelDrawList[s].size();
-			if (!listCount) { continue; }
+			if (s_modelDrawList[s].empty())
+				continue;
 
 			// Bind the shader and set per-frame shader variables.
 			shader->bind();


### PR DESCRIPTION
This set of changes  does the following:
- remove the hardcoded object limit from the modelGPU rendering system (fixes #203), replaces it with dynamic allocation and freeing of objects.

Additionally, since I was staring at this code:
- static-ize all internally-used functions, which, at least with gcc, results in slightly smaller code.
- get rid of all but one of the containers for the model lists: replace the indices used with pointers to the objects themselves. 
- pack the state of the model building into a struct which is then passed around the user functions.

EDIT: reworded since more changes were added after the original commit.
