### PR TITLE
Audio: MIDI null device, perf improvements

### DIFF
--- a/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
+++ b/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
@@ -2346,14 +2346,18 @@ namespace TFE_FrontEndUI
 
 			ImGui::LabelText("##ConfigLabel", "Audio Device:"); ImGui::SameLine(150 * s_uiScale);
 			ImGui::SetNextItemWidth(256 * s_uiScale);
-			ImGui::Combo("##Audio Output", &curOutput, outputAudioNames, outputCount);
+			bool b = ImGui::Combo("##Audio Output", &curOutput, outputAudioNames, outputCount);
 
 			if (ImGui::Button("Reset Audio Output"))
 			{
 				curOutput = -1;
+				b = true;
 			}
-			TFE_Audio::selectDevice(curOutput);
-			sound->audioDevice = curOutput;
+			if (b)
+			{
+				TFE_Audio::selectDevice(curOutput);
+				sound->audioDevice = curOutput;
+			}
 		}
 		ImGui::Separator();
 		{
@@ -2366,14 +2370,18 @@ namespace TFE_FrontEndUI
 
 			ImGui::LabelText("##ConfigLabel", "Midi Device:"); ImGui::SameLine(150 * s_uiScale);
 			ImGui::SetNextItemWidth(256 * s_uiScale);
-			ImGui::Combo("##Midi Output", &curOutput, (const char*)outputMidiNames, outputCount);
+			bool b = ImGui::Combo("##Midi Output", &curOutput, (const char*)outputMidiNames, outputCount);
 
 			if (ImGui::Button("Reset Midi Output"))
 			{
 				curOutput = -1;
+				b = true;
 			}
-			TFE_MidiDevice::selectDevice(u32(curOutput));
-			sound->midiDevice = curOutput;
+			if (b)
+			{
+				TFE_MidiDevice::selectDevice(curOutput);
+				sound->midiDevice = curOutput;
+			}
 		}
 
 		ImGui::Separator();


### PR DESCRIPTION
- add a "MIDI Output Disabled" midi device, which is autoselected when no synth is available.
- only change the audio / midi devices when they've been changed in the GUI.  The current code hammers these functions in every frame, regardless of any changes.

This gets rid of a ton of logspam generated while browsing the audio settings page when no midi synth is available:
"[Error : Midi Device] MidiOutAlsa::sendMessage: error sending MIDI message to port." (this is printed every time the gui is rendered, which is just insane, and needlessly causes CPU usage to spike)