### PR TITLE
CMake/Linux: create gitVersion.h during configure run

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,6 @@ include(GNUInstallDirs)
 
 
 add_executable(tfe)
-target_include_directories(tfe PRIVATE TheForceEngine)
 
 if(WIN32)
 	set_target_properties(tfe PROPERTIES OUTPUT_NAME "TheForceEngine")
@@ -55,6 +54,7 @@ elseif(LINUX)
 	pkg_check_modules(ILU REQUIRED ILU)
 	set(OpenGL_GL_PREFERENCE GLVND)
 	find_package(OpenGL REQUIRED)
+	target_include_directories(tfe PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 	target_include_directories(tfe PRIVATE ${SDL2_INCLUDE_DIRS})
 	target_link_libraries(tfe PRIVATE
 				${OPENGL_LIBRARIES}
@@ -73,7 +73,11 @@ elseif(LINUX)
 	execute_process(COMMAND /usr/bin/ln -sf ${CMAKE_SOURCE_DIR}/TheForceEngine/Shaders)
 	execute_process(COMMAND /usr/bin/ln -sf ${CMAKE_SOURCE_DIR}/TheForceEngine/UI_Images)
 	execute_process(COMMAND /usr/bin/ln -sf ${CMAKE_SOURCE_DIR}/TheForceEngine/UI_Text)
+	include(CreateGitVersionH.cmake)
+	create_git_version_h()
 endif()
+
+target_include_directories(tfe PRIVATE TheForceEngine)
 
 add_subdirectory(TheForceEngine/)
 

--- a/CreateGitVersionH.cmake
+++ b/CreateGitVersionH.cmake
@@ -1,0 +1,49 @@
+# based on https://chromium.googlesource.com/external/github.com/google/benchmark/+/refs/heads/main/cmake/GetGitVersion.cmake
+#
+# create a TFE-compatible "gitVersion.h" file in the build directory.
+#
+find_package(Git)
+
+function(create_git_version_h)
+  if(GIT_EXECUTABLE)
+      execute_process(COMMAND ${GIT_EXECUTABLE} describe --tags --match "v[0-9]*.[0-9]*.[0-9]*" --abbrev=8
+          WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+          RESULT_VARIABLE status
+          OUTPUT_VARIABLE GIT_DESCRIBE_VERSION
+          ERROR_QUIET)
+      if(status)
+          set(GIT_DESCRIBE_VERSION "v0.0.0")
+      endif()
+
+      string(STRIP ${GIT_DESCRIBE_VERSION} GIT_DESCRIBE_VERSION)
+
+      # Work out if the repository is dirty
+      execute_process(COMMAND ${GIT_EXECUTABLE} update-index -q --refresh
+          WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+          OUTPUT_QUIET
+          ERROR_QUIET)
+      execute_process(COMMAND ${GIT_EXECUTABLE} diff-index --name-only HEAD --
+          WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+          OUTPUT_VARIABLE GIT_DIFF_INDEX
+          ERROR_QUIET)
+      string(COMPARE NOTEQUAL "${GIT_DIFF_INDEX}" "" GIT_DIRTY)
+      if (${GIT_DIRTY})
+          set(GIT_DESCRIBE_VERSION "${GIT_DESCRIBE_VERSION}+")
+      endif()
+  else()
+      set(GIT_DESCRIBE_VERSION "0.0.0")
+  endif()
+  message(STATUS "git version: ${GIT_DESCRIBE_VERSION}")
+  set(VERSFILE ${CMAKE_CURRENT_BINARY_DIR}/gitVersion.h)
+  #string(TIMESTAMP TODAY "%Y%m%d %H%M%S")
+  set(VERSION "const char c_gitVersion[] = R\"(${GIT_DESCRIBE_VERSION} ${TODAY})\";")
+  if(EXISTS ${VERSFILE})
+      file(READ ${VERSFILE} VERSIONX)
+  else()
+      set(VERSIONX "")
+  endif()
+  if (NOT "${VERSION}" STREQUAL "${VERSIONX}")
+      file(WRITE ${VERSFILE} "${VERSION}")
+      message(STATUS "wrote new ${VERSFILE}")
+  endif()
+endfunction()

--- a/TheForceEngine/version.h
+++ b/TheForceEngine/version.h
@@ -1,3 +1,3 @@
 #pragma once
 
-#include "gitVersion.h"
+#include <gitVersion.h>


### PR DESCRIPTION
Create a gitVersion.h based on current local repo status. Initially only used with linux builds.

Untested on Windows, but works beautifully with my linux builds.
