### PR TITLE
Linux: improve crash handler

### DIFF
--- a/TheForceEngine/TFE_System/CrashHandler/crashHandlerLinux.cpp
+++ b/TheForceEngine/TFE_System/CrashHandler/crashHandlerLinux.cpp
@@ -1,87 +1,121 @@
+#include <cstring>
+#include <errno.h>
+#include <execinfo.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <unistd.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/resource.h>
+#include <sys/types.h>
+#include <signal.h>
 #include "crashHandler.h"
 #include <TFE_System/system.h>
-#include <TFE_FileSystem/paths.h>
 
-#include <stdio.h>
-#include <signal.h>
 
-static void sigabrtHandler(int);
-static void sigfpeHandler(int /*code*/, int subcode);
-static void sigintHandler(int);
-static void sigillHandler(int);
-static void sigsegvHandler(int);
-static void sigtermHandler(int);
+// On Linux, /proc/self/status contains a "TracerPid:" entry
+// with the PID of the controlling process, or 0 if run directly.
+// Use this to determine whether we are running under
+// gdb/valgrind/...
+static bool are_we_being_debugged(void)
+{
+	char buf[4096], *c;
+	int fd, rd;
+
+	fd = open("/proc/self/status", O_RDONLY);
+	if (!fd)
+		return false;	// assume no.
+	rd = read(fd, buf, 4096);
+	close(fd);
+	if (rd <= 0)
+		return false;
+
+	buf[rd] = 0;
+	c = strstr(buf, "TracerPid:");
+	if (!c)
+		return false;	// can't say.
+
+	c += 10;
+	while (*c && isspace(*c))
+		c++;
+
+	if (!*c)
+		return false;	// can't say for sure.
+
+	return (isdigit(*c) && (*c != '0'));	// PID != 0 => being traced.
+}
+
+static void tfe_sigaction(int signo, siginfo_t *siginfo, void *uctx)
+{
+	int entries, i;
+	void *buf[512];
+	char **ents;
+
+	// gently quit
+	if ((signo == SIGINT) || (signo == SIGTERM)) {
+		TFE_System::postQuitMessage();
+		return;
+	}
+
+	TFE_System::logWrite(LOG_ERROR, "CrashHandler", "Received Signal %d errno %d code %d", signo, siginfo->si_addr, siginfo->si_errno, siginfo->si_code);
+
+	switch (signo) {
+	case SIGILL:
+	case SIGFPE:
+	case SIGSEGV:
+	case SIGBUS:
+		TFE_System::logWrite(LOG_ERROR, "CrashHandler", "faulting address %p", siginfo->si_addr);
+	}
+
+	// backtrace() can also segfault; purposefully ignore SEGV before calling it.
+	signal(SIGSEGV, SIG_IGN);
+	entries = backtrace(buf, 512);
+	if (entries) {
+		ents = backtrace_symbols(buf, entries);
+		TFE_System::logWrite(LOG_ERROR, "CrashHandler", "Backtrace %d:", entries);
+		for (i = 0; i < entries; i++) {
+			TFE_System::logWrite(LOG_ERROR, "CrashHandler", "%03d %s", i, ents[i]);
+		}
+	} else {
+		TFE_System::logWrite(LOG_ERROR, "CrashHandler", "no backtrace possible");
+	}
+
+	// for certain signals, the default handler will create
+	// a coredump if enabled by administrator.
+	signal(signo, SIG_DFL);
+	kill(getpid(), signo);
+}
+
+static void setsig(int signo)
+{
+	struct sigaction sa;
+	memset(&sa, 0, sizeof(struct sigaction));
+	sa.sa_flags = SA_SIGINFO;
+	sa.sa_sigaction = tfe_sigaction;
+	if (sigaction(signo, &sa, NULL)) {
+		fprintf(stderr, "Crash Handler: setsig(%d) failed with %d (%s)\n", signo, errno, strerror(errno));
+	}
+}
 
 namespace TFE_CrashHandler
 {
 	void setProcessExceptionHandlers()
 	{
-#if 0
-		// Catch an abnormal program termination
-		signal(SIGABRT, sigabrtHandler);
+		// skip signal hooking when running under debuggers.
+		if (are_we_being_debugged())
+			return;
 
-		// Catch illegal instruction handler
-		signal(SIGINT, sigintHandler);
-
-		// Catch a termination request
-		signal(SIGTERM, sigtermHandler);
-#endif
+		setsig(SIGINT);		// ctrl-c
+		setsig(SIGTERM);	// kill -15 received
+		setsig(SIGFPE);		// FPU exception
+		setsig(SIGILL);		// unknown opcode
+		setsig(SIGBUS);		// alignment issues
+		setsig(SIGSEGV);	// pointer gone awry
+		setsig(SIGABRT);	// abort() was invoked
 	}
 
 	void setThreadExceptionHandlers()
 	{
-#if 0
-		// Catch a floating point error
-		typedef void(*sigh)(int);
-		signal(SIGFPE, (sigh)sigfpeHandler);
-
-		// Catch an illegal instruction
-		signal(SIGILL, sigillHandler);
-
-		// Catch illegal storage access errors
-		signal(SIGSEGV, sigsegvHandler);
-#endif
 	}
 }  // namespace TFE_CrashHandler
-
-// CRT SIGABRT signal handler
-void sigabrtHandler(int)
-{
-	fprintf(stderr, "Caught SIGBABRT");
-	exit(-4);
-}
-
-// CRT SIGFPE signal handler
-void sigfpeHandler(int /*code*/, int subcode)
-{
-	fprintf(stderr, "Caught SIGFPE");
-	exit(-5);
-}
-
-// CRT sigill signal handler
-void sigillHandler(int)
-{
-	fprintf(stderr, "Caught SIGILL");
-	exit(-6);
-}
-
-// CRT sigint signal handler
-void sigintHandler(int)
-{
-	fprintf(stderr, "Caught SIGINT");
-	exit(-7);
-}
-
-// CRT SIGSEGV signal handler
-void sigsegvHandler(int)
-{
-	fprintf(stderr, "Caught SIGSEGV");
-	exit(-8);
-}
-
-// CRT SIGTERM signal handler
-void sigtermHandler(int)
-{
-	fprintf(stderr, "Caught SIGTERM");
-	exit(-9);
-}


### PR DESCRIPTION
Slightly improve the linux crash handler:
- print signal information
- print a backtrace if possible
- avoid own signal handling when being run under debuggers/tracers/...