### PR TITLE
Add setting to optionally fix DF `targetOffset` AI bug

### DIFF
--- a/TheForceEngine/TFE_DarkForces/Actor/actor.cpp
+++ b/TheForceEngine/TFE_DarkForces/Actor/actor.cpp
@@ -29,6 +29,7 @@
 #include <TFE_Jedi/Memory/list.h>
 #include <TFE_Jedi/Memory/allocator.h>
 #include <TFE_Jedi/Serialization/serialization.h>
+#include <TFE_Settings/settings.h>
 
 using namespace TFE_Jedi;
 
@@ -1201,11 +1202,20 @@ namespace TFE_DarkForces
 			fixed16_16 targetOffset;
 			if (!actorLogic_isStopFlagSet())
 			{
-				// Offset the target by |dx| / 4
-				// This is obviously a typo and bug in the DOS code and should be min(|dx|, |dz|)
-				// but the original code is min(|dx|, |dx|) => |dx|
 				fixed16_16 dx = TFE_Jedi::abs(s_playerObject->posWS.x - obj->posWS.x);
-				targetOffset = dx >> 2;
+				if (!TFE_Settings::getGameSettings()->df_fixTargetOffsetBug) {
+					// Offset the target by |dx| / 4
+					// This is obviously a typo and bug in the DOS code and should be min(|dx|, |dz|)
+					// but the original code is min(|dx|, |dx|) => |dx|
+					targetOffset = dx >> 2;
+				}
+				else
+				{
+					//optional fix to apply the originally intended logic. this has a subtle effect on 
+					// AI movement patterns, usually not affecting a path by more than a few degrees
+					fixed16_16 dz = TFE_Jedi::abs(s_playerObject->posWS.z - obj->posWS.z);
+					targetOffset = TFE_Jedi::min(dx, dz) >> 2;
+				}
 			}
 			else
 			{

--- a/TheForceEngine/TFE_DarkForces/Actor/phaseThree.cpp
+++ b/TheForceEngine/TFE_DarkForces/Actor/phaseThree.cpp
@@ -19,6 +19,7 @@
 #include <TFE_Jedi/Memory/list.h>
 #include <TFE_Jedi/Memory/allocator.h>
 #include <TFE_Jedi/Serialization/serialization.h>
+#include <TFE_Settings/settings.h>
 
 namespace TFE_DarkForces
 {
@@ -812,9 +813,19 @@ namespace TFE_DarkForces
 					targetX = s_eyePos.x;
 					targetZ = s_eyePos.z;
 				}
-				// This is a copy-paste bug in the original code, it really should be the min of dx and dz.
+				
 				fixed16_16 dx = TFE_Jedi::abs(s_playerObject->posWS.x - local(obj)->posWS.x);
-				fixed16_16 offset = dx >> 2;
+				fixed16_16 offset;
+				if (!TFE_Settings::getGameSettings()->df_fixTargetOffsetBug)
+				{
+					// This is a copy-paste bug in the original code, it really should be the min of dx and dz.
+					offset = dx >> 2;
+				}
+				else
+				{
+					fixed16_16 dz = TFE_Jedi::abs(s_playerObject->posWS.z - local(obj)->posWS.z);
+					offset = TFE_Jedi::min(dx, dz) >> 2;
+				}
 				angle14_32 angle = vec2ToAngle(local(obj)->posWS.x - targetX, local(obj)->posWS.z - targetZ);
 
 				local(target)->pos.x = targetX;

--- a/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
+++ b/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
@@ -1115,6 +1115,12 @@ namespace TFE_FrontEndUI
 		{
 			gameSettings->df_bobaFettFacePlayer = bobaFettFacePlayer;
 		}
+		
+		bool fixTargetOffsetBug = gameSettings->df_fixTargetOffsetBug;
+		if (ImGui::Checkbox("Fix target offset bug", &fixTargetOffsetBug))
+		{
+			gameSettings->df_fixTargetOffsetBug = fixTargetOffsetBug;
+		}
 
 		bool ignoreInfLimit = gameSettings->df_ignoreInfLimit;
 		if (ImGui::Checkbox("Remove INF Item Limit (requires restart)", &ignoreInfLimit))

--- a/TheForceEngine/TFE_Settings/settings.cpp
+++ b/TheForceEngine/TFE_Settings/settings.cpp
@@ -431,6 +431,7 @@ namespace TFE_Settings
 			{
 				writeKeyValue_Int(settings, "airControl", s_gameSettings.df_airControl);
 				writeKeyValue_Bool(settings, "bobaFettFacePlayer", s_gameSettings.df_bobaFettFacePlayer);
+				writeKeyValue_Bool(settings, "fixTargetOffset", s_gameSettings.df_fixTargetOffsetBug);
 				writeKeyValue_Bool(settings, "disableFightMusic", s_gameSettings.df_disableFightMusic);
 				writeKeyValue_Bool(settings, "enableAutoaim", s_gameSettings.df_enableAutoaim);
 				writeKeyValue_Bool(settings, "showSecretFoundMsg", s_gameSettings.df_showSecretFoundMsg);
@@ -860,6 +861,10 @@ namespace TFE_Settings
 		else if (strcasecmp("bobaFettFacePlayer", key) == 0)
 		{
 			s_gameSettings.df_bobaFettFacePlayer = parseBool(value);
+		}
+		else if (strcasecmp("fixTargetOffset", key) == 0)
+		{
+			s_gameSettings.df_fixTargetOffsetBug = parseBool(value);
 		}
 		else if (strcasecmp("disableFightMusic", key) == 0)
 		{

--- a/TheForceEngine/TFE_Settings/settings.h
+++ b/TheForceEngine/TFE_Settings/settings.h
@@ -158,6 +158,7 @@ struct TFE_Settings_Game
 	// Dark Forces
 	s32  df_airControl = 0;				// Air control, default = 0, where 0 = speed/256 and 8 = speed; range = [0, 8]
 	bool df_bobaFettFacePlayer = false;	// Make Boba Fett try to face the player in all his attack phases.
+	bool df_fixTargetOffsetBug = false;	// Fix a bug caused by a typo in the original AI that caused AI to only consider offset along the X axis.
 	bool df_disableFightMusic  = false;	// Set to true to disable fight music and music transitions during gameplay.
 	bool df_enableAutoaim      = true;  // Set to true to enable autoaim, false to disable.
 	bool df_showSecretFoundMsg = true;  // Show a message when the player finds a secret.


### PR DESCRIPTION
There are two places in the Dark Forces AI code where the AI computes a `targetOffset` as part of its pathfinding. The original version of Dark Forces only considers the X axis when calculating the offset. As noted by lucius:

> This is obviously a typo and bug in the DOS code and should be `min(|dx|, |dz|)` but the original code is `min(|dx|, |dx|) => |dx|`

This pull request adds a new option to the TFE Game settings menu, "Fix target offset bug". When this option is enabled, the target offset is calculated from `min(|dx|, |dz|)` as was originally intended.

This has a subtle effect on AI movement. I tested with the 'trooper' units (stormtrooper, officer, commando) and found that the difference isn't noticeable without debugging aids, which is probably why the original team missed the bug. 

To help me understand what was going on under the hood and verify that the fix was working, I kludged together a debug visualization tool (not included in this PR) for comparing how the AI would move with or without the bug fix:

![Target Offset](https://github.com/luciusDXL/TheForceEngine/assets/7231744/c3349773-223a-497b-82d2-10b5079c04d7)

The white line shows the path that the AI would take without the bug fix, while the red line shows the path that the AI would take with the bug fix. This image shows a particularly extreme example; usually the difference between the two paths is less than 15 degrees. On the left side of the image, you can see past visualizations where the difference is much smaller.

Given that this is a subtle change, it may not be worth incorporating into TFE, but I figured I may as well make a PR.