### PR TITLE
DarkForces: apply correct palette to escape menu.

### DIFF
--- a/TheForceEngine/TFE_DarkForces/GameUI/escapeMenu.cpp
+++ b/TheForceEngine/TFE_DarkForces/GameUI/escapeMenu.cpp
@@ -135,7 +135,7 @@ namespace TFE_DarkForces
 		return range;
 	}
 			
-	void escapeMenu_load(LangHotkeys* langKeys)
+	void escapeMenu_load(LangHotkeys* langKeys, u32* escMenuPalette)
 	{
 		s_emState.langKeys = langKeys;
 		if (!s_emState.escMenuFrames)
@@ -143,9 +143,11 @@ namespace TFE_DarkForces
 			FilePath filePath;
 			if (!TFE_Paths::getFilePath("MENU.LFD", &filePath)) { return; }
 			Archive* archive = Archive::getArchive(ARCHIVE_LFD, "MENU", filePath.path);
+			u8 palbuffer[768];
 			TFE_Paths::addLocalArchive(archive);
 				s_emState.escMenuFrameCount = getFramesFromAnim("escmenu.anim", &s_emState.escMenuFrames);
 				s_emState.confirmMenuFrameCount = getFramesFromAnim("yesno.anim", &s_emState.confirmMenuFrames);
+				loadPaletteFromPltt("menu.pltt", palbuffer);
 			TFE_Paths::removeLastArchive();
 
 			// Adjust button ranges since different languages seem to move the menu around for some reason...
@@ -167,6 +169,13 @@ namespace TFE_DarkForces
 			
 			// TFE
 			TFE_Jedi::renderer_addHudTextureCallback(escapeMenu_getTextures);
+			// convert palette to argb entries now since we don't need the raw format anywhere.
+			memset(escMenuPalette, 0, 256 * sizeof(u32));
+			u8* pb = palbuffer;
+			for (u32 i = 0; i < 256; i++, pb += 3)
+			{
+				escMenuPalette[i] = 0xffu << 24 | ((u32)pb[0]) | ((u32)(pb[1]) << 8) | ((u32)pb[2] << 16);
+			}
 		}
 	}
 

--- a/TheForceEngine/TFE_DarkForces/GameUI/escapeMenu.h
+++ b/TheForceEngine/TFE_DarkForces/GameUI/escapeMenu.h
@@ -19,8 +19,8 @@ enum EscapeMenuAction
 
 namespace TFE_DarkForces
 {
-	// Preload.
-	void escapeMenu_load(LangHotkeys* hotkeys);
+	// Preload: keys to use(in), palette data to use(out)
+	void escapeMenu_load(LangHotkeys* hotkeys, u32* escMenuPalette);
 
 	// Opens the escape menu, which sets up the background.
 	void escapeMenu_open(u8* framebuffer, u8* palette);

--- a/TheForceEngine/TFE_DarkForces/darkForcesMain.cpp
+++ b/TheForceEngine/TFE_DarkForces/darkForcesMain.cpp
@@ -306,7 +306,7 @@ namespace TFE_DarkForces
 		
 		// TFE Specific
 		agentMenu_load(&s_sharedState.langKeys);
-		escapeMenu_load(&s_sharedState.langKeys);
+		escapeMenu_load(&s_sharedState.langKeys, s_escMenuPalette);
 		// Add texture callbacks.
 		renderer_addHudTextureCallback(TFE_Jedi::level_getLevelTextures);
 		renderer_addHudTextureCallback(TFE_Jedi::level_getObjectTextures);
@@ -1174,10 +1174,6 @@ namespace TFE_DarkForces
 		if (TFE_Paths::getFilePath("wait.pal", &filePath))
 		{
 			FileStream::readContents(&filePath, s_loadingScreenPal, 768);
-		}
-		if (TFE_Paths::getFilePath("secbase.pal", &filePath))
-		{
-			FileStream::readContents(&filePath, s_escMenuPalette, 768);
 		}
 
 		weapon_enableAutomount(s_config.wpnAutoMount);

--- a/TheForceEngine/TFE_DarkForces/mission.cpp
+++ b/TheForceEngine/TFE_DarkForces/mission.cpp
@@ -55,8 +55,8 @@ namespace TFE_DarkForces
 	u8 s_loadingScreenPal[768];
 	u8 s_levelPalette[768];
 	u8 s_basePalette[768];
-	u8 s_escMenuPalette[768];
 	u8 s_framePalette[768];
+	u32 s_escMenuPalette[256];	// RGB
 
 	// Move these to color?
 	JBool s_palModified = JTRUE;
@@ -543,7 +543,7 @@ namespace TFE_DarkForces
 			// Move this out of handleGeneralInput so that the HUD is properly copied.
 			if (escapeMenu_isOpen())
 			{
-				setPalette(s_escMenuPalette);
+				vfb_setPalette(s_escMenuPalette);
 
 				EscapeMenuAction action = escapeMenu_update();
 				if (action == ESC_RETURN || action == ESC_CONFIG)

--- a/TheForceEngine/TFE_DarkForces/mission.h
+++ b/TheForceEngine/TFE_DarkForces/mission.h
@@ -47,5 +47,5 @@ namespace TFE_DarkForces
 	extern u8 s_loadingScreenPal[];
 	extern u8 s_levelPalette[];
 	extern u8 s_basePalette[];
-	extern u8 s_escMenuPalette[];
+	extern u32 s_escMenuPalette[];
 }  // namespace TFE_DarkForces


### PR DESCRIPTION
Apply the menu.pltt palette to the escape menu instead of the secbase level palette.
This fixes the slightly magenta text in the "Quit to Dos are you sure" messagebox of the german version of the game.

Fixes #211 