### PR TITLE
Big endian fixes

### DIFF
--- a/TheForceEngine/TFE_Archive/gobArchive.cpp
+++ b/TheForceEngine/TFE_Archive/gobArchive.cpp
@@ -54,10 +54,10 @@ bool GobArchive::validate(const char *archivePath, s32 minFileCount)
 		file.close();
 		return false;
 	}
-	header.MASTERX = TFE_Endian::swapLE32(header.MASTERX);
+	header.MASTERX = TFE_Endian::le32_to_cpu(header.MASTERX);
 	file.seek(header.MASTERX);
 	file.readBuffer(&MASTERN, sizeof(long));
-	MASTERN = TFE_Endian::swapLE32(MASTERN);
+	MASTERN = TFE_Endian::le32_to_cpu(MASTERN);
 	file.close();
 
 	return MASTERN >= minFileCount;
@@ -71,17 +71,17 @@ bool GobArchive::open(const char *archivePath)
 
 	// Read the directory.
 	m_file.readBuffer(&m_header, sizeof(GOB_Header_t));
-	m_header.MASTERX = TFE_Endian::swapLE32(m_header.MASTERX);
+	m_header.MASTERX = TFE_Endian::le32_to_cpu(m_header.MASTERX);
 	m_file.seek(m_header.MASTERX);
 
 	m_file.readBuffer(&m_fileList.MASTERN, sizeof(u32));
-	m_fileList.MASTERN = TFE_Endian::swapLE32(m_fileList.MASTERN);
+	m_fileList.MASTERN = TFE_Endian::le32_to_cpu(m_fileList.MASTERN);
 	m_fileList.entries = new GOB_Entry_t[m_fileList.MASTERN];
 	m_file.readBuffer(m_fileList.entries, sizeof(GOB_Entry_t), m_fileList.MASTERN);
 	for (s32 i = 0; i < m_fileList.MASTERN; i++)
 	{
-		m_fileList.entries[i].IX = TFE_Endian::swapLE32(m_fileList.entries[i].IX);
-		m_fileList.entries[i].LEN = TFE_Endian::swapLE32(m_fileList.entries[i].LEN);
+		m_fileList.entries[i].IX = TFE_Endian::le32_to_cpu(m_fileList.entries[i].IX);
+		m_fileList.entries[i].LEN = TFE_Endian::le32_to_cpu(m_fileList.entries[i].LEN);
 	}
 
 	strcpy(m_archivePath, archivePath);

--- a/TheForceEngine/TFE_Archive/labArchive.cpp
+++ b/TheForceEngine/TFE_Archive/labArchive.cpp
@@ -1,6 +1,7 @@
 #include <cstring>
 
 #include <TFE_System/system.h>
+#include <TFE_System/endian.h>
 #include "labArchive.h"
 #include <assert.h>
 #include <algorithm>
@@ -25,11 +26,20 @@ bool LabArchive::open(const char *archivePath)
 
 	// Read the directory.
 	m_file.readBuffer(&m_header, sizeof(LAB_Header_t));
+	m_header.version = TFE_Endian::swapLE32(m_header.version);
+	m_header.fileCount = TFE_Endian::swapLE32(m_header.fileCount);
+	m_header.stringTableSize = TFE_Endian::swapLE32(m_header.stringTableSize);
 	m_stringTable = new char[m_header.stringTableSize + 1];
 	m_entries = new LAB_Entry_t[m_header.fileCount];
 
 	// Read the file entries.
 	m_file.readBuffer(m_entries, sizeof(LAB_Entry_t), m_header.fileCount);
+	for (u32 i = 0; i < m_header.fileCount; i++)
+	{
+		m_entries[i].nameOffset = TFE_Endian::swapLE32(m_entries[i].nameOffset);
+		m_entries[i].dataOffset = TFE_Endian::swapLE32(m_entries[i].dataOffset);
+		m_entries[i].len = TFE_Endian::swapLE32(m_entries[i].len);
+	}
 
 	// Read string table.
 	m_file.readBuffer(m_stringTable, m_header.stringTableSize);

--- a/TheForceEngine/TFE_Archive/labArchive.cpp
+++ b/TheForceEngine/TFE_Archive/labArchive.cpp
@@ -26,9 +26,9 @@ bool LabArchive::open(const char *archivePath)
 
 	// Read the directory.
 	m_file.readBuffer(&m_header, sizeof(LAB_Header_t));
-	m_header.version = TFE_Endian::swapLE32(m_header.version);
-	m_header.fileCount = TFE_Endian::swapLE32(m_header.fileCount);
-	m_header.stringTableSize = TFE_Endian::swapLE32(m_header.stringTableSize);
+	m_header.version = TFE_Endian::le32_to_cpu(m_header.version);
+	m_header.fileCount = TFE_Endian::le32_to_cpu(m_header.fileCount);
+	m_header.stringTableSize = TFE_Endian::le32_to_cpu(m_header.stringTableSize);
 	m_stringTable = new char[m_header.stringTableSize + 1];
 	m_entries = new LAB_Entry_t[m_header.fileCount];
 
@@ -36,9 +36,9 @@ bool LabArchive::open(const char *archivePath)
 	m_file.readBuffer(m_entries, sizeof(LAB_Entry_t), m_header.fileCount);
 	for (u32 i = 0; i < m_header.fileCount; i++)
 	{
-		m_entries[i].nameOffset = TFE_Endian::swapLE32(m_entries[i].nameOffset);
-		m_entries[i].dataOffset = TFE_Endian::swapLE32(m_entries[i].dataOffset);
-		m_entries[i].len = TFE_Endian::swapLE32(m_entries[i].len);
+		m_entries[i].nameOffset = TFE_Endian::le32_to_cpu(m_entries[i].nameOffset);
+		m_entries[i].dataOffset = TFE_Endian::le32_to_cpu(m_entries[i].dataOffset);
+		m_entries[i].len = TFE_Endian::le32_to_cpu(m_entries[i].len);
 	}
 
 	// Read string table.

--- a/TheForceEngine/TFE_Archive/lfdArchive.cpp
+++ b/TheForceEngine/TFE_Archive/lfdArchive.cpp
@@ -1,6 +1,7 @@
 #include <cstring>
 
 #include <TFE_System/system.h>
+#include <TFE_System/endian.h>
 #include "lfdArchive.h"
 #include <assert.h>
 #include <algorithm>
@@ -39,6 +40,7 @@ bool LfdArchive::open(const char *archivePath)
 	// Read the directory.
 	LFD_Entry_t root, entry;
 	m_file.readBuffer(&root, sizeof(LFD_Entry_t));
+	root.LENGTH = TFE_Endian::swapLE32(root.LENGTH);
 	m_fileList.MASTERN = root.LENGTH / sizeof(LFD_Entry_t);
 	m_fileList.entries = new LFD_EntryFinal_t[m_fileList.MASTERN];
 
@@ -46,6 +48,7 @@ bool LfdArchive::open(const char *archivePath)
 	for (s32 i = 0; i < m_fileList.MASTERN; i++)
 	{
 		m_file.readBuffer(&entry, sizeof(LFD_Entry_t));
+		entry.LENGTH = TFE_Endian::swapLE32(entry.LENGTH);
 
 		char name[9] = { 0 };
 		char ext[5]  = { 0 };

--- a/TheForceEngine/TFE_Archive/lfdArchive.cpp
+++ b/TheForceEngine/TFE_Archive/lfdArchive.cpp
@@ -40,7 +40,7 @@ bool LfdArchive::open(const char *archivePath)
 	// Read the directory.
 	LFD_Entry_t root, entry;
 	m_file.readBuffer(&root, sizeof(LFD_Entry_t));
-	root.LENGTH = TFE_Endian::swapLE32(root.LENGTH);
+	root.LENGTH = TFE_Endian::le32_to_cpu(root.LENGTH);
 	m_fileList.MASTERN = root.LENGTH / sizeof(LFD_Entry_t);
 	m_fileList.entries = new LFD_EntryFinal_t[m_fileList.MASTERN];
 
@@ -48,7 +48,7 @@ bool LfdArchive::open(const char *archivePath)
 	for (s32 i = 0; i < m_fileList.MASTERN; i++)
 	{
 		m_file.readBuffer(&entry, sizeof(LFD_Entry_t));
-		entry.LENGTH = TFE_Endian::swapLE32(entry.LENGTH);
+		entry.LENGTH = TFE_Endian::le32_to_cpu(entry.LENGTH);
 
 		char name[9] = { 0 };
 		char ext[5]  = { 0 };

--- a/TheForceEngine/TFE_Asset/modelAsset_jedi.cpp
+++ b/TheForceEngine/TFE_Asset/modelAsset_jedi.cpp
@@ -402,14 +402,14 @@ namespace TFE_Model_Jedi
 		const char* buffer = parser.readLine(bufferPos, true);
 		if (!buffer) { return false; }
 
-		f32 version;
-		if (sscanf(buffer, "3DO %f", &version) != 1)
+		s32 versionMajor, versionMinor;
+		if (sscanf(buffer, "3DO %d.%d", &versionMajor, &versionMinor) != 2)
 		{
 			TFE_System::logWrite(LOG_ERROR, "Object3D_Load", "'%s' has no valid name.", name);
 			assert(0);
 			return false;
 		}
-		if (version < 1.2f)
+		if (versionMajor < 1 || (versionMajor == 1 && versionMinor < 2))
 		{
 			TFE_System::logWrite(LOG_ERROR, "Object3D_Load", "'%s' has inavlid version", name);
 			assert(0);

--- a/TheForceEngine/TFE_Asset/spriteAsset_Jedi.cpp
+++ b/TheForceEngine/TFE_Asset/spriteAsset_Jedi.cpp
@@ -2,6 +2,7 @@
 
 #include "spriteAsset_Jedi.h"
 #include <TFE_System/system.h>
+#include <TFE_System/endian.h>
 #include <TFE_FileSystem/filestream.h>
 #include <TFE_FileSystem/paths.h>
 #include <TFE_Asset/assetSystem.h>
@@ -62,8 +63,20 @@ namespace TFE_Sprite_Jedi
 		const u8* data = s_buffer.data();
 
 		// Determine ahead of time how much we need to allocate.
-		const WaxFrame* base_frame = (WaxFrame*)data;
-		const WaxCell* base_cell = WAX_CellPtr(data, base_frame);
+		WaxFrame* base_frame = (WaxFrame*)data;
+		base_frame->offsetX = TFE_Endian::swapLE32(base_frame->offsetX);
+		base_frame->offsetY = TFE_Endian::swapLE32(base_frame->offsetY);
+		base_frame->flip = TFE_Endian::swapLE32(base_frame->flip);
+		base_frame->cellOffset = TFE_Endian::swapLE32(base_frame->cellOffset);
+		base_frame->widthWS = TFE_Endian::swapLE32(base_frame->widthWS);
+		base_frame->heightWS = TFE_Endian::swapLE32(base_frame->heightWS);
+
+		WaxCell* base_cell = WAX_CellPtr(data, base_frame);
+		base_cell->sizeX = TFE_Endian::swapLE32(base_cell->sizeX);
+		base_cell->sizeY = TFE_Endian::swapLE32(base_cell->sizeY);
+		base_cell->compressed = TFE_Endian::swapLE32(base_cell->compressed);
+		base_cell->dataSize = TFE_Endian::swapLE32(base_cell->dataSize);
+		base_cell->columnOffset = TFE_Endian::swapLE32(base_cell->columnOffset);
 		const u32 columnSize = base_cell->sizeX * sizeof(u32);
 
 		// This is a "load in place" format in the original code.
@@ -90,6 +103,11 @@ namespace TFE_Sprite_Jedi
 		{
 			// Update the column offset, it starts right after the cell data.
 			cell->columnOffset = frame->cellOffset + sizeof(WaxCell);
+			u32* columns = (u32*)((u8*)asset + cell->columnOffset);
+			for (s32 c = 0; c < cell->sizeX; c++)
+			{
+				columns[c] = TFE_Endian::swapLE32(columns[c]);
+			}
 		}
 		else
 		{
@@ -211,7 +229,18 @@ namespace TFE_Sprite_Jedi
 		file.close();
 
 		const u8* data = s_buffer.data();
-		const Wax* srcWax = (Wax*)data;
+		Wax* srcWax = (Wax*)data;
+		srcWax->version = TFE_Endian::swapLE32(srcWax->version);
+		srcWax->animCount = TFE_Endian::swapLE32(srcWax->animCount);
+		srcWax->frameCount = TFE_Endian::swapLE32(srcWax->frameCount);
+		srcWax->cellCount = TFE_Endian::swapLE32(srcWax->cellCount);
+		srcWax->xScale = TFE_Endian::swapLE32(srcWax->xScale);
+		srcWax->yScale = TFE_Endian::swapLE32(srcWax->yScale);
+		srcWax->xtraLight = TFE_Endian::swapLE32(srcWax->xtraLight);
+		for (s32 animIdx = 0; animIdx < WAX_MAX_ANIM; animIdx++)
+		{
+			srcWax->animOffsets[animIdx] = TFE_Endian::swapLE32(srcWax->animOffsets[animIdx]);
+		}
 		
 		// every animation is filled out until the end, so no animations = no wax.
 		if (!srcWax->animOffsets[0])
@@ -221,20 +250,71 @@ namespace TFE_Sprite_Jedi
 		s_cellOffsets.clear();
 
 		// First determine the size to allocate (note that this will overallocate a bit because cells are shared).
+		std::vector<u32> swappedAnims;
+		std::vector<u32> swappedViews;
+		std::vector<u32> swappedFrames;
+		std::vector<u32> swappedCells;
 		u32 sizeToAlloc = sizeof(JediWax) + (u32)s_buffer.size();
 		const s32* animOffset = srcWax->animOffsets;
 		for (s32 animIdx = 0; animIdx < 32 && animOffset[animIdx]; animIdx++)
 		{
 			WaxAnim* anim = (WaxAnim*)(data + animOffset[animIdx]);
+			if (animOffset[animIdx] && std::find(swappedAnims.begin(), swappedAnims.end(), animOffset[animIdx]) == swappedAnims.end())
+			{
+				swappedAnims.push_back(animOffset[animIdx]);
+				anim->worldWidth = TFE_Endian::swapLE32(anim->worldWidth);
+				anim->worldHeight = TFE_Endian::swapLE32(anim->worldHeight);
+				anim->frameRate = TFE_Endian::swapLE32(anim->frameRate);
+				anim->frameCount = TFE_Endian::swapLE32(anim->frameCount);
+				for (s32 v = 0; v < WAX_MAX_VIEWS; v++)
+				{
+					anim->viewOffsets[v] = TFE_Endian::swapLE32(anim->viewOffsets[v]);
+				}
+			}
 			const s32* viewOffsets = anim->viewOffsets;
 			for (s32 v = 0; v < 32; v++)
 			{
-				const WaxView* view = (WaxView*)(data + viewOffsets[v]);
+				WaxView* view = (WaxView*)(data + viewOffsets[v]);
+				if (viewOffsets[v] && std::find(swappedViews.begin(), swappedViews.end(), viewOffsets[v]) == swappedViews.end())
+				{
+					swappedViews.push_back(viewOffsets[v]);
+					for (s32 f = 0; f < WAX_MAX_FRAMES; f++)
+					{
+						view->frameOffsets[f] = TFE_Endian::swapLE32(view->frameOffsets[f]);
+					}
+				}
 				const s32* frameOffset = view->frameOffsets;
 				for (s32 f = 0; f < 32 && frameOffset[f]; f++)
 				{
-					const WaxFrame* frame = (WaxFrame*)(data + frameOffset[f]);
-					const WaxCell* cell = frame->cellOffset ? (WaxCell*)(data + frame->cellOffset) : nullptr;
+					WaxFrame* frame = (WaxFrame*)(data + frameOffset[f]);
+					if (frameOffset[f] && std::find(swappedFrames.begin(), swappedFrames.end(), frameOffset[f]) == swappedFrames.end())
+					{
+						swappedFrames.push_back(frameOffset[f]);
+						frame->offsetX = TFE_Endian::swapLE32(frame->offsetX);
+						frame->offsetY = TFE_Endian::swapLE32(frame->offsetY);
+						frame->flip = TFE_Endian::swapLE32(frame->flip);
+						frame->cellOffset = TFE_Endian::swapLE32(frame->cellOffset);
+						frame->widthWS = TFE_Endian::swapLE32(frame->widthWS);
+						frame->heightWS = TFE_Endian::swapLE32(frame->heightWS);
+					}
+					WaxCell* cell = frame->cellOffset ? (WaxCell*)(data + frame->cellOffset) : nullptr;
+					if (frame->cellOffset && std::find(swappedCells.begin(), swappedCells.end(), frame->cellOffset) == swappedCells.end())
+					{
+						swappedCells.push_back(frame->cellOffset);
+						cell->sizeX = TFE_Endian::swapLE32(cell->sizeX);
+						cell->sizeY = TFE_Endian::swapLE32(cell->sizeY);
+						cell->compressed = TFE_Endian::swapLE32(cell->compressed);
+						cell->dataSize = TFE_Endian::swapLE32(cell->dataSize);
+						cell->columnOffset = TFE_Endian::swapLE32(cell->columnOffset);
+						if (cell->compressed == 1)
+						{
+							u32* columns = (u32*)(data + frame->cellOffset + sizeof(WaxCell));
+							for (s32 c = 0; c < cell->sizeX; c++)
+							{
+								columns[c] = TFE_Endian::swapLE32(columns[c]);
+							}
+						}
+					}
 					if (cell && cell->compressed == 0 && isUniqueCell(frame->cellOffset))
 					{
 						sizeToAlloc += cell->sizeX * sizeof(u32);

--- a/TheForceEngine/TFE_Asset/spriteAsset_Jedi.cpp
+++ b/TheForceEngine/TFE_Asset/spriteAsset_Jedi.cpp
@@ -64,19 +64,19 @@ namespace TFE_Sprite_Jedi
 
 		// Determine ahead of time how much we need to allocate.
 		WaxFrame* base_frame = (WaxFrame*)data;
-		base_frame->offsetX = TFE_Endian::swapLE32(base_frame->offsetX);
-		base_frame->offsetY = TFE_Endian::swapLE32(base_frame->offsetY);
-		base_frame->flip = TFE_Endian::swapLE32(base_frame->flip);
-		base_frame->cellOffset = TFE_Endian::swapLE32(base_frame->cellOffset);
-		base_frame->widthWS = TFE_Endian::swapLE32(base_frame->widthWS);
-		base_frame->heightWS = TFE_Endian::swapLE32(base_frame->heightWS);
+		base_frame->offsetX = TFE_Endian::le32_to_cpu(base_frame->offsetX);
+		base_frame->offsetY = TFE_Endian::le32_to_cpu(base_frame->offsetY);
+		base_frame->flip = TFE_Endian::le32_to_cpu(base_frame->flip);
+		base_frame->cellOffset = TFE_Endian::le32_to_cpu(base_frame->cellOffset);
+		base_frame->widthWS = TFE_Endian::le32_to_cpu(base_frame->widthWS);
+		base_frame->heightWS = TFE_Endian::le32_to_cpu(base_frame->heightWS);
 
 		WaxCell* base_cell = WAX_CellPtr(data, base_frame);
-		base_cell->sizeX = TFE_Endian::swapLE32(base_cell->sizeX);
-		base_cell->sizeY = TFE_Endian::swapLE32(base_cell->sizeY);
-		base_cell->compressed = TFE_Endian::swapLE32(base_cell->compressed);
-		base_cell->dataSize = TFE_Endian::swapLE32(base_cell->dataSize);
-		base_cell->columnOffset = TFE_Endian::swapLE32(base_cell->columnOffset);
+		base_cell->sizeX = TFE_Endian::le32_to_cpu(base_cell->sizeX);
+		base_cell->sizeY = TFE_Endian::le32_to_cpu(base_cell->sizeY);
+		base_cell->compressed = TFE_Endian::le32_to_cpu(base_cell->compressed);
+		base_cell->dataSize = TFE_Endian::le32_to_cpu(base_cell->dataSize);
+		base_cell->columnOffset = TFE_Endian::le32_to_cpu(base_cell->columnOffset);
 		const u32 columnSize = base_cell->sizeX * sizeof(u32);
 
 		// This is a "load in place" format in the original code.
@@ -106,7 +106,7 @@ namespace TFE_Sprite_Jedi
 			u32* columns = (u32*)((u8*)asset + cell->columnOffset);
 			for (s32 c = 0; c < cell->sizeX; c++)
 			{
-				columns[c] = TFE_Endian::swapLE32(columns[c]);
+				columns[c] = TFE_Endian::le32_to_cpu(columns[c]);
 			}
 		}
 		else
@@ -230,16 +230,16 @@ namespace TFE_Sprite_Jedi
 
 		const u8* data = s_buffer.data();
 		Wax* srcWax = (Wax*)data;
-		srcWax->version = TFE_Endian::swapLE32(srcWax->version);
-		srcWax->animCount = TFE_Endian::swapLE32(srcWax->animCount);
-		srcWax->frameCount = TFE_Endian::swapLE32(srcWax->frameCount);
-		srcWax->cellCount = TFE_Endian::swapLE32(srcWax->cellCount);
-		srcWax->xScale = TFE_Endian::swapLE32(srcWax->xScale);
-		srcWax->yScale = TFE_Endian::swapLE32(srcWax->yScale);
-		srcWax->xtraLight = TFE_Endian::swapLE32(srcWax->xtraLight);
+		srcWax->version = TFE_Endian::le32_to_cpu(srcWax->version);
+		srcWax->animCount = TFE_Endian::le32_to_cpu(srcWax->animCount);
+		srcWax->frameCount = TFE_Endian::le32_to_cpu(srcWax->frameCount);
+		srcWax->cellCount = TFE_Endian::le32_to_cpu(srcWax->cellCount);
+		srcWax->xScale = TFE_Endian::le32_to_cpu(srcWax->xScale);
+		srcWax->yScale = TFE_Endian::le32_to_cpu(srcWax->yScale);
+		srcWax->xtraLight = TFE_Endian::le32_to_cpu(srcWax->xtraLight);
 		for (s32 animIdx = 0; animIdx < WAX_MAX_ANIM; animIdx++)
 		{
-			srcWax->animOffsets[animIdx] = TFE_Endian::swapLE32(srcWax->animOffsets[animIdx]);
+			srcWax->animOffsets[animIdx] = TFE_Endian::le32_to_cpu(srcWax->animOffsets[animIdx]);
 		}
 		
 		// every animation is filled out until the end, so no animations = no wax.
@@ -262,13 +262,13 @@ namespace TFE_Sprite_Jedi
 			if (animOffset[animIdx] && std::find(swappedAnims.begin(), swappedAnims.end(), animOffset[animIdx]) == swappedAnims.end())
 			{
 				swappedAnims.push_back(animOffset[animIdx]);
-				anim->worldWidth = TFE_Endian::swapLE32(anim->worldWidth);
-				anim->worldHeight = TFE_Endian::swapLE32(anim->worldHeight);
-				anim->frameRate = TFE_Endian::swapLE32(anim->frameRate);
-				anim->frameCount = TFE_Endian::swapLE32(anim->frameCount);
+				anim->worldWidth = TFE_Endian::le32_to_cpu(anim->worldWidth);
+				anim->worldHeight = TFE_Endian::le32_to_cpu(anim->worldHeight);
+				anim->frameRate = TFE_Endian::le32_to_cpu(anim->frameRate);
+				anim->frameCount = TFE_Endian::le32_to_cpu(anim->frameCount);
 				for (s32 v = 0; v < WAX_MAX_VIEWS; v++)
 				{
-					anim->viewOffsets[v] = TFE_Endian::swapLE32(anim->viewOffsets[v]);
+					anim->viewOffsets[v] = TFE_Endian::le32_to_cpu(anim->viewOffsets[v]);
 				}
 			}
 			const s32* viewOffsets = anim->viewOffsets;
@@ -280,7 +280,7 @@ namespace TFE_Sprite_Jedi
 					swappedViews.push_back(viewOffsets[v]);
 					for (s32 f = 0; f < WAX_MAX_FRAMES; f++)
 					{
-						view->frameOffsets[f] = TFE_Endian::swapLE32(view->frameOffsets[f]);
+						view->frameOffsets[f] = TFE_Endian::le32_to_cpu(view->frameOffsets[f]);
 					}
 				}
 				const s32* frameOffset = view->frameOffsets;
@@ -290,28 +290,28 @@ namespace TFE_Sprite_Jedi
 					if (frameOffset[f] && std::find(swappedFrames.begin(), swappedFrames.end(), frameOffset[f]) == swappedFrames.end())
 					{
 						swappedFrames.push_back(frameOffset[f]);
-						frame->offsetX = TFE_Endian::swapLE32(frame->offsetX);
-						frame->offsetY = TFE_Endian::swapLE32(frame->offsetY);
-						frame->flip = TFE_Endian::swapLE32(frame->flip);
-						frame->cellOffset = TFE_Endian::swapLE32(frame->cellOffset);
-						frame->widthWS = TFE_Endian::swapLE32(frame->widthWS);
-						frame->heightWS = TFE_Endian::swapLE32(frame->heightWS);
+						frame->offsetX = TFE_Endian::le32_to_cpu(frame->offsetX);
+						frame->offsetY = TFE_Endian::le32_to_cpu(frame->offsetY);
+						frame->flip = TFE_Endian::le32_to_cpu(frame->flip);
+						frame->cellOffset = TFE_Endian::le32_to_cpu(frame->cellOffset);
+						frame->widthWS = TFE_Endian::le32_to_cpu(frame->widthWS);
+						frame->heightWS = TFE_Endian::le32_to_cpu(frame->heightWS);
 					}
 					WaxCell* cell = frame->cellOffset ? (WaxCell*)(data + frame->cellOffset) : nullptr;
 					if (frame->cellOffset && std::find(swappedCells.begin(), swappedCells.end(), frame->cellOffset) == swappedCells.end())
 					{
 						swappedCells.push_back(frame->cellOffset);
-						cell->sizeX = TFE_Endian::swapLE32(cell->sizeX);
-						cell->sizeY = TFE_Endian::swapLE32(cell->sizeY);
-						cell->compressed = TFE_Endian::swapLE32(cell->compressed);
-						cell->dataSize = TFE_Endian::swapLE32(cell->dataSize);
-						cell->columnOffset = TFE_Endian::swapLE32(cell->columnOffset);
+						cell->sizeX = TFE_Endian::le32_to_cpu(cell->sizeX);
+						cell->sizeY = TFE_Endian::le32_to_cpu(cell->sizeY);
+						cell->compressed = TFE_Endian::le32_to_cpu(cell->compressed);
+						cell->dataSize = TFE_Endian::le32_to_cpu(cell->dataSize);
+						cell->columnOffset = TFE_Endian::le32_to_cpu(cell->columnOffset);
 						if (cell->compressed == 1)
 						{
 							u32* columns = (u32*)(data + frame->cellOffset + sizeof(WaxCell));
 							for (s32 c = 0; c < cell->sizeX; c++)
 							{
-								columns[c] = TFE_Endian::swapLE32(columns[c]);
+								columns[c] = TFE_Endian::le32_to_cpu(columns[c]);
 							}
 						}
 					}

--- a/TheForceEngine/TFE_DarkForces/GameUI/delt.cpp
+++ b/TheForceEngine/TFE_DarkForces/GameUI/delt.cpp
@@ -2,6 +2,7 @@
 #include <cstring>
 
 #include "delt.h"
+#include <TFE_System/endian.h>
 #include <TFE_Game/igame.h>
 #include <TFE_FileSystem/paths.h>
 #include <TFE_FileSystem/filestream.h>
@@ -93,7 +94,9 @@ namespace TFE_DarkForces
 		file.readBuffer(buffer, (u32)size);
 		file.close();
 
-		const s16 frameCount = *((s16*)buffer);
+		s16 frameCount = *((s16*)buffer);
+		frameCount = TFE_Endian::swapLE16(frameCount);
+		
 		const u8* frames = buffer + 2;
 
 		*outFrames = (DeltFrame*)game_alloc(sizeof(DeltFrame) * frameCount);
@@ -102,6 +105,7 @@ namespace TFE_DarkForces
 		for (s32 i = 0; i < frameCount; i++)
 		{
 			u32 size = *((u32*)frames);
+			size = TFE_Endian::swapLE32(size);
 			frames += 4;
 
 			loadDeltIntoFrame(&outFramePtr[i], frames, size);
@@ -226,6 +230,10 @@ namespace TFE_DarkForces
 	void loadDeltIntoFrame(DeltFrame* frame, const u8* buffer, u32 size)
 	{
 		DeltHeader header = *((DeltHeader*)buffer);
+		header.offsetX = TFE_Endian::swapLE16(header.offsetX);
+		header.offsetY = TFE_Endian::swapLE16(header.offsetY);
+		header.sizeX = TFE_Endian::swapLE16(header.sizeX);
+		header.sizeY = TFE_Endian::swapLE16(header.sizeY);
 		header.sizeX++;
 		header.sizeY++;
 
@@ -255,10 +263,10 @@ namespace TFE_DarkForces
 
 			data += sizeof(DeltLine);
 
-			const s32 startX = line->xStart;
-			const s32 startY = line->yStart;
-			const bool rle = (line->sizeAndType & 1) ? true : false;
-			s32 pixelCount = (line->sizeAndType >> 1) & 0x3FFF;
+			const s32 startX = TFE_Endian::swapLE16(line->xStart);
+			const s32 startY = TFE_Endian::swapLE16(line->yStart);
+			const bool rle = (TFE_Endian::swapLE16(line->sizeAndType) & 1) ? true : false;
+			s32 pixelCount = (TFE_Endian::swapLE16(line->sizeAndType) >> 1) & 0x3FFF;
 
 			u8* image = frame->texture.image + startX + startY * header.sizeX;
 			while (pixelCount > 0)

--- a/TheForceEngine/TFE_DarkForces/GameUI/delt.cpp
+++ b/TheForceEngine/TFE_DarkForces/GameUI/delt.cpp
@@ -95,7 +95,7 @@ namespace TFE_DarkForces
 		file.close();
 
 		s16 frameCount = *((s16*)buffer);
-		frameCount = TFE_Endian::swapLE16(frameCount);
+		frameCount = TFE_Endian::le16_to_cpu(frameCount);
 		
 		const u8* frames = buffer + 2;
 
@@ -105,7 +105,7 @@ namespace TFE_DarkForces
 		for (s32 i = 0; i < frameCount; i++)
 		{
 			u32 size = *((u32*)frames);
-			size = TFE_Endian::swapLE32(size);
+			size = TFE_Endian::le32_to_cpu(size);
 			frames += 4;
 
 			loadDeltIntoFrame(&outFramePtr[i], frames, size);
@@ -230,10 +230,10 @@ namespace TFE_DarkForces
 	void loadDeltIntoFrame(DeltFrame* frame, const u8* buffer, u32 size)
 	{
 		DeltHeader header = *((DeltHeader*)buffer);
-		header.offsetX = TFE_Endian::swapLE16(header.offsetX);
-		header.offsetY = TFE_Endian::swapLE16(header.offsetY);
-		header.sizeX = TFE_Endian::swapLE16(header.sizeX);
-		header.sizeY = TFE_Endian::swapLE16(header.sizeY);
+		header.offsetX = TFE_Endian::le16_to_cpu(header.offsetX);
+		header.offsetY = TFE_Endian::le16_to_cpu(header.offsetY);
+		header.sizeX = TFE_Endian::le16_to_cpu(header.sizeX);
+		header.sizeY = TFE_Endian::le16_to_cpu(header.sizeY);
 		header.sizeX++;
 		header.sizeY++;
 
@@ -263,10 +263,10 @@ namespace TFE_DarkForces
 
 			data += sizeof(DeltLine);
 
-			const s32 startX = TFE_Endian::swapLE16(line->xStart);
-			const s32 startY = TFE_Endian::swapLE16(line->yStart);
-			const bool rle = (TFE_Endian::swapLE16(line->sizeAndType) & 1) ? true : false;
-			s32 pixelCount = (TFE_Endian::swapLE16(line->sizeAndType) >> 1) & 0x3FFF;
+			const s32 startX = TFE_Endian::le16_to_cpu(line->xStart);
+			const s32 startY = TFE_Endian::le16_to_cpu(line->yStart);
+			const bool rle = (TFE_Endian::le16_to_cpu(line->sizeAndType) & 1) ? true : false;
+			s32 pixelCount = (TFE_Endian::le16_to_cpu(line->sizeAndType) >> 1) & 0x3FFF;
 
 			u8* image = frame->texture.image + startX + startY * header.sizeX;
 			while (pixelCount > 0)

--- a/TheForceEngine/TFE_DarkForces/Landru/cutscene_film.cpp
+++ b/TheForceEngine/TFE_DarkForces/Landru/cutscene_film.cpp
@@ -135,7 +135,7 @@ namespace TFE_DarkForces
 		{
 			s32 type;
 			file->read(&type);
-			type = TFE_Endian::swapBE32(type);
+			type = TFE_Endian::be32_to_cpu(type);
 
 			char name[32];
 			file->readBuffer(name, 8);
@@ -147,10 +147,10 @@ namespace TFE_DarkForces
 			file->read(&id);
 			file->read(&chunks);
 			file->read(&used);
-			size = TFE_Endian::swapLE32(size);
-			id = TFE_Endian::swapLE16(id);
-			chunks = TFE_Endian::swapLE16(chunks);
-			used = TFE_Endian::swapLE16(used);
+			size = TFE_Endian::le32_to_cpu(size);
+			id = TFE_Endian::le16_to_cpu(id);
+			chunks = TFE_Endian::le16_to_cpu(chunks);
+			used = TFE_Endian::le16_to_cpu(used);
 
 			// Allocate space for the object.
 			FilmObject* obj = (FilmObject*)landru_alloc(sizeof(FilmObject) + used);
@@ -376,9 +376,9 @@ namespace TFE_DarkForces
 			file.read(&version);
 			file.read(&cellCount);
 			file.read(&arraySize);
-			version = TFE_Endian::swapLE16(version);
-			cellCount = TFE_Endian::swapLE16(cellCount);
-			arraySize = TFE_Endian::swapLE16(arraySize);
+			version = TFE_Endian::le16_to_cpu(version);
+			cellCount = TFE_Endian::le16_to_cpu(cellCount);
+			arraySize = TFE_Endian::le16_to_cpu(arraySize);
 
 			if (version != CF_VERSION)
 			{
@@ -462,7 +462,7 @@ namespace TFE_DarkForces
 	JBool cutsceneFilm_isTimeStamp(Film* film, FilmObject* filmObj, u8* data)
 	{
 		s16* chunk = (s16*)(data + filmObj->offset);
-		if (TFE_Endian::swapLE16(chunk[1]) == CF_CMD_TIMESTAMP && TFE_Endian::swapLE16(chunk[2]) == (s16)film->curCell)
+		if (TFE_Endian::le16_to_cpu(chunk[1]) == CF_CMD_TIMESTAMP && TFE_Endian::le16_to_cpu(chunk[2]) == (s16)film->curCell)
 		{
 			return JTRUE;
 		}
@@ -598,13 +598,13 @@ namespace TFE_DarkForces
 	void cutsceneFilm_stepFilmFrame(FilmObject* filmObj, u8* data)
 	{
 		s16* chunk = (s16*)(data + filmObj->offset);
-		filmObj->offset += TFE_Endian::swapLE16(chunk[0]);
+		filmObj->offset += TFE_Endian::le16_to_cpu(chunk[0]);
 	}
 
 	JBool cutsceneFilm_isNextFrame(FilmObject* filmObj, u8* data)
 	{
 		s16* chunk = (s16*)(data + filmObj->offset);
-		if (TFE_Endian::swapLE16(chunk[1]) == CF_CMD_TIMESTAMP || TFE_Endian::swapLE16(chunk[1]) == CF_CMD_END)
+		if (TFE_Endian::le16_to_cpu(chunk[1]) == CF_CMD_TIMESTAMP || TFE_Endian::le16_to_cpu(chunk[1]) == CF_CMD_END)
 		{
 			return JTRUE;
 		}
@@ -614,55 +614,55 @@ namespace TFE_DarkForces
 	void cutsceneFilm_setActorToFilm(FilmObject* filmObj, u8* data)
 	{
 		s16* chunk = (s16*)(data + filmObj->offset);
-		u32 type = TFE_Endian::swapLE16(chunk[1]);
+		u32 type = TFE_Endian::le16_to_cpu(chunk[1]);
 		LActor* actor = (LActor*)filmObj->data;
 		chunk += 2;
 
 		switch (type)
 		{
 			case CF_CMD_ACTOR_POS:
-				lactor_setPos(actor, TFE_Endian::swapLE16(chunk[0]), TFE_Endian::swapLE16(chunk[1]), TFE_Endian::swapLE16(chunk[2]), TFE_Endian::swapLE16(chunk[3]));
+				lactor_setPos(actor, TFE_Endian::le16_to_cpu(chunk[0]), TFE_Endian::le16_to_cpu(chunk[1]), TFE_Endian::le16_to_cpu(chunk[2]), TFE_Endian::le16_to_cpu(chunk[3]));
 				break;
 
 			case CF_CMD_ACTOR_VEL:
-				lactor_setSpeed(actor, TFE_Endian::swapLE16(chunk[0]), TFE_Endian::swapLE16(chunk[1]), TFE_Endian::swapLE16(chunk[2]), TFE_Endian::swapLE16(chunk[3]));
+				lactor_setSpeed(actor, TFE_Endian::le16_to_cpu(chunk[0]), TFE_Endian::le16_to_cpu(chunk[1]), TFE_Endian::le16_to_cpu(chunk[2]), TFE_Endian::le16_to_cpu(chunk[3]));
 				break;
 
 			case CF_CMD_ACTOR_Z:
-				lactor_setZPlane(actor, TFE_Endian::swapLE16(chunk[0]));
+				lactor_setZPlane(actor, TFE_Endian::le16_to_cpu(chunk[0]));
 				break;
 
 			case CF_CMD_ACTOR_STATE:
-				lactor_setState(actor, TFE_Endian::swapLE16(chunk[0]), TFE_Endian::swapLE16(chunk[1]));
+				lactor_setState(actor, TFE_Endian::le16_to_cpu(chunk[0]), TFE_Endian::le16_to_cpu(chunk[1]));
 				break;
 
 			case CF_CMD_ACTOR_STATEV:
-				lactor_setStateSpeed(actor, TFE_Endian::swapLE16(chunk[0]), TFE_Endian::swapLE16(chunk[1]));
+				lactor_setStateSpeed(actor, TFE_Endian::le16_to_cpu(chunk[0]), TFE_Endian::le16_to_cpu(chunk[1]));
 				break;
 
 			case CF_CMD_ACTOR_VAR1:
-				actor->var1 = TFE_Endian::swapLE16(chunk[0]);
+				actor->var1 = TFE_Endian::le16_to_cpu(chunk[0]);
 				break;
 
 			case CF_CMD_ACTOR_VAR2:
-				actor->var2 = TFE_Endian::swapLE16(chunk[0]);
+				actor->var2 = TFE_Endian::le16_to_cpu(chunk[0]);
 				break;
 
 			case CF_CMD_ACTOR_CLIP:
-				lrect_set(&actor->frame, TFE_Endian::swapLE16(chunk[0]), TFE_Endian::swapLE16(chunk[1]), TFE_Endian::swapLE16(chunk[2]), TFE_Endian::swapLE16(chunk[3]));
+				lrect_set(&actor->frame, TFE_Endian::le16_to_cpu(chunk[0]), TFE_Endian::le16_to_cpu(chunk[1]), TFE_Endian::le16_to_cpu(chunk[2]), TFE_Endian::le16_to_cpu(chunk[3]));
 				break;
 
 			case CF_CMD_ACTOR_CLIPV:
-				lrect_set(&actor->frameVelocity, TFE_Endian::swapLE16(chunk[0]), TFE_Endian::swapLE16(chunk[1]), TFE_Endian::swapLE16(chunk[2]), TFE_Endian::swapLE16(chunk[3]));
+				lrect_set(&actor->frameVelocity, TFE_Endian::le16_to_cpu(chunk[0]), TFE_Endian::le16_to_cpu(chunk[1]), TFE_Endian::le16_to_cpu(chunk[2]), TFE_Endian::le16_to_cpu(chunk[3]));
 				break;
 
 			case CF_CMD_ACTOR_SHOW:
-				if (TFE_Endian::swapLE16(chunk[0])) { lactor_show(actor); }
+				if (TFE_Endian::le16_to_cpu(chunk[0])) { lactor_show(actor); }
 				else { lactor_hide(actor); }
 				break;
 
 			case CF_CMD_ACTOR_FLIP:
-				lactor_setFlip(actor, TFE_Endian::swapLE16(chunk[0]), TFE_Endian::swapLE16(chunk[1]));
+				lactor_setFlip(actor, TFE_Endian::le16_to_cpu(chunk[0]), TFE_Endian::le16_to_cpu(chunk[1]));
 				break;
 		}
 	}
@@ -671,7 +671,7 @@ namespace TFE_DarkForces
 	{
 		s16* chunk = (s16*)(data + filmObj->offset);
 		u8*  byteChunk = (u8*)chunk;
-		u16  type = TFE_Endian::swapLE16(chunk[1]);
+		u16  type = TFE_Endian::le16_to_cpu(chunk[1]);
 
 		switch (type)
 		{
@@ -695,8 +695,8 @@ namespace TFE_DarkForces
 			} break;
 			case CF_CMD_VIEW_FADE:
 			{
-				s16 fade = TFE_Endian::swapLE16(chunk[2]);
-				s16 colorFade = TFE_Endian::swapLE16(chunk[3]);
+				s16 fade = TFE_Endian::le16_to_cpu(chunk[2]);
+				s16 colorFade = TFE_Endian::le16_to_cpu(chunk[3]);
 				cutsceneFilm_setFade(fade, colorFade);
 			} break;
 		}
@@ -705,7 +705,7 @@ namespace TFE_DarkForces
 	void cutsceneFilm_setPaletteToFilm(Film* film, FilmObject* filmObj, u8* data)
 	{
 		s16* chunk = (s16*)(data + filmObj->offset);
-		if (TFE_Endian::swapLE16(chunk[1]) == CF_CMD_PALETTE_SET)
+		if (TFE_Endian::le16_to_cpu(chunk[1]) == CF_CMD_PALETTE_SET)
 		{
 			lpalette_setDstPal((LPalette*)filmObj->data);
 		}
@@ -715,7 +715,7 @@ namespace TFE_DarkForces
 	{
 		LSound* sound = (LSound*)filmObj->data;
 		s16* chunk = (s16*)(data + filmObj->offset);
-		u16  type = TFE_Endian::swapLE16(chunk[1]);
+		u16  type = TFE_Endian::le16_to_cpu(chunk[1]);
 		chunk += 2;
 
 		switch (type)
@@ -737,15 +737,15 @@ namespace TFE_DarkForces
 			} break;
 			case CF_CMD_SOUND_VOLUME:
 			{
-				setSoundVolume(sound, TFE_Endian::swapLE16(chunk[0]));
+				setSoundVolume(sound, TFE_Endian::le16_to_cpu(chunk[0]));
 			} break;
 			case CF_CMD_SOUND_FADE:
 			{
-				setSoundFade(sound, TFE_Endian::swapLE16(chunk[0]), TFE_Endian::swapLE16(chunk[1]));
+				setSoundFade(sound, TFE_Endian::le16_to_cpu(chunk[0]), TFE_Endian::le16_to_cpu(chunk[1]));
 			} break;
 			case CF_CMD_SOUND_VAR1:
 			{
-				sound->var1 = TFE_Endian::swapLE16(chunk[0]);
+				sound->var1 = TFE_Endian::le16_to_cpu(chunk[0]);
 				if (sound->var1 == 1)
 				{
 					setSoundKeep(sound);
@@ -753,11 +753,11 @@ namespace TFE_DarkForces
 			} break;
 			case CF_CMD_SOUND_VAR2:
 			{
-				sound->var2 = TFE_Endian::swapLE16(chunk[0]);
+				sound->var2 = TFE_Endian::le16_to_cpu(chunk[0]);
 			} break;
 			case CF_CMD_SOUND_CMD:
 			{
-				if (TFE_Endian::swapLE16(chunk[0]))
+				if (TFE_Endian::le16_to_cpu(chunk[0]))
 				{
 					if (sound->var2 == 1)
 					{
@@ -769,15 +769,15 @@ namespace TFE_DarkForces
 					}
 				}
 
-				if (TFE_Endian::swapLE16(chunk[1])) { setSoundVolume(sound, TFE_Endian::swapLE16(chunk[1])); }
-				if (TFE_Endian::swapLE16(chunk[2]) || TFE_Endian::swapLE16(chunk[3]))
+				if (TFE_Endian::le16_to_cpu(chunk[1])) { setSoundVolume(sound, TFE_Endian::le16_to_cpu(chunk[1])); }
+				if (TFE_Endian::le16_to_cpu(chunk[2]) || TFE_Endian::le16_to_cpu(chunk[3]))
 				{
-					setSoundFade(sound, TFE_Endian::swapLE16(chunk[2]), TFE_Endian::swapLE16(chunk[3]));
+					setSoundFade(sound, TFE_Endian::le16_to_cpu(chunk[2]), TFE_Endian::le16_to_cpu(chunk[3]));
 				}
 			} break;
 			case CF_CMD_SOUND_CMD2:
 			{
-				if (TFE_Endian::swapLE16(chunk[0]))
+				if (TFE_Endian::le16_to_cpu(chunk[0]))
 				{
 					if (sound->var2 == 1)
 					{
@@ -789,14 +789,14 @@ namespace TFE_DarkForces
 					}
 				}
 
-				if (TFE_Endian::swapLE16(chunk[1])) { setSoundVolume(sound, TFE_Endian::swapLE16(chunk[1])); }
-				if (TFE_Endian::swapLE16(chunk[2]) || TFE_Endian::swapLE16(chunk[3]))
+				if (TFE_Endian::le16_to_cpu(chunk[1])) { setSoundVolume(sound, TFE_Endian::le16_to_cpu(chunk[1])); }
+				if (TFE_Endian::le16_to_cpu(chunk[2]) || TFE_Endian::le16_to_cpu(chunk[3]))
 				{
-					setSoundFade(sound, TFE_Endian::swapLE16(chunk[2]), TFE_Endian::swapLE16(chunk[3]));
+					setSoundFade(sound, TFE_Endian::le16_to_cpu(chunk[2]), TFE_Endian::le16_to_cpu(chunk[3]));
 				}
 
-				if (TFE_Endian::swapLE16(chunk[4])) { setSoundPan(sound, TFE_Endian::swapLE16(chunk[4])); }
-				if (TFE_Endian::swapLE16(chunk[5]) || TFE_Endian::swapLE16(chunk[6])) { setSoundPanFade(sound, TFE_Endian::swapLE16(chunk[5]), TFE_Endian::swapLE16(chunk[6])); }
+				if (TFE_Endian::le16_to_cpu(chunk[4])) { setSoundPan(sound, TFE_Endian::le16_to_cpu(chunk[4])); }
+				if (TFE_Endian::le16_to_cpu(chunk[5]) || TFE_Endian::le16_to_cpu(chunk[6])) { setSoundPanFade(sound, TFE_Endian::le16_to_cpu(chunk[5]), TFE_Endian::le16_to_cpu(chunk[6])); }
 			} break;
 		}
 	}

--- a/TheForceEngine/TFE_DarkForces/Landru/lactorAnim.cpp
+++ b/TheForceEngine/TFE_DarkForces/Landru/lactorAnim.cpp
@@ -42,7 +42,7 @@ namespace TFE_DarkForces
 		s16* data = (s16*)lactor_getArrayData(actor, actor->state);
 		if (data && data[0] != -1 && data[1] != -1)
 		{
-			lrect_set(rect, TFE_Endian::swapLE16(data[0]), TFE_Endian::swapLE16(data[1]), TFE_Endian::swapLE16(data[2]) + 1, TFE_Endian::swapLE16(data[3]) + 1);
+			lrect_set(rect, TFE_Endian::le16_to_cpu(data[0]), TFE_Endian::le16_to_cpu(data[1]), TFE_Endian::le16_to_cpu(data[2]) + 1, TFE_Endian::le16_to_cpu(data[3]) + 1);
 			JBool xFlip, yFlip;
 			lactor_getFlip(actor, &xFlip, &yFlip);
 			lrect_flip(rect, &actor->bounds, xFlip, yFlip);
@@ -90,7 +90,7 @@ namespace TFE_DarkForces
 
 			s16 animCount;
 			file.read(&animCount);
-			animCount = TFE_Endian::swapLE16(animCount); 
+			animCount = TFE_Endian::le16_to_cpu(animCount); 
 			u8** array = (u8**)landru_alloc(sizeof(u8*) * animCount);
 			if (array)
 			{
@@ -98,7 +98,7 @@ namespace TFE_DarkForces
 				{
 					s32 deltaSize;
 					file.read(&deltaSize);
-					deltaSize = TFE_Endian::swapLE32(deltaSize); 
+					deltaSize = TFE_Endian::le32_to_cpu(deltaSize); 
 					if (deltaSize <= 0) { array[i] = nullptr; continue; }
 
 					array[i] = (u8*)landru_alloc(deltaSize);

--- a/TheForceEngine/TFE_DarkForces/Landru/lactorAnim.cpp
+++ b/TheForceEngine/TFE_DarkForces/Landru/lactorAnim.cpp
@@ -4,6 +4,7 @@
 #include "cutscene_film.h"
 #include "lview.h"
 #include "ltimer.h"
+#include <TFE_System/endian.h>
 #include <TFE_Game/igame.h>
 #include <assert.h>
 
@@ -41,7 +42,7 @@ namespace TFE_DarkForces
 		s16* data = (s16*)lactor_getArrayData(actor, actor->state);
 		if (data && data[0] != -1 && data[1] != -1)
 		{
-			lrect_set(rect, data[0], data[1], data[2] + 1, data[3] + 1);
+			lrect_set(rect, TFE_Endian::swapLE16(data[0]), TFE_Endian::swapLE16(data[1]), TFE_Endian::swapLE16(data[2]) + 1, TFE_Endian::swapLE16(data[3]) + 1);
 			JBool xFlip, yFlip;
 			lactor_getFlip(actor, &xFlip, &yFlip);
 			lrect_flip(rect, &actor->bounds, xFlip, yFlip);
@@ -89,6 +90,7 @@ namespace TFE_DarkForces
 
 			s16 animCount;
 			file.read(&animCount);
+			animCount = TFE_Endian::swapLE16(animCount); 
 			u8** array = (u8**)landru_alloc(sizeof(u8*) * animCount);
 			if (array)
 			{
@@ -96,6 +98,7 @@ namespace TFE_DarkForces
 				{
 					s32 deltaSize;
 					file.read(&deltaSize);
+					deltaSize = TFE_Endian::swapLE32(deltaSize); 
 					if (deltaSize <= 0) { array[i] = nullptr; continue; }
 
 					array[i] = (u8*)landru_alloc(deltaSize);

--- a/TheForceEngine/TFE_DarkForces/Landru/lactorDelt.cpp
+++ b/TheForceEngine/TFE_DarkForces/Landru/lactorDelt.cpp
@@ -5,6 +5,7 @@
 #include "lview.h"
 #include "ldraw.h"
 #include "ltimer.h"
+#include <TFE_System/endian.h>
 #include <TFE_Game/igame.h>
 #include <assert.h>
 
@@ -42,7 +43,7 @@ namespace TFE_DarkForces
 		s16* data = (s16*)actor->data;
 		if (data)
 		{
-			lrect_set(rect, data[0], data[1], data[2], data[3]);
+			lrect_set(rect, TFE_Endian::swapLE16(data[0]), TFE_Endian::swapLE16(data[1]), TFE_Endian::swapLE16(data[2]), TFE_Endian::swapLE16(data[3]));
 			JBool hFlip, vFlip;
 			lactor_getFlip(actor, &hFlip, &vFlip);
 			lrect_flip(rect, &actor->bounds, hFlip, JFALSE);
@@ -153,11 +154,11 @@ namespace TFE_DarkForces
 	JBool lactorDelt_drawClipped(u8* data, s16 x, s16 y, JBool dirty)
 	{
 		s16* data16 = (s16*)data;
-		s16 sx = data16[0] + x;
-		s16 sy = data16[1] + y;
+		s16 sx = TFE_Endian::swapLE16(data16[0]) + x;
+		s16 sy = TFE_Endian::swapLE16(data16[1]) + y;
 
-		s16 ex = data16[2] + x;
-		s16 ey = data16[3] + y;
+		s16 ex = TFE_Endian::swapLE16(data16[2]) + x;
+		s16 ey = TFE_Endian::swapLE16(data16[3]) + y;
 		data16 += 4;
 
 		LRect drect;
@@ -197,17 +198,17 @@ namespace TFE_DarkForces
 		s16 ex, ey;
 		if (hFlip)
 		{
-			ex = w - data16[0] + x;
-			sy = data16[1] + y;
-			sx = w - data16[2] + x;
-			ey = data16[3] + y;
+			ex = w - TFE_Endian::swapLE16(data16[0]) + x;
+			sy = TFE_Endian::swapLE16(data16[1]) + y;
+			sx = w - TFE_Endian::swapLE16(data16[2]) + x;
+			ey = TFE_Endian::swapLE16(data16[3]) + y;
 		}
 		else
 		{
-			sx = data16[0] + x;
-			sy = data16[1] + y;
-			ex = data16[2] + x;
-			ey = data16[3] + y;
+			sx = TFE_Endian::swapLE16(data16[0]) + x;
+			sy = TFE_Endian::swapLE16(data16[1]) + y;
+			ex = TFE_Endian::swapLE16(data16[2]) + x;
+			ey = TFE_Endian::swapLE16(data16[3]) + y;
 		}
 		data16 += 4;
 

--- a/TheForceEngine/TFE_DarkForces/Landru/lactorDelt.cpp
+++ b/TheForceEngine/TFE_DarkForces/Landru/lactorDelt.cpp
@@ -43,7 +43,7 @@ namespace TFE_DarkForces
 		s16* data = (s16*)actor->data;
 		if (data)
 		{
-			lrect_set(rect, TFE_Endian::swapLE16(data[0]), TFE_Endian::swapLE16(data[1]), TFE_Endian::swapLE16(data[2]), TFE_Endian::swapLE16(data[3]));
+			lrect_set(rect, TFE_Endian::le16_to_cpu(data[0]), TFE_Endian::le16_to_cpu(data[1]), TFE_Endian::le16_to_cpu(data[2]), TFE_Endian::le16_to_cpu(data[3]));
 			JBool hFlip, vFlip;
 			lactor_getFlip(actor, &hFlip, &vFlip);
 			lrect_flip(rect, &actor->bounds, hFlip, JFALSE);
@@ -154,11 +154,11 @@ namespace TFE_DarkForces
 	JBool lactorDelt_drawClipped(u8* data, s16 x, s16 y, JBool dirty)
 	{
 		s16* data16 = (s16*)data;
-		s16 sx = TFE_Endian::swapLE16(data16[0]) + x;
-		s16 sy = TFE_Endian::swapLE16(data16[1]) + y;
+		s16 sx = TFE_Endian::le16_to_cpu(data16[0]) + x;
+		s16 sy = TFE_Endian::le16_to_cpu(data16[1]) + y;
 
-		s16 ex = TFE_Endian::swapLE16(data16[2]) + x;
-		s16 ey = TFE_Endian::swapLE16(data16[3]) + y;
+		s16 ex = TFE_Endian::le16_to_cpu(data16[2]) + x;
+		s16 ey = TFE_Endian::le16_to_cpu(data16[3]) + y;
 		data16 += 4;
 
 		LRect drect;
@@ -198,17 +198,17 @@ namespace TFE_DarkForces
 		s16 ex, ey;
 		if (hFlip)
 		{
-			ex = w - TFE_Endian::swapLE16(data16[0]) + x;
-			sy = TFE_Endian::swapLE16(data16[1]) + y;
-			sx = w - TFE_Endian::swapLE16(data16[2]) + x;
-			ey = TFE_Endian::swapLE16(data16[3]) + y;
+			ex = w - TFE_Endian::le16_to_cpu(data16[0]) + x;
+			sy = TFE_Endian::le16_to_cpu(data16[1]) + y;
+			sx = w - TFE_Endian::le16_to_cpu(data16[2]) + x;
+			ey = TFE_Endian::le16_to_cpu(data16[3]) + y;
 		}
 		else
 		{
-			sx = TFE_Endian::swapLE16(data16[0]) + x;
-			sy = TFE_Endian::swapLE16(data16[1]) + y;
-			ex = TFE_Endian::swapLE16(data16[2]) + x;
-			ey = TFE_Endian::swapLE16(data16[3]) + y;
+			sx = TFE_Endian::le16_to_cpu(data16[0]) + x;
+			sy = TFE_Endian::le16_to_cpu(data16[1]) + y;
+			ex = TFE_Endian::le16_to_cpu(data16[2]) + x;
+			ey = TFE_Endian::le16_to_cpu(data16[3]) + y;
 		}
 		data16 += 4;
 

--- a/TheForceEngine/TFE_DarkForces/Landru/ldraw.cpp
+++ b/TheForceEngine/TFE_DarkForces/Landru/ldraw.cpp
@@ -2,6 +2,7 @@
 #include "lcanvas.h"
 #include "lsystem.h"
 #include <TFE_Game/igame.h>
+#include <TFE_System/endian.h>
 #include <TFE_Jedi/Math/core_math.h>
 #include <TFE_Jedi/Renderer/virtualFramebuffer.h>
 #include <cassert>
@@ -75,14 +76,14 @@ namespace TFE_DarkForces
 		while (1)
 		{
 			const s16* deltaLine = (s16*)srcImage;
-			s16 sizeAndType = deltaLine[0];
+			s16 sizeAndType = TFE_Endian::swapLE16(deltaLine[0]);
 			if (sizeAndType == 0)
 			{
 				break;
 			}
 
-			s16 xStart = deltaLine[1] + x;
-			s16 yStart = deltaLine[2] + y;
+			s16 xStart = TFE_Endian::swapLE16(deltaLine[1]) + x;
+			s16 yStart = TFE_Endian::swapLE16(deltaLine[2]) + y;
 			// Size of the Delta Line structure.
 			srcImage += sizeof(s16) * 3;
 
@@ -169,9 +170,9 @@ namespace TFE_DarkForces
 		while (1)
 		{
 			const s16* deltaLine = (s16*)srcImage;
-			s16 sizeAndType = deltaLine[0];
-			s16 xStart = deltaLine[1] + x;
-			s16 yStart = deltaLine[2] + y;
+			s16 sizeAndType = TFE_Endian::swapLE16(deltaLine[0]);
+			s16 xStart = TFE_Endian::swapLE16(deltaLine[1]) + x;
+			s16 yStart = TFE_Endian::swapLE16(deltaLine[2]) + y;
 			srcImage += 3 * sizeof(s16);
 
 			if (sizeAndType == 0) { break; }
@@ -240,14 +241,14 @@ namespace TFE_DarkForces
 		while (1)
 		{
 			const s16* deltaLine = (s16*)srcImage;
-			s16 sizeAndType = deltaLine[0];
+			s16 sizeAndType = TFE_Endian::swapLE16(deltaLine[0]);
 			if (sizeAndType == 0)
 			{
 				break;
 			}
 
-			s16 xCur = w - deltaLine[1] + x;
-			s16 yStart = deltaLine[2] + y;
+			s16 xCur = w - TFE_Endian::swapLE16(deltaLine[1]) + x;
+			s16 yStart = TFE_Endian::swapLE16(deltaLine[2]) + y;
 			// Size of the Delta Line structure.
 			srcImage += sizeof(s16) * 3;
 
@@ -305,9 +306,9 @@ namespace TFE_DarkForces
 		while (1)
 		{
 			const s16* deltaLine = (s16*)srcImage;
-			s16 sizeAndType = deltaLine[0];
-			s16 xStart = deltaLine[1] + x;
-			s16 yStart = deltaLine[2] + y;
+			s16 sizeAndType = TFE_Endian::swapLE16(deltaLine[0]);
+			s16 xStart = TFE_Endian::swapLE16(deltaLine[1]) + x;
+			s16 yStart = TFE_Endian::swapLE16(deltaLine[2]) + y;
 			srcImage += 3 * sizeof(s16);
 
 			if (sizeAndType == 0) { break; }
@@ -316,7 +317,7 @@ namespace TFE_DarkForces
 			s32 pixelCount = (sizeAndType >> 1) & 0x3fff;
 			u8* dstImage = &framebuffer[yStart*stride];
 
-			s16 xCur = w - deltaLine[1] + x;
+			s16 xCur = w - TFE_Endian::swapLE16(deltaLine[1]) + x;
 			s16 yCur = yStart;
 			JBool writeRow = (yCur >= clipRect.top && yCur < clipRect.bottom) ? JTRUE : JFALSE;
 

--- a/TheForceEngine/TFE_DarkForces/Landru/ldraw.cpp
+++ b/TheForceEngine/TFE_DarkForces/Landru/ldraw.cpp
@@ -76,14 +76,14 @@ namespace TFE_DarkForces
 		while (1)
 		{
 			const s16* deltaLine = (s16*)srcImage;
-			s16 sizeAndType = TFE_Endian::swapLE16(deltaLine[0]);
+			s16 sizeAndType = TFE_Endian::le16_to_cpu(deltaLine[0]);
 			if (sizeAndType == 0)
 			{
 				break;
 			}
 
-			s16 xStart = TFE_Endian::swapLE16(deltaLine[1]) + x;
-			s16 yStart = TFE_Endian::swapLE16(deltaLine[2]) + y;
+			s16 xStart = TFE_Endian::le16_to_cpu(deltaLine[1]) + x;
+			s16 yStart = TFE_Endian::le16_to_cpu(deltaLine[2]) + y;
 			// Size of the Delta Line structure.
 			srcImage += sizeof(s16) * 3;
 
@@ -170,9 +170,9 @@ namespace TFE_DarkForces
 		while (1)
 		{
 			const s16* deltaLine = (s16*)srcImage;
-			s16 sizeAndType = TFE_Endian::swapLE16(deltaLine[0]);
-			s16 xStart = TFE_Endian::swapLE16(deltaLine[1]) + x;
-			s16 yStart = TFE_Endian::swapLE16(deltaLine[2]) + y;
+			s16 sizeAndType = TFE_Endian::le16_to_cpu(deltaLine[0]);
+			s16 xStart = TFE_Endian::le16_to_cpu(deltaLine[1]) + x;
+			s16 yStart = TFE_Endian::le16_to_cpu(deltaLine[2]) + y;
 			srcImage += 3 * sizeof(s16);
 
 			if (sizeAndType == 0) { break; }
@@ -241,14 +241,14 @@ namespace TFE_DarkForces
 		while (1)
 		{
 			const s16* deltaLine = (s16*)srcImage;
-			s16 sizeAndType = TFE_Endian::swapLE16(deltaLine[0]);
+			s16 sizeAndType = TFE_Endian::le16_to_cpu(deltaLine[0]);
 			if (sizeAndType == 0)
 			{
 				break;
 			}
 
-			s16 xCur = w - TFE_Endian::swapLE16(deltaLine[1]) + x;
-			s16 yStart = TFE_Endian::swapLE16(deltaLine[2]) + y;
+			s16 xCur = w - TFE_Endian::le16_to_cpu(deltaLine[1]) + x;
+			s16 yStart = TFE_Endian::le16_to_cpu(deltaLine[2]) + y;
 			// Size of the Delta Line structure.
 			srcImage += sizeof(s16) * 3;
 
@@ -306,9 +306,9 @@ namespace TFE_DarkForces
 		while (1)
 		{
 			const s16* deltaLine = (s16*)srcImage;
-			s16 sizeAndType = TFE_Endian::swapLE16(deltaLine[0]);
-			s16 xStart = TFE_Endian::swapLE16(deltaLine[1]) + x;
-			s16 yStart = TFE_Endian::swapLE16(deltaLine[2]) + y;
+			s16 sizeAndType = TFE_Endian::le16_to_cpu(deltaLine[0]);
+			s16 xStart = TFE_Endian::le16_to_cpu(deltaLine[1]) + x;
+			s16 yStart = TFE_Endian::le16_to_cpu(deltaLine[2]) + y;
 			srcImage += 3 * sizeof(s16);
 
 			if (sizeAndType == 0) { break; }
@@ -317,7 +317,7 @@ namespace TFE_DarkForces
 			s32 pixelCount = (sizeAndType >> 1) & 0x3fff;
 			u8* dstImage = &framebuffer[yStart*stride];
 
-			s16 xCur = w - TFE_Endian::swapLE16(deltaLine[1]) + x;
+			s16 xCur = w - TFE_Endian::le16_to_cpu(deltaLine[1]) + x;
 			s16 yCur = yStart;
 			JBool writeRow = (yCur >= clipRect.top && yCur < clipRect.bottom) ? JTRUE : JFALSE;
 

--- a/TheForceEngine/TFE_DarkForces/Landru/lfont.cpp
+++ b/TheForceEngine/TFE_DarkForces/Landru/lfont.cpp
@@ -161,10 +161,10 @@ namespace TFE_DarkForces
 		file.read(&font->numChars);
 		file.read(&font->width);
 		file.read(&font->height);
-		font->firstChar = TFE_Endian::swapLE16(font->firstChar);
-		font->numChars = TFE_Endian::swapLE16(font->numChars);
-		font->width = TFE_Endian::swapLE16(font->width);
-		font->height = TFE_Endian::swapLE16(font->height);
+		font->firstChar = TFE_Endian::le16_to_cpu(font->firstChar);
+		font->numChars = TFE_Endian::le16_to_cpu(font->numChars);
+		font->width = TFE_Endian::le16_to_cpu(font->width);
+		font->height = TFE_Endian::le16_to_cpu(font->height);
 		font->charSize = (font->width >> 3) * font->height;
 
 		if (font->height > MAX_FONT_HEIGHT)
@@ -176,8 +176,8 @@ namespace TFE_DarkForces
 
 		file.read(&font->baseline);
 		file.read(&font->isColor);
-		font->baseline = TFE_Endian::swapLE16(font->baseline);
-		font->isColor = TFE_Endian::swapLE16(font->isColor);
+		font->baseline = TFE_Endian::le16_to_cpu(font->baseline);
+		font->isColor = TFE_Endian::le16_to_cpu(font->isColor);
 		
 		font->widthArray = (u8*)landru_alloc(256);
 		memset(font->widthArray, 0, 256);

--- a/TheForceEngine/TFE_DarkForces/Landru/lfont.cpp
+++ b/TheForceEngine/TFE_DarkForces/Landru/lfont.cpp
@@ -4,6 +4,7 @@
 #include "lpalette.h"
 #include "lsystem.h"
 #include "ltimer.h"
+#include <TFE_System/endian.h>
 #include <TFE_Game/igame.h>
 #include <TFE_Jedi/Math/core_math.h>
 #include <TFE_Jedi/Renderer/virtualFramebuffer.h>
@@ -160,6 +161,10 @@ namespace TFE_DarkForces
 		file.read(&font->numChars);
 		file.read(&font->width);
 		file.read(&font->height);
+		font->firstChar = TFE_Endian::swapLE16(font->firstChar);
+		font->numChars = TFE_Endian::swapLE16(font->numChars);
+		font->width = TFE_Endian::swapLE16(font->width);
+		font->height = TFE_Endian::swapLE16(font->height);
 		font->charSize = (font->width >> 3) * font->height;
 
 		if (font->height > MAX_FONT_HEIGHT)
@@ -171,6 +176,8 @@ namespace TFE_DarkForces
 
 		file.read(&font->baseline);
 		file.read(&font->isColor);
+		font->baseline = TFE_Endian::swapLE16(font->baseline);
+		font->isColor = TFE_Endian::swapLE16(font->isColor);
 		
 		font->widthArray = (u8*)landru_alloc(256);
 		memset(font->widthArray, 0, 256);

--- a/TheForceEngine/TFE_DarkForces/agent.cpp
+++ b/TheForceEngine/TFE_DarkForces/agent.cpp
@@ -451,11 +451,11 @@ namespace TFE_DarkForces
 		{
 			return JFALSE;
 		}
-		saveData->agentData.selectedMission = TFE_Endian::le32_to_cpu(saveData->agentData.selectedMission);
-		saveData->agentData.nextMission = TFE_Endian::le32_to_cpu(saveData->agentData.nextMission);
+		saveData->agentData.selectedMission = TFE_Endian::cpu_to_le32(saveData->agentData.selectedMission);
+		saveData->agentData.nextMission = TFE_Endian::cpu_to_le32(saveData->agentData.nextMission);
 		for (s32 i = 0; i < 140; i++)
 		{
-			saveData->ammo[i] = TFE_Endian::le32_to_cpu(saveData->ammo[i]);
+			saveData->ammo[i] = TFE_Endian::cpu_to_le32(saveData->ammo[i]);
 		}
 		file->writeBuffer(saveData, sizeof(LevelSaveData));
 		return JTRUE;

--- a/TheForceEngine/TFE_DarkForces/agent.cpp
+++ b/TheForceEngine/TFE_DarkForces/agent.cpp
@@ -435,11 +435,11 @@ namespace TFE_DarkForces
 		{
 			return JFALSE;
 		}
-		saveData->agentData.selectedMission = TFE_Endian::swapLE32(saveData->agentData.selectedMission);
-		saveData->agentData.nextMission = TFE_Endian::swapLE32(saveData->agentData.nextMission);
+		saveData->agentData.selectedMission = TFE_Endian::le32_to_cpu(saveData->agentData.selectedMission);
+		saveData->agentData.nextMission = TFE_Endian::le32_to_cpu(saveData->agentData.nextMission);
 		for (s32 i = 0; i < 140; i++)
 		{
-			saveData->ammo[i] = TFE_Endian::swapLE32(saveData->ammo[i]);
+			saveData->ammo[i] = TFE_Endian::le32_to_cpu(saveData->ammo[i]);
 		}
 		return JTRUE;
 	}
@@ -451,11 +451,11 @@ namespace TFE_DarkForces
 		{
 			return JFALSE;
 		}
-		saveData->agentData.selectedMission = TFE_Endian::swapLE32(saveData->agentData.selectedMission);
-		saveData->agentData.nextMission = TFE_Endian::swapLE32(saveData->agentData.nextMission);
+		saveData->agentData.selectedMission = TFE_Endian::le32_to_cpu(saveData->agentData.selectedMission);
+		saveData->agentData.nextMission = TFE_Endian::le32_to_cpu(saveData->agentData.nextMission);
 		for (s32 i = 0; i < 140; i++)
 		{
-			saveData->ammo[i] = TFE_Endian::swapLE32(saveData->ammo[i]);
+			saveData->ammo[i] = TFE_Endian::le32_to_cpu(saveData->ammo[i]);
 		}
 		file->writeBuffer(saveData, sizeof(LevelSaveData));
 		return JTRUE;

--- a/TheForceEngine/TFE_DarkForces/agent.cpp
+++ b/TheForceEngine/TFE_DarkForces/agent.cpp
@@ -10,6 +10,7 @@
 #include <TFE_FileSystem/paths.h>
 #include <TFE_System/system.h>
 #include <TFE_System/parser.h>
+#include <TFE_System/endian.h>
 #include <TFE_Jedi/Serialization/serialization.h>
 #include <assert.h>
 
@@ -434,15 +435,27 @@ namespace TFE_DarkForces
 		{
 			return JFALSE;
 		}
+		saveData->agentData.selectedMission = TFE_Endian::swapLE32(saveData->agentData.selectedMission);
+		saveData->agentData.nextMission = TFE_Endian::swapLE32(saveData->agentData.nextMission);
+		for (s32 i = 0; i < 140; i++)
+		{
+			saveData->ammo[i] = TFE_Endian::swapLE32(saveData->ammo[i]);
+		}
 		return JTRUE;
 	}
 
-	JBool agent_writeAgentConfigData(FileStream* file, s32 agentId, const LevelSaveData* saveData)
+	JBool agent_writeAgentConfigData(FileStream* file, s32 agentId, LevelSaveData* saveData)
 	{
 		s32 fileOffset = agentId*sizeof(LevelSaveData) + s_headerSize;
 		if (!file->seek(fileOffset))
 		{
 			return JFALSE;
+		}
+		saveData->agentData.selectedMission = TFE_Endian::swapLE32(saveData->agentData.selectedMission);
+		saveData->agentData.nextMission = TFE_Endian::swapLE32(saveData->agentData.nextMission);
+		for (s32 i = 0; i < 140; i++)
+		{
+			saveData->ammo[i] = TFE_Endian::swapLE32(saveData->ammo[i]);
 		}
 		file->writeBuffer(saveData, sizeof(LevelSaveData));
 		return JTRUE;

--- a/TheForceEngine/TFE_DarkForces/agent.h
+++ b/TheForceEngine/TFE_DarkForces/agent.h
@@ -54,7 +54,7 @@ namespace TFE_DarkForces
 	void  agent_levelEndTask();
 
 	JBool agent_readConfigData(FileStream* file, s32 agentId, LevelSaveData* saveData);
-	JBool agent_writeAgentConfigData(FileStream* file, s32 agentId, const LevelSaveData* saveData);
+	JBool agent_writeAgentConfigData(FileStream* file, s32 agentId, LevelSaveData* saveData);
 	void  agent_readSavedDataForLevel(s32 agentId, s32 levelIndex);
 	void  agent_saveLevelCompletion(u8 diff, s32 levelIndex);
 	s32   agent_saveInventory(s32 agentId, s32 nextLevel);

--- a/TheForceEngine/TFE_Jedi/Level/rtexture.cpp
+++ b/TheForceEngine/TFE_Jedi/Level/rtexture.cpp
@@ -61,21 +61,21 @@ namespace TFE_Jedi
 	{
 		s16 res = *((s16*)data);
 		data += 2;
-		return TFE_Endian::swapLE16(res);
+		return TFE_Endian::le16_to_cpu(res);
 	}
 
 	u16 readUShort(const u8*& data)
 	{
 		u16 res = *((u16*)data);
 		data += 2;
-		return TFE_Endian::swapLE16(res);
+		return TFE_Endian::le16_to_cpu(res);
 	}
 
 	s32 readInt(const u8*& data)
 	{
 		s32 res = *((s32*)data);
 		data += 4;
-		return TFE_Endian::swapLE32(res);
+		return TFE_Endian::le32_to_cpu(res);
 	}
 
 	void bitmap_setupAnimationTask()
@@ -281,7 +281,7 @@ namespace TFE_Jedi
 					u8* dst = texture->image;
 					for (s32 i = 0; i < texture->width; i++, dst += texture->height)
 					{
-						const u8* src = &inBuffer[TFE_Endian::swapLE32(columns[i])];
+						const u8* src = &inBuffer[TFE_Endian::le32_to_cpu(columns[i])];
 						decompressColumn_Type1(src, dst, texture->height);
 					}
 				}
@@ -290,7 +290,7 @@ namespace TFE_Jedi
 					u8* dst = texture->image;
 					for (s32 i = 0; i < texture->width; i++, dst += texture->height)
 					{
-						const u8* src = &inBuffer[TFE_Endian::swapLE32(columns[i])];
+						const u8* src = &inBuffer[TFE_Endian::le32_to_cpu(columns[i])];
 						decompressColumn_Type2(src, dst, texture->height);
 					}
 				}
@@ -482,12 +482,12 @@ namespace TFE_Jedi
 		const u8* base = tex->image + 2;
 		for (s32 i = 0; i < anim->count; i++)
 		{
-			const TextureData* frame = (TextureData*)(base + TFE_Endian::swapLE32(textureOffsets[i]));
+			const TextureData* frame = (TextureData*)(base + TFE_Endian::le32_to_cpu(textureOffsets[i]));
 			outFrames[i] = *frame;
-			outFrames[i].width = TFE_Endian::swapLE16(outFrames[i].width);
-			outFrames[i].height = TFE_Endian::swapLE16(outFrames[i].height);
-			outFrames[i].uvWidth = TFE_Endian::swapLE16(outFrames[i].uvWidth);
-			outFrames[i].uvHeight = TFE_Endian::swapLE16(outFrames[i].uvHeight);
+			outFrames[i].width = TFE_Endian::le16_to_cpu(outFrames[i].width);
+			outFrames[i].height = TFE_Endian::le16_to_cpu(outFrames[i].height);
+			outFrames[i].uvWidth = TFE_Endian::le16_to_cpu(outFrames[i].uvWidth);
+			outFrames[i].uvHeight = TFE_Endian::le16_to_cpu(outFrames[i].uvHeight);
 			
 			// Somehow this doesn't crash in DOS...
 			if (outFrames[i].width >= 16384 || outFrames[i].height >= 16384)

--- a/TheForceEngine/TFE_Jedi/Level/rtexture.cpp
+++ b/TheForceEngine/TFE_Jedi/Level/rtexture.cpp
@@ -3,6 +3,7 @@
 #include "rtexture.h"
 #include <TFE_Game/igame.h>
 #include <TFE_System/system.h>
+#include <TFE_System/endian.h>
 #include <TFE_Archive/archive.h>
 #include <TFE_Asset/assetSystem.h>
 #include <TFE_FileSystem/paths.h>
@@ -60,21 +61,21 @@ namespace TFE_Jedi
 	{
 		s16 res = *((s16*)data);
 		data += 2;
-		return res;
+		return TFE_Endian::swapLE16(res);
 	}
 
 	u16 readUShort(const u8*& data)
 	{
 		u16 res = *((u16*)data);
 		data += 2;
-		return res;
+		return TFE_Endian::swapLE16(res);
 	}
 
 	s32 readInt(const u8*& data)
 	{
 		s32 res = *((s32*)data);
 		data += 4;
-		return res;
+		return TFE_Endian::swapLE32(res);
 	}
 
 	void bitmap_setupAnimationTask()
@@ -280,7 +281,7 @@ namespace TFE_Jedi
 					u8* dst = texture->image;
 					for (s32 i = 0; i < texture->width; i++, dst += texture->height)
 					{
-						const u8* src = &inBuffer[columns[i]];
+						const u8* src = &inBuffer[TFE_Endian::swapLE32(columns[i])];
 						decompressColumn_Type1(src, dst, texture->height);
 					}
 				}
@@ -289,7 +290,7 @@ namespace TFE_Jedi
 					u8* dst = texture->image;
 					for (s32 i = 0; i < texture->width; i++, dst += texture->height)
 					{
-						const u8* src = &inBuffer[columns[i]];
+						const u8* src = &inBuffer[TFE_Endian::swapLE32(columns[i])];
 						decompressColumn_Type2(src, dst, texture->height);
 					}
 				}
@@ -481,11 +482,15 @@ namespace TFE_Jedi
 		const u8* base = tex->image + 2;
 		for (s32 i = 0; i < anim->count; i++)
 		{
-			const TextureData* frame = (TextureData*)(base + textureOffsets[i]);
+			const TextureData* frame = (TextureData*)(base + TFE_Endian::swapLE32(textureOffsets[i]));
 			outFrames[i] = *frame;
-
+			outFrames[i].width = TFE_Endian::swapLE16(outFrames[i].width);
+			outFrames[i].height = TFE_Endian::swapLE16(outFrames[i].height);
+			outFrames[i].uvWidth = TFE_Endian::swapLE16(outFrames[i].uvWidth);
+			outFrames[i].uvHeight = TFE_Endian::swapLE16(outFrames[i].uvHeight);
+			
 			// Somehow this doesn't crash in DOS...
-			if (frame->width >= 16384 || frame->height >= 16384)
+			if (outFrames[i].width >= 16384 || outFrames[i].height >= 16384)
 			{
 				outFrames[i] = outFrames[0];
 			}

--- a/TheForceEngine/TFE_System/endian.h
+++ b/TheForceEngine/TFE_System/endian.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "types.h"
+#include <SDL_endian.h>
+
+namespace TFE_Endian
+{
+	inline u16 swapLE16(u16 x)
+	{
+		return SDL_SwapLE16(x);
+	}
+
+	inline u32 swapLE32(u32 x)
+	{
+		return SDL_SwapLE32(x);
+	}
+
+	inline u64 swap64LE(u64 x)
+	{
+		return SDL_SwapLE64(x);
+	}
+
+	inline f32 swapFloatLE(f32 x)
+	{
+		return SDL_SwapFloatLE(x);
+	}
+
+	inline u16 swapBE16(u16 x)
+	{
+		return SDL_SwapBE16(x);
+	}
+
+	inline u32 swapBE32(u32 x)
+	{
+		return SDL_SwapBE32(x);
+	}
+
+	inline u64 swap64BE(u64 x)
+	{
+		return SDL_SwapBE64(x);
+	}
+
+	inline f32 swapFloatBE(f32 x)
+	{
+		return SDL_SwapFloatBE(x);
+	}
+}

--- a/TheForceEngine/TFE_System/endian.h
+++ b/TheForceEngine/TFE_System/endian.h
@@ -5,42 +5,42 @@
 
 namespace TFE_Endian
 {
-	inline u16 swapLE16(u16 x)
+	inline u16 le16_to_cpu(u16 x)
 	{
 		return SDL_SwapLE16(x);
 	}
 
-	inline u32 swapLE32(u32 x)
+	inline u32 le32_to_cpu(u32 x)
 	{
 		return SDL_SwapLE32(x);
 	}
 
-	inline u64 swap64LE(u64 x)
+	inline u64 le64_to_cpu(u64 x)
 	{
 		return SDL_SwapLE64(x);
 	}
 
-	inline f32 swapFloatLE(f32 x)
+	inline f32 lef32_to_cpu(f32 x)
 	{
 		return SDL_SwapFloatLE(x);
 	}
 
-	inline u16 swapBE16(u16 x)
+	inline u16 be16_to_cpu(u16 x)
 	{
 		return SDL_SwapBE16(x);
 	}
 
-	inline u32 swapBE32(u32 x)
+	inline u32 be32_to_cpu(u32 x)
 	{
 		return SDL_SwapBE32(x);
 	}
 
-	inline u64 swap64BE(u64 x)
+	inline u64 be64_to_cpu(u64 x)
 	{
 		return SDL_SwapBE64(x);
 	}
 
-	inline f32 swapFloatBE(f32 x)
+	inline f32 bef32_to_cpu(f32 x)
 	{
 		return SDL_SwapFloatBE(x);
 	}

--- a/TheForceEngine/TFE_System/endian.h
+++ b/TheForceEngine/TFE_System/endian.h
@@ -15,6 +15,11 @@ namespace TFE_Endian
 		return SDL_SwapLE32(x);
 	}
 
+	inline u32 cpu_to_le32(u32 x)
+	{
+		return SDL_SwapLE32(x);
+	}
+
 	inline u64 le64_to_cpu(u64 x)
 	{
 		return SDL_SwapLE64(x);


### PR DESCRIPTION
I started working on porting TFE to big endian systems. I focused mostly on loading the original game data, editor-only features were not tested. This should allow TFE to run on various alternate systems, like PS3, XB360, Wii, WiiU, Amiga and its derivatives.
To avoid reinventing the wheel I wrapped SDL_endian.h in a header (TFE_System/endian.h), so it can be replaced with custom implementations if necessary. 