### PR TITLE
Fix gcc/clang warnings wrt. varargs in ImGui use

### DIFF
--- a/TheForceEngine/TFE_A11y/accessibility.cpp
+++ b/TheForceEngine/TFE_A11y/accessibility.cpp
@@ -305,12 +305,12 @@ namespace TFE_A11Y  // a11y is industry slang for accessibility
 			//TFE_System::logWrite(LOG_ERROR, "a11y", (std::to_string(i) + " " + std::to_string(textSize.y) + ", " + std::to_string(lineHeight) + " " + std::to_string(lines) + " " + std::to_string(totalLines) + " " + std::to_string(windowSize.y)).c_str());
 			if (wrapText)
 			{
-				ImGui::TextWrapped(title->text.c_str());
+				ImGui::TextWrapped("%s", title->text.c_str());
 			}
 			else
 			{
 				ImGui::SetCursorPosX((windowSize.x - textSize.x) * 0.5f);
-				ImGui::Text(title->text.c_str());
+				ImGui::Text("%s", title->text.c_str());
 			}
 
 			// Reduce the caption's time remaining, removing it from the list if it's out of time

--- a/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
+++ b/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
@@ -2591,7 +2591,7 @@ namespace TFE_FrontEndUI
 	void DrawFontSizeCombo(float labelWidth, float valueWidth, const char* label, const char* comboTag, s32* currentValue)
 	{
 		ImGui::SetNextItemWidth(labelWidth);
-		ImGui::LabelText("##ConfigLabel", label);
+		ImGui::LabelText("##ConfigLabel", "%s", label);
 		ImGui::SameLine();
 		ImGui::SetNextItemWidth(valueWidth);
 		ImGui::Combo(comboTag, currentValue, c_fontSize, IM_ARRAYSIZE(c_fontSize));
@@ -2601,7 +2601,7 @@ namespace TFE_FrontEndUI
 	{
 		ImGui::SetNextItemWidth(labelWidth);
 		ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(color->getRedF(), color->getGreenF(), color->getBlueF(), color->getAlphaF()));
-		ImGui::LabelText("##ConfigLabel", label);
+		ImGui::LabelText("##ConfigLabel", "%s", label);
 		ImGui::PopStyleColor();
 		ImGui::SameLine();
 		RGBAf c;
@@ -2620,7 +2620,7 @@ namespace TFE_FrontEndUI
 	void DrawLabelledFloatSlider(float labelWidth, float valueWidth, const char* label, const char* tag, float* value, float min, float max)
 	{
 		ImGui::SetNextItemWidth(labelWidth);
-		ImGui::LabelText("##ConfigLabel", label);
+		ImGui::LabelText("##ConfigLabel", "%s", label);
 		ImGui::SameLine();
 		ImGui::SetNextItemWidth(valueWidth);
 		ImGui::SliderFloat(tag, value, min, max);
@@ -2629,7 +2629,7 @@ namespace TFE_FrontEndUI
 	void DrawLabelledIntSlider(float labelWidth, float valueWidth, const char* label, const char* tag, int* value, int min, int max)
 	{
 		ImGui::SetNextItemWidth(labelWidth);
-		ImGui::LabelText("##ConfigLabel", label);
+		ImGui::LabelText("##ConfigLabel", "%s", label);
 		ImGui::SameLine();
 		ImGui::SetNextItemWidth(valueWidth);
 		ImGui::SliderInt(tag, value, min, max);


### PR DESCRIPTION
Fix the following warnings emitted by gcc/clang:
warning: format not a string literal and no format arguments [-Wformat-security]
Since the ImGui::LabelText functions behave like printf(), add an explicit format specifier.