### PR TITLE
DF: implement Keyboard keys for other languages

### DIFF
--- a/TheForceEngine/TFE_DarkForces/GameUI/agentMenu.cpp
+++ b/TheForceEngine/TFE_DarkForces/GameUI/agentMenu.cpp
@@ -79,6 +79,7 @@ namespace TFE_DarkForces
 	static u32 s_agentDlgCount;
 	
 	static char s_newAgentName[32];
+	static LangHotkeys* s_langKeys;
 
 	///////////////////////////////////////////
 	// Forward Declarations
@@ -239,17 +240,17 @@ namespace TFE_DarkForces
 				s_buttonPressed = AGENT_NEW;
 				s_buttonHover = JTRUE;
 			}
-			else if (TFE_Input::keyPressed(KEY_R))
+			else if (TFE_Input::keyPressed(s_langKeys->k_agdel))
 			{
 				s_buttonPressed = AGENT_REMOVE;
 				s_buttonHover = JTRUE;
 			}
-			else if (TFE_Input::keyPressed(KEY_D))
+			else if (TFE_Input::keyPressed(KEY_D))	// DOS
 			{
 				s_buttonPressed = AGENT_EXIT;
 				s_buttonHover = JTRUE;
 			}
-			else if (TFE_Input::keyPressed(KEY_B) || TFE_Input::keyPressed(KEY_RETURN) || TFE_Input::keyPressed(KEY_KP_ENTER))
+			else if (TFE_Input::keyPressed(s_langKeys->k_begin) || TFE_Input::keyPressed(KEY_RETURN) || TFE_Input::keyPressed(KEY_KP_ENTER))
 			{
 				s_buttonPressed = AGENT_BEGIN;
 				s_buttonHover = JTRUE;
@@ -446,7 +447,7 @@ namespace TFE_DarkForces
 		setPalette();
 	}
 
-	void agentMenu_load()
+	void agentMenu_load(LangHotkeys* langKeys)
 	{
 		FilePath filePath;
 		if (!TFE_Paths::getFilePath("AGENTMNU.LFD", &filePath)) { return; }
@@ -458,6 +459,8 @@ namespace TFE_DarkForces
 		s_agentDlgCount = getFramesFromAnim("agentdlg.anim", &s_agentDlgFrames);
 		getFrameFromDelt("cursor.delt", &s_cursor);
 		TFE_Paths::removeLastArchive();
+		
+		s_langKeys = langKeys;
 	}
 		
 	void agentMenu_startup()
@@ -651,7 +654,7 @@ namespace TFE_DarkForces
 		}
 		else
 		{
-			if (TFE_Input::keyPressed(KEY_Y))
+			if (TFE_Input::keyPressed(s_langKeys->k_yes))
 			{
 				agentMenu_removeAgent(s_agentId);
 				s_removeAgentDlg = false;
@@ -718,7 +721,7 @@ namespace TFE_DarkForces
 		else
 		{
 			// Activate button 's_escButtonPressed'
-			if (TFE_Input::keyPressed(KEY_Y))
+			if (TFE_Input::keyPressed(s_langKeys->k_yes))
 			{
 				quit = JTRUE;
 				s_quitConfirmDlg = JFALSE;

--- a/TheForceEngine/TFE_DarkForces/GameUI/agentMenu.h
+++ b/TheForceEngine/TFE_DarkForces/GameUI/agentMenu.h
@@ -4,6 +4,7 @@
 // UI code will not be available until future releases.
 //////////////////////////////////////////////////////////////////////
 
+#include <TFE_DarkForces/util.h>
 #include <TFE_System/types.h>
 
 namespace TFE_DarkForces
@@ -12,7 +13,7 @@ namespace TFE_DarkForces
 	// levelIndex will hold the selected level index (1 - 14).
 	JBool agentMenu_update(s32* levelIndex);
 
-	void agentMenu_load();
+	void agentMenu_load(LangHotkeys* hotkeys);
 
 	// Reset Presistent State.
 	void agentMenu_resetState();

--- a/TheForceEngine/TFE_DarkForces/GameUI/escapeMenu.cpp
+++ b/TheForceEngine/TFE_DarkForces/GameUI/escapeMenu.cpp
@@ -95,6 +95,7 @@ namespace TFE_DarkForces
 		ConfirmState confirmState = CONFIRM_STATE_NONE;
 
 		RenderTargetHandle renderTarget = nullptr;
+		LangHotkeys* langKeys;
 	};
 	static EscapeMenuState s_emState = {};
 
@@ -134,8 +135,9 @@ namespace TFE_DarkForces
 		return range;
 	}
 			
-	void escapeMenu_load()
+	void escapeMenu_load(LangHotkeys* langKeys)
 	{
+		s_emState.langKeys = langKeys;
 		if (!s_emState.escMenuFrames)
 		{
 			FilePath filePath;
@@ -533,15 +535,15 @@ namespace TFE_DarkForces
 				{
 					actionPressed = ESC_BTN_ABORT;
 				}
-				if (TFE_Input::keyPressed(KEY_C))
+				if (TFE_Input::keyPressed(s_emState.langKeys->k_conf))
 				{
 					actionPressed = ESC_BTN_CONFIG;
 				}
-				if (TFE_Input::keyPressed(KEY_Q))
+				if (TFE_Input::keyPressed(s_emState.langKeys->k_quit))
 				{
 					actionPressed = ESC_BTN_QUIT;
 				}
-				if (TFE_Input::keyPressed(KEY_R))
+				if (TFE_Input::keyPressed(s_emState.langKeys->k_cont))
 				{
 					actionPressed = ESC_BTN_RETURN;
 				}
@@ -567,7 +569,7 @@ namespace TFE_DarkForces
 		{
 			if (actionPressed < 0)
 			{
-				if (TFE_Input::keyPressed(KEY_Y))
+				if (TFE_Input::keyPressed(s_emState.langKeys->k_yes))
 				{
 					actionPressed = CONFIRM_YES;
 				}

--- a/TheForceEngine/TFE_DarkForces/GameUI/escapeMenu.h
+++ b/TheForceEngine/TFE_DarkForces/GameUI/escapeMenu.h
@@ -4,6 +4,7 @@
 // UI code will not be available until future releases.
 //////////////////////////////////////////////////////////////////////
 
+#include <TFE_DarkForces/util.h>
 #include <TFE_System/types.h>
 
 enum EscapeMenuAction
@@ -19,7 +20,7 @@ enum EscapeMenuAction
 namespace TFE_DarkForces
 {
 	// Preload.
-	void escapeMenu_load();
+	void escapeMenu_load(LangHotkeys* hotkeys);
 
 	// Opens the escape menu, which sets up the background.
 	void escapeMenu_open(u8* framebuffer, u8* palette);

--- a/TheForceEngine/TFE_DarkForces/GameUI/missionBriefing.cpp
+++ b/TheForceEngine/TFE_DarkForces/GameUI/missionBriefing.cpp
@@ -47,6 +47,7 @@ namespace TFE_DarkForces
 	static LActor* s_menuActor = nullptr;
 	static LPalette* s_palette = nullptr;
 	static u8* s_framebuffer = nullptr;
+	static LangHotkeys* s_langKeys;
 
 	s16 s_briefY;
 	s32 s_briefingMaxY;
@@ -81,8 +82,10 @@ namespace TFE_DarkForces
 	///////////////////////////////////////////
 	// API Implementation
 	///////////////////////////////////////////
-	void missionBriefing_start(const char* archive, const char* bgAnim, const char* mission, const char* palette, s32 skill)
+	void missionBriefing_start(const char* archive, const char* bgAnim, const char* mission, const char* palette, s32 skill, LangHotkeys* langKeys)
 	{
+		s_langKeys = langKeys;
+
 		menu_init();
 		menu_startupDisplay();
 
@@ -353,23 +356,23 @@ namespace TFE_DarkForces
 			}
 		}
 
-		if (TFE_Input::keyPressed(KEY_E))
+		if (TFE_Input::keyPressed(s_langKeys->k_easy))
 		{
 			s_keyPressed = BRIEF_BTN_EASY;
 			s_skill = 0;
 		}
-		else if (TFE_Input::keyPressed(KEY_M))
+		else if (TFE_Input::keyPressed(s_langKeys->k_med))
 		{
 			s_keyPressed = BRIEF_BTN_MEDIUM;
 			s_skill = 1;
 		}
-		else if (TFE_Input::keyPressed(KEY_H))
+		else if (TFE_Input::keyPressed(s_langKeys->k_hard))
 		{
 			s_keyPressed = BRIEF_BTN_HARD;
 			s_skill = 2;
 		}
 
-		if (TFE_Input::keyPressed(KEY_C) || TFE_Input::keyPressed(KEY_ESCAPE))
+		if (TFE_Input::keyPressed(s_langKeys->k_canc) || TFE_Input::keyPressed(KEY_ESCAPE))
 		{
 			*abort = JTRUE;
 			exitBriefing = JTRUE;

--- a/TheForceEngine/TFE_DarkForces/GameUI/missionBriefing.h
+++ b/TheForceEngine/TFE_DarkForces/GameUI/missionBriefing.h
@@ -5,6 +5,7 @@
 //////////////////////////////////////////////////////////////////////
 
 #include <TFE_System/types.h>
+#include <TFE_DarkForces/util.h>
 #include <TFE_DarkForces/Landru/lrect.h>
 
 namespace TFE_DarkForces
@@ -16,7 +17,7 @@ namespace TFE_DarkForces
 		BRIEF_PAGE_SCROLL = BRIEF_LINE_SCROLL * 10,
 	};
 
-	void  missionBriefing_start(const char* archive, const char* bgAnim, const char* mission, const char* palette, s32 skill);
+	void  missionBriefing_start(const char* archive, const char* bgAnim, const char* mission, const char* palette, s32 skill, LangHotkeys* langKeys);
 	void  missionBriefing_cleanup();
 	JBool missionBriefing_update(s32* skill, JBool* abort);
 }

--- a/TheForceEngine/TFE_DarkForces/gameMessage.cpp
+++ b/TheForceEngine/TFE_DarkForces/gameMessage.cpp
@@ -118,4 +118,19 @@ namespace TFE_DarkForces
 		}  // for (s32 i = 0; i < msgCount; i++, msg++)
 		return 1;
 	}
+	
+	GameMessage* getGameMessage(GameMessages* messages, s32 msgId)
+	{
+		s32 count = messages->count;
+		GameMessage* msg = messages->msgList;
+
+		for (s32 i = 0; i < count; i++, msg++)
+		{
+			if (msgId == msg->id)
+			{
+				return msg;
+			}
+		}
+		return nullptr;
+	}
 }  // TFE_DarkForces

--- a/TheForceEngine/TFE_DarkForces/gameMessage.h
+++ b/TheForceEngine/TFE_DarkForces/gameMessage.h
@@ -22,4 +22,5 @@ namespace TFE_DarkForces
 
 	void gameMessage_freeBuffer();
 	s32 parseMessageFile(GameMessages* messages, const FilePath* path, s32 mode);
+	GameMessage* getGameMessage(GameMessages* messages, s32 msgId);
 }  // TFE_DarkForces

--- a/TheForceEngine/TFE_DarkForces/hud.cpp
+++ b/TheForceEngine/TFE_DarkForces/hud.cpp
@@ -113,7 +113,6 @@ namespace TFE_DarkForces
 	///////////////////////////////////////////
 	// Forward Declarations
 	///////////////////////////////////////////
-	GameMessage* hud_getMessage(GameMessages* messages, s32 msgId);
 	TextureData* hud_loadTexture(const char* texFile);
 	Font* hud_loadFont(const char* fontFile);
 	void copyIntoPalette(u8* dst, u8* src, s32 count, s32 mode);
@@ -129,7 +128,7 @@ namespace TFE_DarkForces
 	///////////////////////////////////////////
 	void hud_sendTextMessage(s32 msgId)
 	{
-		GameMessage* msg = hud_getMessage(&s_hudMessages, msgId);
+		GameMessage* msg = getGameMessage(&s_hudMessages, msgId);
 		// Only display the message if it is the same or lower priority than the current message.
 		if (!msg || msg->priority > s_hudMsgPriority)
 		{
@@ -999,21 +998,6 @@ namespace TFE_DarkForces
 		return nullptr;
 	}
 
-	GameMessage* hud_getMessage(GameMessages* messages, s32 msgId)
-	{
-		s32 count = messages->count;
-		GameMessage* msg = messages->msgList;
-
-		for (s32 i = 0; i < count; i++, msg++)
-		{
-			if (msgId == msg->id)
-			{
-				return msg;
-			}
-		}
-		return nullptr;
-	}
-		
 	void copyIntoPalette(u8* dst, u8* src, s32 count, s32 mode)
 	{
 		memcpy(dst, src, count * 3);

--- a/TheForceEngine/TFE_DarkForces/util.h
+++ b/TheForceEngine/TFE_DarkForces/util.h
@@ -3,11 +3,26 @@
 // Dark Forces Game Message
 // This handles HUD messages, local messages, etc.
 //////////////////////////////////////////////////////////////////////
+#include <TFE_Input/inputEnum.h>
 #include <TFE_System/types.h>
 #include <TFE_FileSystem/paths.h>
 
 namespace TFE_DarkForces
 {
+	// language-specific hotkeys
+	struct LangHotkeys {
+		KeyboardCode k_yes;
+		KeyboardCode k_quit;
+		KeyboardCode k_cont;	// resume mission
+		KeyboardCode k_conf;	// configure
+		KeyboardCode k_agdel;	// delete agent
+		KeyboardCode k_begin;	// begin mission
+		KeyboardCode k_easy;
+		KeyboardCode k_med;
+		KeyboardCode k_hard;
+		KeyboardCode k_canc;
+	};
+
 	char* copyAndAllocateString(const char* start, const char* end);
 	char* copyAndAllocateString(const char* str);
 


### PR DESCRIPTION
Other language versions of DF use different keys in the Briefing, Agent, and Escape Menu screens.

Parse the "HOTKEYS.MSG" file which is different for each language version to get to know the right
hotkeys to use.

Fixes #212 
