### PR TITLE
DF: Hud: fix HUD font rendering for ASCII codes >= 128

### DIFF
--- a/TheForceEngine/TFE_DarkForces/hud.cpp
+++ b/TheForceEngine/TFE_DarkForces/hud.cpp
@@ -1076,7 +1076,7 @@ namespace TFE_DarkForces
 			fixed16_16 x0 = xf;
 
 			fixed16_16 fWidth = mul16(intToFixed16(font->width), xScale);
-			for (char c = *msg; c != 0;)
+			for (unsigned char c = *(unsigned char *)msg; c != 0;)
 			{
 				if (c == '\n')
 				{
@@ -1095,7 +1095,7 @@ namespace TFE_DarkForces
 					xf += mul16(intToFixed16(font->horzSpacing + glyph->width), xScale);
 				}
 				msg++;
-				c = *msg;
+				c = *(unsigned char *)msg;
 			}
 		}
 	}


### PR DESCRIPTION
This bandaid fixes missing rendering of font glyphs with index >= 128, fixes missing german Umlaute characters.

Fixes #210 

EDIT: the issue is in TheForceEngine/TFE_DarkForces/hud.cpp:1090:   c <= font->maxChar  signed vs. unsigned.
