### PR TITLE
fix MIDI device list and selection

### DIFF
--- a/TheForceEngine/TFE_Audio/midiDevice.cpp
+++ b/TheForceEngine/TFE_Audio/midiDevice.cpp
@@ -71,6 +71,7 @@ namespace TFE_MidiDevice
 		}
 		if (index != s_openPort && index >= 0 && index < getDeviceCount())
 		{
+			s_midiout->closePort();
 			s_midiout->openPort(index);
 			s_openPort = (s32)index;
 			return true;

--- a/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
+++ b/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
@@ -2334,7 +2334,7 @@ namespace TFE_FrontEndUI
 		ImGui::LabelText("##ConfigLabel", "Audio Output");
 
 		const char* outputAudioNames[MAX_AUDIO_OUTPUTS];
-		char outputMidiNames[MAX_AUDIO_OUTPUTS][256];
+		char outputMidiNames[MAX_AUDIO_OUTPUTS * 256];
 		{
 			s32 outputCount = 0, curOutput = 0;
 			const OutputDeviceInfo* outputInfo = TFE_Audio::getOutputDeviceList(outputCount, curOutput);
@@ -2359,9 +2359,12 @@ namespace TFE_FrontEndUI
 		{
 			s32 outputCount = 0, curOutput = 0;
 			outputCount = min(MAX_AUDIO_OUTPUTS, (s32)TFE_MidiDevice::getDeviceCount());
+			char* midiList = outputMidiNames;
+			memset(outputMidiNames, 0, 256 * MAX_AUDIO_OUTPUTS);
 			for (s32 i = 0; i < outputCount; i++)
 			{
-				TFE_MidiDevice::getDeviceName(i, outputMidiNames[i], 256);
+				TFE_MidiDevice::getDeviceName(i, midiList, 256);
+				midiList += strlen(midiList) + 1;	// +1 as imgui entry divider
 			}
 
 			ImGui::LabelText("##ConfigLabel", "Midi Device:"); ImGui::SameLine(150 * s_uiScale);


### PR DESCRIPTION
- the midi device list only showed the first entry, fix that.
- upon selecting a different midi port, close the open connection first. Gets rid of an error I see on Linux.

Should fix #200 and make #171 irrelevant.