### PR TITLE
Patches relating to morph_move and morph_spin (draft)

### DIFF
--- a/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
+++ b/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
@@ -664,6 +664,8 @@ namespace TFE_FrontEndUI
 					// Game
 					gameSettings->df_showSecretFoundMsg = false;
 					gameSettings->df_bobaFettFacePlayer = false;
+					gameSettings->df_morphPatch1 = false;
+					gameSettings->df_morphPatch2 = false;
 					// Graphics
 					graphicsSettings->rendererIndex = RENDERER_SOFTWARE;
 					graphicsSettings->widescreen = false;
@@ -1094,6 +1096,18 @@ namespace TFE_FrontEndUI
 		if (ImGui::Checkbox("Remove INF Item Limit (requires restart)", &ignoreInfLimit))
 		{
 			gameSettings->df_ignoreInfLimit = ignoreInfLimit;
+		}
+
+		bool morphPatch1 = gameSettings->df_morphPatch1;
+		if (ImGui::Checkbox("Enforce no-walk wall flag for moving walls", &morphPatch1))
+		{
+			gameSettings->df_morphPatch1 = morphPatch1;
+		}
+
+		bool morphPatch2 = gameSettings->df_morphPatch2;
+		if (ImGui::Checkbox("Morph_move elevators will push objects", &morphPatch2))
+		{
+			gameSettings->df_morphPatch2 = morphPatch2;
 		}
 
 		if (s_drawNoGameDataMsg)

--- a/TheForceEngine/TFE_Jedi/InfSystem/infSystem.cpp
+++ b/TheForceEngine/TFE_Jedi/InfSystem/infSystem.cpp
@@ -3469,7 +3469,12 @@ namespace TFE_Jedi
 		// First attempt to move walls in the sector.
 		if (!sector_moveWalls(elev->sector, delta, elev->dirOrCenter.x, elev->dirOrCenter.z, elev->flags))
 		{
-			elev->nextStop = inf_advanceStops(elev->stops, 0, -1);		// elevator is blocked by player and "rebound" flag is set; return to previous stop
+			TFE_Settings_Game* gameSettings = TFE_Settings::getGameSettings();
+			if (gameSettings->df_morphPatch2)
+			{
+				elev->nextStop = inf_advanceStops(elev->stops, 0, -1);		// elevator is blocked by player and "rebound" flag is set; return to previous stop
+			}
+			
 			return elev->iValue;
 		}
 
@@ -3514,7 +3519,8 @@ namespace TFE_Jedi
 		const angle14_32 angleInt = floor16(angle);
 		if (!sector_canRotateWalls(sector, angleInt, centerX, centerZ))
 		{
-			if (sector->flags2 & SEC_FLAGS2_MORPH_ELEV_REBOUND)
+			TFE_Settings_Game* gameSettings = TFE_Settings::getGameSettings();
+			if (gameSettings->df_morphPatch2 && sector->flags2 & SEC_FLAGS2_MORPH_ELEV_REBOUND)
 			{
 				elev->nextStop = inf_advanceStops(elev->stops, 0, -1);		// return to previous stop if "rebound" flag is set
 			}

--- a/TheForceEngine/TFE_Jedi/InfSystem/infSystem.cpp
+++ b/TheForceEngine/TFE_Jedi/InfSystem/infSystem.cpp
@@ -3469,6 +3469,7 @@ namespace TFE_Jedi
 		// First attempt to move walls in the sector.
 		if (!sector_moveWalls(elev->sector, delta, elev->dirOrCenter.x, elev->dirOrCenter.z, elev->flags))
 		{
+			elev->nextStop = inf_advanceStops(elev->stops, 0, -1);		// return to previous stop if non-crushing sector and player is in the way
 			return elev->iValue;
 		}
 
@@ -3513,6 +3514,11 @@ namespace TFE_Jedi
 		const angle14_32 angleInt = floor16(angle);
 		if (!sector_canRotateWalls(sector, angleInt, centerX, centerZ))
 		{
+			if (!(sector->flags1 & SEC_FLAGS1_CRUSHING))
+			{
+				elev->nextStop = inf_advanceStops(elev->stops, 0, -1);		// return to previous stop if non-crushing sector and player is in the way
+			}
+			
 			return elev->iValue;
 		}
 

--- a/TheForceEngine/TFE_Jedi/InfSystem/infSystem.cpp
+++ b/TheForceEngine/TFE_Jedi/InfSystem/infSystem.cpp
@@ -3469,7 +3469,7 @@ namespace TFE_Jedi
 		// First attempt to move walls in the sector.
 		if (!sector_moveWalls(elev->sector, delta, elev->dirOrCenter.x, elev->dirOrCenter.z, elev->flags))
 		{
-			elev->nextStop = inf_advanceStops(elev->stops, 0, -1);		// return to previous stop if non-crushing sector and player is in the way
+			elev->nextStop = inf_advanceStops(elev->stops, 0, -1);		// elevator is blocked by player and "rebound" flag is set; return to previous stop
 			return elev->iValue;
 		}
 
@@ -3514,9 +3514,9 @@ namespace TFE_Jedi
 		const angle14_32 angleInt = floor16(angle);
 		if (!sector_canRotateWalls(sector, angleInt, centerX, centerZ))
 		{
-			if (!(sector->flags1 & SEC_FLAGS1_CRUSHING))
+			if (sector->flags2 & SEC_FLAGS2_MORPH_ELEV_REBOUND)
 			{
-				elev->nextStop = inf_advanceStops(elev->stops, 0, -1);		// return to previous stop if non-crushing sector and player is in the way
+				elev->nextStop = inf_advanceStops(elev->stops, 0, -1);		// return to previous stop if "rebound" flag is set
 			}
 			
 			return elev->iValue;

--- a/TheForceEngine/TFE_Jedi/Level/rsector.cpp
+++ b/TheForceEngine/TFE_Jedi/Level/rsector.cpp
@@ -293,10 +293,22 @@ namespace TFE_Jedi
 			
 			if (obj && (obj->flags & OBJ_FLAG_MOVABLE) && (obj->entityFlags != ETFLAG_PLAYER))
 			{
-				if (sector_objOverlapsWall(wall, obj, &objSide) && objSide == 1)
+				// This has to be done because of what I suspect is a bug/typo in sector_objOverlapsWall() where the floor and ceiling
+				// heights of wall->sector are tested instead of wall->nextSector
+				RWall* wallToCheckForOverlap = wall->mirror == -1 ? wall : wall->mirrorWall;
+
+				fixed16_16 x0 = wallToCheckForOverlap->w0->x;
+				fixed16_16 z0 = wallToCheckForOverlap->w0->z;
+				wallToCheckForOverlap->w0->x += offsetX;
+				wallToCheckForOverlap->w0->z += offsetZ;
+				
+				if (sector_objOverlapsWall(wallToCheckForOverlap, obj, &objSide))
 				{
 					sector_moveObject(obj, offsetX, offsetZ);
 				}
+
+				wallToCheckForOverlap->w0->x = x0;
+				wallToCheckForOverlap->w0->z = z0;
 			}
 		}
 	}
@@ -1154,7 +1166,7 @@ namespace TFE_Jedi
 		RSector* next = wall->nextSector;
 		if (next)
 		{
-			RSector* sector = wall->nextSector;
+			RSector* sector = wall->sector;
 			if (sector->floorHeight >= obj->posWS.y)
 			{
 				fixed16_16 objTop = obj->posWS.y - obj->worldHeight;

--- a/TheForceEngine/TFE_Jedi/Level/rsector.cpp
+++ b/TheForceEngine/TFE_Jedi/Level/rsector.cpp
@@ -240,7 +240,7 @@ namespace TFE_Jedi
 				sectorBlockedByPlayer |= sector_canWallMove(wall, offsetX, offsetZ);
 
 				SecObject** objectsThisSector = sector->objectList;
-				sector_moveObjectsIfBlockingWall(wall, objectsThisSector, sector->objectCount, offsetX, offsetZ);
+				sector_moveObjectsIfBlockingWall(wall, objectsThisSector, sector->objectCapacity, offsetX, offsetZ);
 
 				RWall* mirror = wall->mirrorWall;
 				if (mirror && (mirror->flags1 & WF1_WALL_MORPHS))
@@ -248,7 +248,7 @@ namespace TFE_Jedi
 					sectorBlockedByPlayer |= sector_canWallMove(mirror, offsetX, offsetZ);
 
 					SecObject** objectsNextSector = wall->nextSector->objectList;
-					sector_moveObjectsIfBlockingWall(mirror, objectsNextSector, wall->nextSector->objectCount, offsetX, offsetZ);
+					sector_moveObjectsIfBlockingWall(mirror, objectsNextSector, wall->nextSector->objectCapacity, offsetX, offsetZ);
 				}
 			}
 		}
@@ -284,11 +284,13 @@ namespace TFE_Jedi
 		return ~sectorBlockedByPlayer;
 	}
 
-	void sector_moveObjectsIfBlockingWall(RWall* wall, SecObject** objects, s32 objectCount, fixed16_16 offsetX, fixed16_16 offsetZ)
+	void sector_moveObjectsIfBlockingWall(RWall* wall, SecObject** objects, s32 objectCapacity, fixed16_16 offsetX, fixed16_16 offsetZ)
 	{
-		for (s32 i = 0; i < objectCount; i++)
+		for (s32 i = 0; i < objectCapacity; i++)
 		{
 			SecObject* obj = objects[i];
+			if (!obj) { continue; }
+
 			s32 objSide = 0;
 			
 			if (obj && (obj->flags & OBJ_FLAG_MOVABLE) && (obj->entityFlags != ETFLAG_PLAYER))

--- a/TheForceEngine/TFE_Jedi/Level/rsector.cpp
+++ b/TheForceEngine/TFE_Jedi/Level/rsector.cpp
@@ -247,8 +247,9 @@ namespace TFE_Jedi
 			}
 		}
 
-		// If "crushing" sector, move the player and allow the walls to continue moving
-		if (sectorBlockedByPlayer && sector->flags1 & SEC_FLAGS1_CRUSHING)
+		// Normally: Move the player if he is blocking the elevator, and allow the walls to continue moving
+		// If "rebound" flag is set, the elevator will be sent back to its previous stop (door behaviour)
+		if (sectorBlockedByPlayer && !(sector->flags2 & SEC_FLAGS2_MORPH_ELEV_REBOUND))
 		{
 			sector_moveObject(s_playerObject, offsetX, offsetZ);
 			sectorBlockedByPlayer = JFALSE;

--- a/TheForceEngine/TFE_Jedi/Level/rsector.cpp
+++ b/TheForceEngine/TFE_Jedi/Level/rsector.cpp
@@ -1166,13 +1166,20 @@ namespace TFE_Jedi
 		RSector* next = wall->nextSector;
 		if (next)
 		{
-			RSector* sector = wall->sector;
-			if (sector->floorHeight >= obj->posWS.y)
+			if ((wall->flags3 & WF3_SOLID_WALL) || wall->mirrorWall->flags3 & WF3_SOLID_WALL)
 			{
-				fixed16_16 objTop = obj->posWS.y - obj->worldHeight;
-				if (sector->ceilingHeight < objTop)
+				// the wall is "solid" so skip this escape route
+			}
+			else
+			{
+				RSector* sector = wall->sector;				// It is likely that this was supposed to be wall->nextSector
+				if (sector->floorHeight >= obj->posWS.y)
 				{
-					return JFALSE;
+					fixed16_16 objTop = obj->posWS.y - obj->worldHeight;
+					if (sector->ceilingHeight < objTop)
+					{
+						return JFALSE;
+					}
 				}
 			}
 		}

--- a/TheForceEngine/TFE_Jedi/Level/rsector.h
+++ b/TheForceEngine/TFE_Jedi/Level/rsector.h
@@ -38,6 +38,12 @@ enum SectorFlags1
 	SEC_FLAGS1_SECRET        = FLAG_BIT(19),
 };
 
+enum SectorFlags2
+{
+	SEC_FLAGS2_MORPH_ELEV_REBOUND	= FLAG_BIT(0)		// JK added: used to instruct a morph_move or morph_spin elevator to rebound on contact with player (door behaviour)
+};
+
+
 // Added for TFE to support floating point and GPU sub-renderers.
 // Floating point or GPU based sector data should be cached and only parts updated based
 // on these flags.

--- a/TheForceEngine/TFE_Settings/settings.cpp
+++ b/TheForceEngine/TFE_Settings/settings.cpp
@@ -437,6 +437,8 @@ namespace TFE_Settings
 				writeKeyValue_Bool(settings, "autorun", s_gameSettings.df_autorun);
 				writeKeyValue_Bool(settings, "ignoreInfLimit", s_gameSettings.df_ignoreInfLimit);
 				writeKeyValue_Int(settings, "pitchLimit", s_gameSettings.df_pitchLimit);
+				writeKeyValue_Bool(settings, "morphPatch1", s_gameSettings.df_morphPatch1);
+				writeKeyValue_Bool(settings, "morphPatch2", s_gameSettings.df_morphPatch2);
 			}
 		}
 	}
@@ -884,6 +886,14 @@ namespace TFE_Settings
 		else if (strcasecmp("pitchLimit", key) == 0)
 		{
 			s_gameSettings.df_pitchLimit = PitchLimit(parseInt(value));
+		}
+		else if (strcasecmp("morphPatch1", key) == 0)
+		{
+			s_gameSettings.df_morphPatch1 = parseBool(value);
+		}
+		else if (strcasecmp("morphPatch2", key) == 0)
+		{
+			s_gameSettings.df_morphPatch2 = parseBool(value);
 		}
 	}
 

--- a/TheForceEngine/TFE_Settings/settings.h
+++ b/TheForceEngine/TFE_Settings/settings.h
@@ -163,6 +163,8 @@ struct TFE_Settings_Game
 	bool df_showSecretFoundMsg = true;  // Show a message when the player finds a secret.
 	bool df_autorun = false;			// Run by default instead of walk.
 	bool df_ignoreInfLimit = true;		// Ignore the vanilla INF limit.
+	bool df_morphPatch1 = true;			// "No walk" (solid wall) flag is enforced for collision with moving walls.
+	bool df_morphPatch2 = false;		// Moving (not rotating) walls will push the player and other objects. Option for moving and rotating elevators to rebound on contact with player.
 	PitchLimit df_pitchLimit  = PITCH_VANILLA_PLUS;
 };
 


### PR DESCRIPTION
There are 4 main components

1. Observing the "solid wall" flag when testing for objects colliding with a moving wall. This fixes the issues with the Starsend tram, Harkov train, Dark Tide 3 shuttle ride, and similar, where you can jump through "glass windows" or impassable adjoined walls
2. Pushing the player object if it is blocking a moving wall. This allows the elevator to continue moving at its proper speed rather than slowing down to 4 units per second (improves behaviour of tram in StarsEnd)
3. Testing for non-player objects in the path of a moving wall, and pushing them also if they are contacted by the wall. The motivation was to try and prevent enemies from passing through moving walls (and potentially falling out of the map), most notably the remote at the start of Nar Shaddaa. It is very effective for stationary items or slow moving enemies but less reliable for fast moving or smaller enemies (like the remote...).
4. Introducing the ability for a moving or rotating elevator to "rebound" back to its previous stop if the player is in its path. This copies the behaviour of doors (and non-crusher elevators), and enables horizontally moving/rotating doors to behave like the vertical doors; and also prevents the player from becoming trapped in a horizontal door. It makes use of the (previously unused) sector flags 2. 

In settings, I've decided to group 2-4 together as one option (default `off`) and have 1 by itself. I think 1 is very unlikely to break any existing behaviour whereas 2-4 may have effects on some legacy mods.

We can discuss in discord; it might also be useful to get the input of the folks who are really familiar with all the existing mods to know which ones might be impacted by the changes.