### PR TITLE
Fix linux build

### DIFF
--- a/TheForceEngine/TFE_A11y/accessibility.cpp
+++ b/TheForceEngine/TFE_A11y/accessibility.cpp
@@ -158,7 +158,7 @@ namespace TFE_A11Y  // a11y is industry slang for accessibility
 	void loadDefaultFont(bool clearAtlas)
 	{
 		char fontpath[TFE_MAX_PATH];
-		sprintf(fontpath, DEFAULT_FONT);
+		sprintf(fontpath, "%s", DEFAULT_FONT);
 		TFE_Paths::mapSystemPath(fontpath);
 		loadFont(fontpath, clearAtlas);
 	}

--- a/TheForceEngine/TFE_Jedi/Renderer/RClassic_GPU/screenDrawGPU.cpp
+++ b/TheForceEngine/TFE_Jedi/Renderer/RClassic_GPU/screenDrawGPU.cpp
@@ -14,6 +14,7 @@
 #include "screenDrawGPU.h"
 #include "rsectorGPU.h"
 #include <algorithm>
+#include <cstring>
 
 namespace TFE_Jedi
 {


### PR DESCRIPTION
The cstring header was missing in `screenDrawGPU.cpp` so the compiler could not find the `memcpy` function and there was a possible format string bug waiting in `accessibility.cpp`.
