### PR TITLE
Cleats and swimming sounds

### DIFF
--- a/TheForceEngine/TFE_DarkForces/player.cpp
+++ b/TheForceEngine/TFE_DarkForces/player.cpp
@@ -1379,7 +1379,7 @@ namespace TFE_DarkForces
 			}
 			else
 			{
-				if (!s_playerInWater)
+				if (!s_playerInWater || !(TFE_Settings::getGameSettings()->df_movementSounds))
 				{
 					sound_play(s_jumpSoundSource);
 				}
@@ -2205,6 +2205,8 @@ namespace TFE_DarkForces
 
 	void handlePlayerMovementSounds()
 	{
+		TFE_Settings_Game* settings = TFE_Settings::getGameSettings();
+		
 		fixed16_16 pHeight = s_playerObject->posWS.y;
 		fixed16_16 fHeight = s_playerObject->sector->floorHeight;
 		s32 distFromLastFootstep = distApprox(s_lastFootstepPos.x, s_lastFootstepPos.z, s_playerObject->posWS.x, s_playerObject->posWS.z) / 65536;
@@ -2213,9 +2215,16 @@ namespace TFE_DarkForces
 		if (s_playerSector->secHeight - 1 >= 0 && (pHeight - fHeight) >= FIXED(3) && s_playerSpeedAve > FIXED(8))
 		{
 			// player is in water deeper than 3dfu and moving
-			if (!s_swimmingSoundId)
+			if (!s_swimmingSoundId && settings->df_movementSounds)
 			{
 				s_swimmingSoundId = sound_play(s_swimSoundSource);
+			}
+
+			// immediately stop sound if player switches setting off
+			if (s_swimmingSoundId && !settings->df_movementSounds) 
+			{
+				sound_stop(s_swimmingSoundId);
+				s_swimmingSoundId = NULL_SOUND;
 			}
 		}
 		else
@@ -2224,8 +2233,9 @@ namespace TFE_DarkForces
 			if (s_swimmingSoundId)
 			{
 				sound_stop(s_swimmingSoundId);
-				sound_play(s_swimStopSoundSource);
 				s_swimmingSoundId = NULL_SOUND;
+
+				if (settings->df_movementSounds) sound_play(s_swimStopSoundSource);
 			}
 		}
 
@@ -2234,7 +2244,7 @@ namespace TFE_DarkForces
 		{
 			// play next footstep sound if player has moved 16 units and is on the floor; reset lastFootstepPos
 			// TODO set a constant for footstep distance
-			if (distFromLastFootstep >= 16 && s_onFloor)
+			if (distFromLastFootstep >= 16 && s_onFloor && settings->df_movementSounds)
 			{
 				s_footstepNumber++;
 				if (s_footstepNumber > 3)

--- a/TheForceEngine/TFE_DarkForces/player.cpp
+++ b/TheForceEngine/TFE_DarkForces/player.cpp
@@ -2210,7 +2210,7 @@ namespace TFE_DarkForces
 		s32 distFromLastFootstep = distApprox(s_lastFootstepPos.x, s_lastFootstepPos.z, s_playerObject->posWS.x, s_playerObject->posWS.z) / 65536;
 
 		// In water
-		if (s_playerInWater && (pHeight - fHeight) >= FIXED(3) && s_playerSpeedAve > FIXED(8))
+		if (s_playerSector->secHeight - 1 >= 0 && (pHeight - fHeight) >= FIXED(3) && s_playerSpeedAve > FIXED(8))
 		{
 			// player is in water deeper than 3dfu and moving
 			if (!s_swimmingSoundId)

--- a/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
+++ b/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
@@ -620,6 +620,7 @@ namespace TFE_FrontEndUI
 					// Game
 					gameSettings->df_showSecretFoundMsg = true;
 					gameSettings->df_bobaFettFacePlayer = true;
+					gameSettings->df_movementSounds = true;
 					// Graphics
 					graphicsSettings->rendererIndex = RENDERER_HARDWARE;
 					graphicsSettings->skyMode = SKYMODE_CYLINDER;
@@ -651,6 +652,7 @@ namespace TFE_FrontEndUI
 					// Game
 					gameSettings->df_showSecretFoundMsg = false;
 					gameSettings->df_bobaFettFacePlayer = false;
+					gameSettings->df_movementSounds = false;
 					// Graphics
 					graphicsSettings->rendererIndex = RENDERER_SOFTWARE;
 					graphicsSettings->widescreen = false;
@@ -1075,6 +1077,12 @@ namespace TFE_FrontEndUI
 		if (ImGui::Checkbox("Boba Fett Face Player Fix", &bobaFettFacePlayer))
 		{
 			gameSettings->df_bobaFettFacePlayer = bobaFettFacePlayer;
+		}
+
+		bool movementSounds = gameSettings->df_movementSounds;
+		if (ImGui::Checkbox("Ice Cleat and Swimming Sound Effects", &movementSounds))
+		{
+			gameSettings->df_movementSounds = movementSounds;
 		}
 
 		if (s_drawNoGameDataMsg)

--- a/TheForceEngine/TFE_Settings/settings.cpp
+++ b/TheForceEngine/TFE_Settings/settings.cpp
@@ -432,6 +432,7 @@ namespace TFE_Settings
 				writeKeyValue_Bool(settings, "showSecretFoundMsg", s_gameSettings.df_showSecretFoundMsg);
 				writeKeyValue_Bool(settings, "autorun", s_gameSettings.df_autorun);
 				writeKeyValue_Int(settings, "pitchLimit", s_gameSettings.df_pitchLimit);
+				writeKeyValue_Bool(settings, "movementSounds", s_gameSettings.df_movementSounds);
 			}
 		}
 	}
@@ -859,6 +860,10 @@ namespace TFE_Settings
 		else if (strcasecmp("pitchLimit", key) == 0)
 		{
 			s_gameSettings.df_pitchLimit = PitchLimit(parseInt(value));
+		}
+		else if (strcasecmp("movementSounds", key) == 0)
+		{
+			s_gameSettings.df_movementSounds = parseBool(value);
 		}
 	}
 

--- a/TheForceEngine/TFE_Settings/settings.h
+++ b/TheForceEngine/TFE_Settings/settings.h
@@ -157,6 +157,7 @@ struct TFE_Settings_Game
 	bool df_enableAutoaim      = true;  // Set to true to enable autoaim, false to disable.
 	bool df_showSecretFoundMsg = true;  // Show a message when the player finds a secret.
 	bool df_autorun = false;			// Run by default instead of walk.
+	bool df_movementSounds = false;		// Ice cleat and swimming sounds enabled
 	PitchLimit df_pitchLimit  = PITCH_VANILLA_PLUS;
 };
 


### PR DESCRIPTION
Adds code for ice-cleat and swimming sound effects, which were included with the game but unused in the original.
The feature is a toggleable game setting, like autorun.

Note: the 4 cleats VOC files need to be shipped separately. The original game has a single VOC file with all 4 combined; I have split them so the interval can be altered to match how fast the player is moving.