### PR TITLE
Fix Linux crash in A11y on startup

### DIFF
--- a/TheForceEngine/TFE_A11y/accessibility.cpp
+++ b/TheForceEngine/TFE_A11y/accessibility.cpp
@@ -208,7 +208,7 @@ namespace TFE_A11Y  // a11y is industry slang for accessibility
 		}
 		assert(s_currentCaptionFont != nullptr);
 
-		char name[256];
+		char name[TFE_MAX_PATH];
 		FileUtil::getFileNameFromPath(path.c_str(), name);
 		s_currentFontFile.name = string(name);
 		s_currentFontFile.path = path;

--- a/TheForceEngine/TFE_A11y/accessibility.cpp
+++ b/TheForceEngine/TFE_A11y/accessibility.cpp
@@ -158,7 +158,7 @@ namespace TFE_A11Y  // a11y is industry slang for accessibility
 	void loadDefaultFont(bool clearAtlas)
 	{
 		char fontpath[TFE_MAX_PATH];
-		sprintf(fontpath, DEFAULT_FONT);
+		snprintf(fontpath, TFE_MAX_PATH, "%s", DEFAULT_FONT);
 		TFE_Paths::mapSystemPath(fontpath);
 		loadFont(fontpath, clearAtlas);
 	}

--- a/TheForceEngine/TFE_FileSystem/filestream-posix.cpp
+++ b/TheForceEngine/TFE_FileSystem/filestream-posix.cpp
@@ -18,6 +18,11 @@ extern u32  s_workBufferU32[1024];		//4k buffer.
 extern char s_workBufferChar[32768];	//32k buffer.
 
 
+namespace FileUtil {
+	extern bool existsNoCase(const char *filename);
+	extern char* findFileNoCase(const char *fn);
+}
+
 FileStream::FileStream() : Stream()
 {
 	m_file = nullptr;

--- a/TheForceEngine/TFE_FileSystem/fileutil-posix.cpp
+++ b/TheForceEngine/TFE_FileSystem/fileutil-posix.cpp
@@ -15,6 +15,7 @@
 // implement TFE FileUtil for Linux and compatibles.
 namespace FileUtil
 {
+	bool existsNoCase(const char *filename);
 	static char *findFileObjectNoCase(const char *filename, bool objisdir);
 
 	void readDirectory(const char *dir, const char *ext, FileList& fileList)
@@ -324,6 +325,11 @@ namespace FileUtil
 	char *findFileNoCase(const char *filename)
 	{
 		return findFileObjectNoCase(filename, false);
+	}
+
+	char *findDirNoCase(const char *dn)
+	{
+		return findFileObjectNoCase(dn, true);
 	}
 
 	bool existsNoCase(const char *filename)

--- a/TheForceEngine/TFE_FileSystem/fileutil.cpp
+++ b/TheForceEngine/TFE_FileSystem/fileutil.cpp
@@ -233,11 +233,6 @@ namespace FileUtil
 		return !(GetFileAttributesA(path)==INVALID_FILE_ATTRIBUTES && GetLastError()==ERROR_FILE_NOT_FOUND);
 	}
 
-	bool existsNoCase( const char *path )
-	{
-		return exists(path);
-	}
-
 	u64 getModifiedTime( const char* path )
 	{
 		FILETIME creationTime;
@@ -303,13 +298,6 @@ namespace FileUtil
 		}
 #endif
 		pathOS[len] = 0;
-	}
-
-	char *findFileNoCase(const char *fn)
-	{
-		// windows doesn't care about file name case, return that
-		// we have not found the file.
-		return NULL;
 	}
 
 	void replaceExtension(const char* srcPath, const char* newExt, char* outPath)

--- a/TheForceEngine/TFE_FileSystem/fileutil.h
+++ b/TheForceEngine/TFE_FileSystem/fileutil.h
@@ -24,13 +24,11 @@ namespace FileUtil
 	void deleteFile(const char* srcFile);
 
 	bool exists(const char* path);
-	bool existsNoCase(const char* path);
 	bool directoryExits(const char* path, char* outPath = nullptr);
 	u64  getModifiedTime(const char* path);
 
 	void fixupPath(char* path);
 	void convertToOSPath(const char* path, char* pathOS);
 
-	char *findFileNoCase(const char *fn);
 	void replaceExtension(const char* srcPath, const char* newExt, char* outPath);
 }

--- a/TheForceEngine/TFE_FileSystem/paths-posix.cpp
+++ b/TheForceEngine/TFE_FileSystem/paths-posix.cpp
@@ -9,6 +9,11 @@
 #include <deque>
 #include <string>
 
+namespace FileUtil {
+	extern bool existsNoCase(const char *filename);
+	extern char *findDirNoCase(const char *dn);
+}
+
 namespace TFE_Paths
 {
 	struct FileMapping
@@ -163,6 +168,11 @@ namespace TFE_Paths
 		for (auto it = s_systemPaths.begin(); it != s_systemPaths.end(); it++) {
 			sprintf(fullname, "%s%s", it->c_str(), fname);
 			if (FileUtil::existsNoCase(fullname)) {
+				strncpy(fname, fullname, TFE_MAX_PATH);
+				return true;
+			}
+			// is it a dir?
+			if (FileUtil::findDirNoCase(fullname)) {
 				strncpy(fname, fullname, TFE_MAX_PATH);
 				return true;
 			}


### PR DESCRIPTION
- Extend the mapSystemPath() call to also work on paths, as required by A11y components
- Fix a too small path buffer which causes startup crashes (#327)