### PR TITLE
Linux: name executable "TheForceEngine"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,11 +40,9 @@ include(GNUInstallDirs)
 
 
 add_executable(tfe)
+set_target_properties(tfe PROPERTIES OUTPUT_NAME "TheForceEngine")
 
-if(WIN32)
-	set_target_properties(tfe PROPERTIES OUTPUT_NAME "TheForceEngine")
-elseif(LINUX)
-	set_target_properties(tfe PROPERTIES OUTPUT_NAME "tfelnx")
+if(LINUX)
 	find_package(PkgConfig REQUIRED)
 	find_package(Threads REQUIRED)
 	pkg_check_modules(RTAUDIO REQUIRED rtaudio>=5.2.0)

--- a/README.md
+++ b/README.md
@@ -74,9 +74,15 @@ __sudo make install__
 * If no additional parameters were added to CMake, files will be installed in __/usr/local/bin__, __/usr/local/share/TheForceEngine/__
 
 #### Running TFE
+##### External application dependencies
 * "KDialog" for file dialog on KDE Plasma Desktop Environment
 * "zenity" for file dialog on all other desktop environments
 * "TiMidity++" or "FluidSynth" software synthesizer for glorious MIDI Music.
-	* __timidity -iA --sequencer-ports=1__
-	* __fluidsynth -s -L2 /path/to/preferred/soundfont.sf2__
 * or external MIDI Hardware.
+
+##### Launch
+* Start your preferred MIDI Software Synthesizer first:
+	* __timidity -iA --sequencer-ports=1__
+	* __fluidsynth -s -L2 -m alsa_seq /path/to/soundfont.sf2__
+* Start the Engine by Clicking the __"TheForceEngine"__ Desktop icon or by running __"TheForceEngine"__ in a shell.
+


### PR DESCRIPTION
Call the final executable on Linux "TheForceEngine", just like on Windows, for consistency on all supported platforms.

While "tfelnx" is short, it does not immediately remind one of what it is about.