### PR TITLE
Headwave is now a persistent setting in the A11y menu.

### DIFF
--- a/TheForceEngine/TFE_DarkForces/config.cpp
+++ b/TheForceEngine/TFE_DarkForces/config.cpp
@@ -6,7 +6,6 @@ namespace TFE_DarkForces
 {
 	GameConfig s_config =
 	{
-		JTRUE,	// headwave
 		JTRUE,	// wpnAutoMount
 		JFALSE, // mouseTurnEnabled
 		JTRUE,  // mouseLookEnabled

--- a/TheForceEngine/TFE_DarkForces/config.h
+++ b/TheForceEngine/TFE_DarkForces/config.h
@@ -11,7 +11,6 @@ namespace TFE_DarkForces
 {
 	struct GameConfig
 	{
-		JBool headwave;
 		JBool wpnAutoMount;
 		JBool mouseTurnEnabled;
 		JBool mouseLookEnabled;

--- a/TheForceEngine/TFE_DarkForces/mission.cpp
+++ b/TheForceEngine/TFE_DarkForces/mission.cpp
@@ -1298,8 +1298,9 @@ namespace TFE_DarkForces
 
 			if (inputMapping_getActionState(IADF_HEADWAVE_TOGGLE) == STATE_PRESSED)
 			{
-				s_config.headwave = ~s_config.headwave;
-				if (s_config.headwave)
+				TFE_Settings_A11y* settings = TFE_Settings::getA11ySettings();
+				settings->enableHeadwave = !settings->enableHeadwave;
+				if (settings->enableHeadwave)
 				{
 					hud_sendTextMessage(14);
 				}

--- a/TheForceEngine/TFE_DarkForces/player.cpp
+++ b/TheForceEngine/TFE_DarkForces/player.cpp
@@ -2064,7 +2064,7 @@ namespace TFE_DarkForces
 		// Headwave
 		s32 xWpnWaveOffset = 0;
 		s_headwaveVerticalOffset = 0;
-		if (s_config.headwave && (player->flags & OBJ_FLAG_EYE))
+		if (TFE_Settings::getA11ySettings()->enableHeadwave && (player->flags & OBJ_FLAG_EYE))
 		{
 			fixed16_16 playerSpeedAve = distApprox(0, 0, s_playerVelX, s_playerVelZ);
 			if (!moved)

--- a/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
+++ b/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
@@ -2752,6 +2752,11 @@ namespace TFE_FrontEndUI
 		DrawLabelledIntSlider(labelW, valueW, "Max Lines", "##CML", &a11y->gameplayMaxTextLines, 2, 7);
 		DrawLabelledIntSlider(labelW, valueW, "Min. Volume", "##CMV", &a11y->gameplayCaptionMinVolume, 0, 127);
 
+		ImGui::PushFont(s_dialogFont);
+		ImGui::LabelText("##ConfigLabel4", "Motion Sickess");
+		ImGui::PopFont();
+		ImGui::Checkbox("Enable headwave", &a11y->enableHeadwave);
+
 		TFE_A11Y::drawExampleCaptions();
 	}
 

--- a/TheForceEngine/TFE_Settings/settings.cpp
+++ b/TheForceEngine/TFE_Settings/settings.cpp
@@ -465,6 +465,8 @@ namespace TFE_Settings
 		writeKeyValue_Int(settings, "gameplayMaxTextLines", s_a11ySettings.gameplayMaxTextLines);
 		writeKeyValue_Float(settings, "gameplayTextSpeed", s_a11ySettings.gameplayTextSpeed);
 		writeKeyValue_Int(settings, "gameplayCaptionMinVolume", s_a11ySettings.gameplayCaptionMinVolume);
+		
+		writeKeyValue_Bool(settings, "enableHeadwave", s_a11ySettings.enableHeadwave);
 	}
 
 	void writeGameSettings(FileStream& settings)
@@ -990,6 +992,10 @@ namespace TFE_Settings
 		else if (strcasecmp("gameplayCaptionMinVolume", key) == 0)
 		{
 			s_a11ySettings.gameplayCaptionMinVolume = parseInt(value);
+		}
+		else if (strcasecmp("enableHeadwave", key) == 0)
+		{
+			s_a11ySettings.enableHeadwave = parseBool(value);
 		}
 	}
 

--- a/TheForceEngine/TFE_Settings/settings.h
+++ b/TheForceEngine/TFE_Settings/settings.h
@@ -277,6 +277,9 @@ struct TFE_Settings_A11y
 	bool showGameplayTextBorder = false;
 	f32 gameplayTextSpeed = 1.0f;
 	s32 gameplayCaptionMinVolume = 32; // In range 0 - 127
+
+	// Motion sickness settings
+	bool enableHeadwave = true;
 };
 
 namespace TFE_Settings


### PR DESCRIPTION
Headwave gives some players motion sickness, so this now appears as a setting under "motion sickness" in the Accessibility menu. The setting can still be toggled with F6, but now is saved between sessions.