### PR TITLE
Fix the build process on GNU/Linux systems.

### DIFF
--- a/TheForceEngine/TFE_Jedi/Level/levelBin.cpp
+++ b/TheForceEngine/TFE_Jedi/Level/levelBin.cpp
@@ -1,3 +1,5 @@
+#include <cstring>
+
 #include "levelBin.h"
 #include "level.h"
 #include "levelData.h"


### PR DESCRIPTION
The cstring header was missing, therefore memcpy, memset, strcasecmp, strcat and strcpy could not be found during compilation.