### PR TITLE
New debugging features

### DIFF
--- a/TheForceEngine/TFE_DarkForces/hud.cpp
+++ b/TheForceEngine/TFE_DarkForces/hud.cpp
@@ -98,6 +98,7 @@ namespace TFE_DarkForces
 	static s32 s_prevSecondaryAmmo = 0;
 	static JBool s_prevSuperchageHud = JFALSE;
 	static JBool s_prevHeadlampActive = JFALSE;
+	static bool s_showAdvancedData = false;
 
 	///////////////////////////////////////////
 	// Shared State
@@ -345,6 +346,8 @@ namespace TFE_DarkForces
 
 	void hud_startup(JBool fromSave)
 	{
+		CVAR_BOOL(s_showAdvancedData, "d_showData", CVFLAG_DO_NOT_SERIALIZE, "Enable to display debug information in HUD.");
+
 		// Reset cached values.
 		s_prevBatteryPower = 0;
 		s_prevLifeCount = 0;
@@ -383,7 +386,7 @@ namespace TFE_DarkForces
 			// s_screenDirtyLeft[s_curFrameBufferIdx] = JTRUE;
 		}
 
-		if (s_showData && s_playerEye)
+		if (s_playerEye && (s_showData || s_showAdvancedData))
 		{
 			fixed16_16 x, z;
 			getCameraXZ(&x, &z);
@@ -394,6 +397,16 @@ namespace TFE_DarkForces
 			sprintf((char*)dataStr, "X:%04d Y:%.1f Z:%04d H:%.1f S:%d%%", floor16(x), -fixed16ToFloat(s_playerEye->posWS.y), floor16(z), fixed16ToFloat(s_playerEye->worldHeight), s_secretsPercent);
 			displayHudMessage(s_hudFont, (DrawRect*)vfb_getScreenRect(VFB_RECT_UI), 164 + xOffset, 10, dataStr, framebuffer);
 			// s_screenDirtyRight[s_curFrameBufferIdx] = JTRUE;
+
+			if (s_showAdvancedData) {
+				f32 pitch = angleToFloatDegrees(s_playerEye->pitch);
+				f32 yaw = angleToFloatDegrees(s_playerEye->yaw);
+				//f32 roll = angleToFloatDegrees(s_playerEye->roll); //always 0
+				sprintf((char*)dataStr, "PIT:%05.1f YAW:%05.1f SEC:%d%", pitch, yaw, s_playerEye->sector->id);
+				displayHudMessage(s_hudFont, (DrawRect*)vfb_getScreenRect(VFB_RECT_UI), 164 + xOffset, 20, dataStr, framebuffer);
+				sprintf((char*)dataStr, "TICK:%04d", s_playerTick);
+				displayHudMessage(s_hudFont, (DrawRect*)vfb_getScreenRect(VFB_RECT_UI), 164 + xOffset, 30, dataStr, framebuffer);
+			}
 		}
 	}
 

--- a/TheForceEngine/TFE_DarkForces/mission.cpp
+++ b/TheForceEngine/TFE_DarkForces/mission.cpp
@@ -194,6 +194,13 @@ namespace TFE_DarkForces
 		if (args.size() < 3) { return; }
 		logic_spawnEnemy(args[1].c_str(), args[2].c_str());
 	}
+	
+	void console_showMessage(const ConsoleArgList& args)
+	{
+		if (args.size() < 2) return;
+		if (args.size() == 2) hud_sendTextMessage(args[1].c_str(), 0);
+		if (args.size() >= 3) hud_sendTextMessage(args[1].c_str(), strToInt(args[2].c_str()));
+	}
 
 	void mission_createDisplay()
 	{
@@ -353,7 +360,8 @@ namespace TFE_DarkForces
 		{
 			// TFE-specific
 			mission_addCheatCommands();
-			CCMD("spawnEnemy", console_spawnEnemy, 2, "spawnEnemy(waxName, enemyTypeName) - spawns an enemy 8 units away in the player direction. Example: spawnEnemy offcfin.wax i_officer");
+			CCMD("spawnEnemy", console_spawnEnemy, 2, "  spawnEnemy(waxName, enemyTypeName) - spawns an enemy 8 units in front of\n  the player. Example:\n      spawnEnemy offcfin.wax i_officer");
+			CCMD("showMessage", console_showMessage, 1, "  showMessage(message, [priority]) Display a message in the HUD, optionally\n  with priority. Examples:\n      showMessage \"Hello World\"\n      showMessage Testing 1");
 
 			// Make sure the loading screen is displayed for at least 1 second.
 			if (!s_loadingFromSave)

--- a/TheForceEngine/TFE_FrontEndUI/console.cpp
+++ b/TheForceEngine/TFE_FrontEndUI/console.cpp
@@ -365,6 +365,21 @@ namespace TFE_Console
 		s_history.clear();
 	}
 
+	//Returns the number of times that `find` occurs in `str`
+	s32 countOccurences(std::string str, std::string find)
+	{
+		std::string::size_type pos = 0;
+		int count = 0;
+		for (;;) {
+			pos = str.find(find, pos);
+			if (pos == std::string::npos)
+				break;
+			++count;
+			++pos;
+		}
+		return count;
+	}
+
 	void c_cmdHelp(const ConsoleArgList& args)
 	{
 		const size_t count = s_cmd.size();
@@ -584,6 +599,9 @@ namespace TFE_Console
 			s32 y = (s32)consoleHeight - 16 - 2*s_fontSize;
 			for (s32 i = start; i >= 0 && y > -s_fontSize; i--, y -= s_fontSize)
 			{
+				//fix text overflowing the console if this history entry contained newlines
+				int newLineOccurences = countOccurences(s_history[i].text, "\n");
+				y -= s_fontSize * newLineOccurences;
 				ImGui::SetCursorPosY(f32(y));
 				ImGui::TextColored(ImVec4(s_history[i].color.x, s_history[i].color.y, s_history[i].color.z, s_history[i].color.w), "%s", s_history[i].text.c_str());
 			}

--- a/TheForceEngine/TFE_Jedi/Math/fixedPoint.h
+++ b/TheForceEngine/TFE_Jedi/Math/fixedPoint.h
@@ -118,6 +118,10 @@ namespace TFE_Jedi
 		return angle14_16(angle * 45.5111f);
 	}
 
+	inline f32 angleToFloatDegrees(angle14_16 angle) {
+		return f32(angle) * 360.0f / 16384.0f;
+	}
+
 	// Convert a floating point angle from [0, 2pi) to a fixed point value where 0 -> 0 and 2pi -> 16384
 	// This isn't really the same as fixed16_16 but matches the original source.
 	inline fixed16_16 floatAngleToFixed(f32 angle)

--- a/TheForceEngine/TFE_Jedi/Renderer/RClassic_GPU/rsectorGPU.cpp
+++ b/TheForceEngine/TFE_Jedi/Renderer/RClassic_GPU/rsectorGPU.cpp
@@ -231,6 +231,7 @@ namespace TFE_Jedi
 		if (!m_gpuInit)
 		{
 			CVAR_BOOL(s_showWireframe, "d_enableWireframe", CVFLAG_DO_NOT_SERIALIZE, "Enable wireframe rendering.");
+			CVAR_BOOL(s_enableDebug, "d_enableDebug", CVFLAG_DO_NOT_SERIALIZE, "Enable debug rendering.");
 			TFE_COUNTER(s_wallSegGenerated, "Wall Segments");
 			
 			m_gpuInit = true;


### PR DESCRIPTION
- New console command **`showMessage(message, [priority])`**: displays a message in the HUD, optionally with priority. 
- New CVAR **`d_showData`**: when enabled, shows an extended version of what you get from the LADATA cheat (adds pitch, yaw, sector, tick)
- New CVAR **`d_enableDebug`**: controls debug rendering
- `fixedPoint.h`: added `angleToFloatDegrees()`
- `console.cpp`: fixed messages overflowing the console if they contained newline characters