### PR TITLE
DF: escapeMenu: Fix wrong palette in german version.

### DIFF
--- a/TheForceEngine/TFE_DarkForces/GameUI/escapeMenu.cpp
+++ b/TheForceEngine/TFE_DarkForces/GameUI/escapeMenu.cpp
@@ -134,16 +134,18 @@ namespace TFE_DarkForces
 		return range;
 	}
 			
-	void escapeMenu_load()
+	void escapeMenu_load(u32* escMenuPalette)
 	{
 		if (!s_emState.escMenuFrames)
 		{
 			FilePath filePath;
 			if (!TFE_Paths::getFilePath("MENU.LFD", &filePath)) { return; }
 			Archive* archive = Archive::getArchive(ARCHIVE_LFD, "MENU", filePath.path);
+			u8 palbuffer[768];
 			TFE_Paths::addLocalArchive(archive);
 				s_emState.escMenuFrameCount = getFramesFromAnim("escmenu.anim", &s_emState.escMenuFrames);
 				s_emState.confirmMenuFrameCount = getFramesFromAnim("yesno.anim", &s_emState.confirmMenuFrames);
+				loadPaletteFromPltt("menu.pltt", palbuffer);
 			TFE_Paths::removeLastArchive();
 
 			// Adjust button ranges since different languages seem to move the menu around for some reason...
@@ -165,6 +167,13 @@ namespace TFE_DarkForces
 			
 			// TFE
 			TFE_Jedi::renderer_addHudTextureCallback(escapeMenu_getTextures);
+			// convert palette to argb entries
+			memset(escMenuPalette, 0, 256 * sizeof(u32));
+			u8* pb = palbuffer;
+			for (u32 i = 0; i < 256; i++, pb += 3)
+			{
+				escMenuPalette[i] = 0xffu << 24 | ((u32)pb[0]) | ((u32)(pb[1]) << 8) | ((u32)pb[2] << 16);
+			}
 		}
 	}
 

--- a/TheForceEngine/TFE_DarkForces/GameUI/escapeMenu.h
+++ b/TheForceEngine/TFE_DarkForces/GameUI/escapeMenu.h
@@ -19,7 +19,7 @@ enum EscapeMenuAction
 namespace TFE_DarkForces
 {
 	// Preload.
-	void escapeMenu_load();
+	void escapeMenu_load(u32* escMenuPalette);
 
 	// Opens the escape menu, which sets up the background.
 	void escapeMenu_open(u8* framebuffer, u8* palette);

--- a/TheForceEngine/TFE_DarkForces/darkForcesMain.cpp
+++ b/TheForceEngine/TFE_DarkForces/darkForcesMain.cpp
@@ -305,7 +305,7 @@ namespace TFE_DarkForces
 		
 		// TFE Specific
 		agentMenu_load();
-		escapeMenu_load();
+		escapeMenu_load(s_escMenuPalette);
 		// Add texture callbacks.
 		renderer_addHudTextureCallback(TFE_Jedi::level_getLevelTextures);
 		renderer_addHudTextureCallback(TFE_Jedi::level_getObjectTextures);
@@ -1137,10 +1137,6 @@ namespace TFE_DarkForces
 		if (TFE_Paths::getFilePath("wait.pal", &filePath))
 		{
 			FileStream::readContents(&filePath, s_loadingScreenPal, 768);
-		}
-		if (TFE_Paths::getFilePath("secbase.pal", &filePath))
-		{
-			FileStream::readContents(&filePath, s_escMenuPalette, 768);
 		}
 
 		weapon_enableAutomount(s_config.wpnAutoMount);

--- a/TheForceEngine/TFE_DarkForces/mission.cpp
+++ b/TheForceEngine/TFE_DarkForces/mission.cpp
@@ -55,8 +55,8 @@ namespace TFE_DarkForces
 	u8 s_loadingScreenPal[768];
 	u8 s_levelPalette[768];
 	u8 s_basePalette[768];
-	u8 s_escMenuPalette[768];
 	u8 s_framePalette[768];
+	u32 s_escMenuPalette[256];	// RGB
 
 	// Move these to color?
 	JBool s_palModified = JTRUE;
@@ -543,7 +543,7 @@ namespace TFE_DarkForces
 			// Move this out of handleGeneralInput so that the HUD is properly copied.
 			if (escapeMenu_isOpen())
 			{
-				setPalette(s_escMenuPalette);
+				vfb_setPalette(s_escMenuPalette);
 
 				EscapeMenuAction action = escapeMenu_update();
 				if (action == ESC_RETURN || action == ESC_CONFIG)

--- a/TheForceEngine/TFE_DarkForces/mission.h
+++ b/TheForceEngine/TFE_DarkForces/mission.h
@@ -47,5 +47,5 @@ namespace TFE_DarkForces
 	extern u8 s_loadingScreenPal[];
 	extern u8 s_levelPalette[];
 	extern u8 s_basePalette[];
-	extern u8 s_escMenuPalette[];
+	extern u32 s_escMenuPalette[];
 }  // namespace TFE_DarkForces


### PR DESCRIPTION
Apply the "menu.PLTT" Palette from the MENU.LFD file to the Escape Menu, instead of the palette for the secbase level.
Fixes #211  slightly magenta text in the german version of the "Quit to DOS, are you sure?" Messagebox.
