### PR TITLE
Linux/CMake: also install the Mods folder from source

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,7 @@ elseif(LINUX)
 	# the necessary support file directories into the build env.
 	execute_process(COMMAND /usr/bin/ln -sf ${CMAKE_SOURCE_DIR}/TheForceEngine/Documentation)
 	execute_process(COMMAND /usr/bin/ln -sf ${CMAKE_SOURCE_DIR}/TheForceEngine/Fonts)
+	execute_process(COMMAND /usr/bin/ln -sf ${CMAKE_SOURCE_DIR}/TheForceEngine/Mods)
 	execute_process(COMMAND /usr/bin/ln -sf ${CMAKE_SOURCE_DIR}/TheForceEngine/Shaders)
 	execute_process(COMMAND /usr/bin/ln -sf ${CMAKE_SOURCE_DIR}/TheForceEngine/UI_Images)
 	execute_process(COMMAND /usr/bin/ln -sf ${CMAKE_SOURCE_DIR}/TheForceEngine/UI_Text)
@@ -98,6 +99,7 @@ install(DIRECTORY
 	"${CMAKE_CURRENT_SOURCE_DIR}/TheForceEngine/UI_Images"
 	"${CMAKE_CURRENT_SOURCE_DIR}/TheForceEngine/Shaders"
 	"${CMAKE_CURRENT_SOURCE_DIR}/TheForceEngine/Fonts"
+	"${CMAKE_CURRENT_SOURCE_DIR}/TheForceEngine/Mods"
 	DESTINATION "${CMAKE_INSTALL_DATADIR}"
         FILE_PERMISSIONS
           OWNER_READ OWNER_WRITE


### PR DESCRIPTION
It contains the adjustable HUD Mod, which was not installed by default and caused crashes before lucius fixed the code.