### PR TITLE
Linux: misc fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,17 @@ This can be overridden by defining the "__TFE_DATA_HOME__" environment variable.
 ##### Building from Source
 * [CMake](https://cmake.org) 3.12 or higher to build the source.
 * GCC-11 and newer or equivalent clang version.
+* How to build
+	* unpack the source or fetch from github
+	* create a build directory and chdir into it:
+__mkdir tfe-build; cd tfe-build__
+	* run CMake in the build directory:
+__cmake -S /path/to/tfe-source/__
+	* build it:
+__make__
+	* install it:
+__sudo make install__  
+if no additional parameters were added to cmake, files will be installed in /usr/local/bin, /usr/local/share/TheForceEngine/
 
 ##### Running TFE
 * "KDialog" for file dialog on KDE Plasma Desktop Environment

--- a/TheForceEngine/TFE_FileSystem/fileutil-posix.cpp
+++ b/TheForceEngine/TFE_FileSystem/fileutil-posix.cpp
@@ -226,10 +226,7 @@ namespace FileUtil
 
 	bool exists(const char *path)
 	{
-		struct stat st;
-		int ret = stat(path, &st);
-
-		return ret ? (errno != ENOENT) : true;
+		return existsNoCase(path);
 	}
 
 	// Linux filesystems are case-sensitive; try to open the

--- a/TheForceEngine/TFE_FileSystem/paths-posix.cpp
+++ b/TheForceEngine/TFE_FileSystem/paths-posix.cpp
@@ -1,5 +1,5 @@
 #include <cstring>
-
+#include <cassert>
 #include "paths.h"
 #include "fileutil.h"
 #include "filestream.h"
@@ -100,7 +100,10 @@ namespace TFE_Paths
 
 	bool setUserDocumentsPath(const char *append)
 	{
-		setTFEPath(append, PATH_USER_DOCUMENTS);
+		// ensure SetProgramDataPath() was called before
+		assert(!s_paths[PATH_PROGRAM_DATA].empty());
+
+		s_paths[PATH_USER_DOCUMENTS] = s_paths[PATH_PROGRAM_DATA];
 		s_systemPaths.push_back(getPath(PATH_USER_DOCUMENTS));
 		// set cwd to user documents path, because Dear ImGUI drops
 		// its ini file at the cwd, we don't want it to litter somewhere


### PR DESCRIPTION
- Add step-by-step instructions on how to build and instal TFE Linux from source. Fixes #231 
- change directory/file enumeration to not treat symlinks as special: Fixes #229 
- make all file/dir existence checks case-agnostic: Since DF and Outlaws are DOS/Windows applications, they are used to case-agnostic filesystems, so the linux implementation must do the extra steps to be so as well (noticed because I could not select the "Outlaws.lab" file).

