### PR TITLE
MIDI: more fixes for multiple midi devices

### DIFF
--- a/TheForceEngine/TFE_Audio/midiDevice.cpp
+++ b/TheForceEngine/TFE_Audio/midiDevice.cpp
@@ -79,6 +79,11 @@ namespace TFE_MidiDevice
 		return false;
 	}
 
+	u32 getActiveDevice(void)
+	{
+		return s_openPort > 0 ? s_openPort : 0;
+	}
+
 	void sendMessage(const u8* msg, u32 size)
 	{
 		if (s_midiout) { s_midiout->sendMessage(msg, (size_t)size); }

--- a/TheForceEngine/TFE_Audio/midiDevice.h
+++ b/TheForceEngine/TFE_Audio/midiDevice.h
@@ -9,6 +9,7 @@ namespace TFE_MidiDevice
 	u32  getDeviceCount();
 	void getDeviceName(u32 index, char* buffer, u32 maxLength);
 	bool selectDevice(s32 index);
+	u32  getActiveDevice(void);
 
 	void sendMessage(const u8* msg, u32 size);
 	void sendMessage(u8 arg0, u8 arg1, u8 arg2 = 0);

--- a/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
+++ b/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
@@ -2357,7 +2357,7 @@ namespace TFE_FrontEndUI
 		}
 		ImGui::Separator();
 		{
-			s32 outputCount = 0, curOutput = 0;
+			s32 outputCount = 0, curOutput = TFE_MidiDevice::getActiveDevice();
 			outputCount = min(MAX_AUDIO_OUTPUTS, (s32)TFE_MidiDevice::getDeviceCount());
 			char* midiList = outputMidiNames;
 			memset(outputMidiNames, 0, 256 * MAX_AUDIO_OUTPUTS);
@@ -2369,14 +2369,17 @@ namespace TFE_FrontEndUI
 
 			ImGui::LabelText("##ConfigLabel", "Midi Device:"); ImGui::SameLine(150 * s_uiScale);
 			ImGui::SetNextItemWidth(256 * s_uiScale);
-			ImGui::Combo("##Midi Output", &curOutput, (const char*)outputMidiNames, outputCount);
-
+			bool hasChanged = ImGui::Combo("##Midi Output", &curOutput, (const char*)outputMidiNames, outputCount);
 			if (ImGui::Button("Reset Midi Output"))
 			{
 				curOutput = -1;
+				hasChanged = true;
 			}
-			TFE_MidiDevice::selectDevice(u32(curOutput));
-			sound->midiDevice = curOutput;
+			if (hasChanged)
+			{
+				TFE_MidiDevice::selectDevice(u32(curOutput));
+				sound->midiDevice = TFE_MidiDevice::getActiveDevice();
+			}
 		}
 
 		ImGui::Separator();


### PR DESCRIPTION
The previous MIDI fix was not thorough enough:
- only change the selected device if the combobox had an activity. basically every frame the selected midi device would be reset back to index 0 when no selection was made in the combobox.
- Add a function to get the currently selected midi port so the combobox can show that.

Fixes #226 and #151