### PR TITLE
IMuse: clamp priority parameter to 127

### DIFF
--- a/TheForceEngine/TFE_Jedi/IMuse/imuse.cpp
+++ b/TheForceEngine/TFE_Jedi/IMuse/imuse.cpp
@@ -1296,7 +1296,7 @@ namespace TFE_Jedi
 
 	void ImHandleChannelPriorityChange(ImMidiPlayer* player, ImMidiOutChannel* channel)
 	{
-		channel->priority = channel->partPriority + player->priority;
+		channel->priority = std::min(channel->partPriority + player->priority, 127);
 		if (channel->data)
 		{
 			ImMidiChannelSetPriority(channel->data, channel->priority);


### PR DESCRIPTION
Sometimes the priority computed is larger than the allowed 127 by MiDi, and this confuses the Linux ALSA MIDI Parser.  Ensure it's never larger than 127.
Fixes a ton of "incomplete message!" MIDI errors in the log when System Midi is in use on Linux.