### PR TITLE
A11y: Don't init captions if they are disabled; improved settings UI

### DIFF
--- a/TheForceEngine/TFE_A11y/accessibility.cpp
+++ b/TheForceEngine/TFE_A11y/accessibility.cpp
@@ -354,7 +354,7 @@ namespace TFE_A11Y  // a11y is industry slang for accessibility
 		};
 
 		s_status = CC_LOADED;
-		delete s_captionsBuffer;
+		free(s_captionsBuffer);
 	}
 
 	void onFileError(const string path)

--- a/TheForceEngine/TFE_A11y/accessibility.cpp
+++ b/TheForceEngine/TFE_A11y/accessibility.cpp
@@ -33,7 +33,7 @@ namespace TFE_A11Y  // a11y is industry slang for accessibility
 	bool filterCaptionFile(const string fileName);
 	void onFileError(const string path);
 	void enqueueCaption(const ConsoleArgList& args);
-	void drawCaptions(std::vector<Caption>* captions);
+	Vec2f drawCaptions(std::vector<Caption>* captions);
 	string toUpper(string input);
 	string toLower(string input);
 	string toFileName(string language);
@@ -47,7 +47,6 @@ namespace TFE_A11Y  // a11y is industry slang for accessibility
 	///////////////////////////////////////////
 	const char* DEFAULT_FONT = "Fonts/NotoSans-Regular.ttf";
 	const f32 MAX_CAPTION_WIDTH = 1200;
-	const f32 DEFAULT_LINE_HEIGHT = 20;
 	const f32 LINE_PADDING = 5;
 	// Base duration of a caption
 	const s64 BASE_DURATION_MICROSECONDS = secondsToMicroseconds(0.9f);
@@ -501,15 +500,15 @@ namespace TFE_A11Y  // a11y is industry slang for accessibility
 		//TFE_System::logWrite(LOG_ERROR, "a11y", std::to_string(active.size()).c_str());
 	}
 
-	void drawCaptions()
+	Vec2f drawCaptions()
 	{
 		if (s_activeCaptions.size() > 0)
 		{
-			drawCaptions(&s_activeCaptions);
+			return drawCaptions(&s_activeCaptions);
 		}
 	}
 
-	void drawCaptions(std::vector<Caption>* captions)
+	Vec2f drawCaptions(std::vector<Caption>* captions)
 	{
 		if (isFontLoaded()) { ImGui::PushFont(s_currentCaptionFont); }
 
@@ -614,15 +613,19 @@ namespace TFE_A11Y  // a11y is industry slang for accessibility
 				}
 			}
 		}
+
+		ImVec2 finalWindowSize = ImGui::GetWindowSize();
 		ImGui::PopStyleColor();
 		ImGui::End();
 
 		if (isFontLoaded()) { ImGui::PopFont(); }
 
 		s_lastTime = time;
+
+		return { finalWindowSize.x, finalWindowSize.y };
 	}
 
-	void drawExampleCaptions()
+	Vec2f drawExampleCaptions()
 	{
 		if (s_exampleCaptions.size() == 0)
 		{
@@ -630,7 +633,7 @@ namespace TFE_A11Y  // a11y is industry slang for accessibility
 			caption.env = CC_CUTSCENE;
 			s_exampleCaptions.push_back(caption);
 		}
-		drawCaptions(&s_exampleCaptions);
+		return drawCaptions(&s_exampleCaptions);
 	}
 
 	bool cutsceneCaptionsEnabled()

--- a/TheForceEngine/TFE_A11y/accessibility.cpp
+++ b/TheForceEngine/TFE_A11y/accessibility.cpp
@@ -403,11 +403,11 @@ namespace TFE_A11Y  // a11y is industry slang for accessibility
 				f32 fontScale;
 				auto windowSize = calcWindowSize(&fontScale, env);
 				assert(fontScale > 0);
-				s32 count = 1;
-				size_t idx = 0;
+
+				size_t idx = 0;   // Index of current character in string.
+				string line = ""; // Current line of the current chunk.
 				string chunk;
 				s32 chunkLineCount = 0;
-				string line = "";
 				while (idx < caption.text.length())
 				{
 					// Extend the line one character at a time until we exceed the width of the panel
@@ -431,8 +431,8 @@ namespace TFE_A11Y  // a11y is industry slang for accessibility
 						}
 						else { break; }
 
-						// If the chunk has three lines, add it as a new caption.
-						if (chunkLineCount >= 3)
+						// If the chunk has reached the maximum number of lines, add it as a new caption.
+						if (chunkLineCount >= maxLines)
 						{
 							s32 length = (s32)chunk.length();
 							f32 ratio = length / (f32)caption.text.length();
@@ -450,7 +450,6 @@ namespace TFE_A11Y  // a11y is industry slang for accessibility
 							else { break; }
 
 							caption.microsecondsRemaining -= next.microsecondsRemaining;
-							count++;
 							idx = 0;
 							chunkLineCount = 0;
 							chunk = "";

--- a/TheForceEngine/TFE_A11y/accessibility.h
+++ b/TheForceEngine/TFE_A11y/accessibility.h
@@ -41,7 +41,12 @@ namespace TFE_A11Y {
 	///////////////////////////////////////////
 	// Functions
 	///////////////////////////////////////////
+
+	// Initialize the A11y system.
 	void init();
+
+	// Initialize the caption system. Only call this if the current status is CC_NOT_LOADED.
+	void initCaptions();
 
 	// Fonts
 	FilePathList getFontFiles();
@@ -53,7 +58,7 @@ namespace TFE_A11Y {
 	// Captions
 	FilePathList getCaptionFiles();
 	FilePath getCurrentCaptionFile();
-	A11yStatus getStatus();
+	A11yStatus getCaptionSystemStatus();
 	void loadCaptions(const string path);
 	void clearActiveCaptions();
 	void drawCaptions();

--- a/TheForceEngine/TFE_A11y/accessibility.h
+++ b/TheForceEngine/TFE_A11y/accessibility.h
@@ -37,6 +37,7 @@ namespace TFE_A11Y {
 	///////////////////////////////////////////
 	const string FILE_NAME_START = "subtitles-";
 	const string FILE_NAME_EXT = ".txt";
+	const f32 DEFAULT_LINE_HEIGHT = 20;
 
 	///////////////////////////////////////////
 	// Functions
@@ -61,8 +62,8 @@ namespace TFE_A11Y {
 	A11yStatus getCaptionSystemStatus();
 	void loadCaptions(const string path);
 	void clearActiveCaptions();
-	void drawCaptions();
-	void drawExampleCaptions();
+	Vec2f drawCaptions();
+	Vec2f drawExampleCaptions();
 	void focusCaptions();
 	void enqueueCaption(Caption caption);
 	void onSoundPlay(char* name, CaptionEnv env);

--- a/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
+++ b/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
@@ -2785,7 +2785,7 @@ namespace TFE_FrontEndUI
 		ImGui::Dummy(ImVec2(0.0f, 10.0f));
 		ImGui::Separator();
 		ImGui::PushFont(s_dialogFont);
-		ImGui::LabelText("##ConfigLabel4", "Motion Sickess");
+		ImGui::LabelText("##ConfigLabel4", "Motion Sickness");
 		ImGui::PopFont();
 		ImGui::Checkbox("Enable headwave", &a11ySettings->enableHeadwave);
 	}

--- a/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
+++ b/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
@@ -2690,7 +2690,12 @@ namespace TFE_FrontEndUI
 		float labelW = 140 * s_uiScale;
 		float valueW = 260 * s_uiScale;
 
-		if (TFE_A11Y::getStatus() == TFE_A11Y::CC_ERROR)
+		// Check status, and init the caption system if necessary.
+		if (TFE_A11Y::getCaptionSystemStatus() == TFE_A11Y::CC_NOT_LOADED) 
+		{
+			TFE_A11Y::initCaptions(); 
+		}
+		if (TFE_A11Y::getCaptionSystemStatus() == TFE_A11Y::CC_ERROR)
 		{
 			ImGui::LabelText("##ConfigLabel", "Error: Caption file could not be loaded!");
 		}
@@ -2699,7 +2704,7 @@ namespace TFE_FrontEndUI
 		ImGui::LabelText("##ConfigLabel", "Subtitle/caption file:");
 		TFE_A11Y::FilePath currentCaptionFile = TFE_A11Y::getCurrentCaptionFile();
 		string currentCaptionFilePath = DrawFileListCombo("##ccfile", currentCaptionFile.name, currentCaptionFile.path, TFE_A11Y::getCaptionFiles());
-		// If user changed the selected caption file, reload captions
+		// If user changed the selected caption file, reload captions.
 		if (currentCaptionFilePath != currentCaptionFile.path)
 		{
 			TFE_A11Y::clearActiveCaptions();

--- a/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
+++ b/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
@@ -249,7 +249,7 @@ namespace TFE_FrontEndUI
 	void configHud();
 	void configSound();
 	void configSystem();
-	void configA11y();
+	void configA11y(s32 tabWidth, u32 height);
 	void pickCurrentResolution();
 	void manual();
 	void credits();
@@ -882,7 +882,7 @@ namespace TFE_FrontEndUI
 			}
 
 			ImGui::SetNextWindowPos(ImVec2(160.0f*s_uiScale, 0.0f));
-			ImGui::SetNextWindowSize(ImVec2(f32(tabWidth), f32(h)));
+			if (s_configTab != CONFIG_A11Y) { ImGui::SetNextWindowSize(ImVec2(f32(tabWidth), f32(h))); }
 			ImGui::SetNextWindowBgAlpha(0.95f);
 			ImGui::Begin("##Settings", &active, window_flags);
 
@@ -920,7 +920,7 @@ namespace TFE_FrontEndUI
 				configSystem();
 				break;
 			case CONFIG_A11Y:
-				configA11y();
+				configA11y(tabWidth, h);
 				break;
 			};
 			renderBackground();
@@ -2684,11 +2684,33 @@ namespace TFE_FrontEndUI
 	}
 
 	// Accessibility
-	void configA11y()
+	void configA11y(s32 tabWidth, u32 height)
 	{
-		TFE_Settings_A11y* a11y = TFE_Settings::getA11ySettings();
-		float labelW = 140 * s_uiScale;
-		float valueW = 260 * s_uiScale;
+		// WINDOW --------------------------------------------
+		TFE_Settings_A11y* a11ySettings = TFE_Settings::getA11ySettings();
+		f32 labelW = 140 * s_uiScale;
+		f32 valueW = 260 * s_uiScale - 10;
+
+		// Draw the example caption if captions are enabled, and resize the settings window accordingly.
+		if (a11ySettings->captionSystemEnabled())
+		{
+			Vec2f captionWindowSize = TFE_A11Y::drawExampleCaptions();
+
+			// Resize the settings window so it isn't covered by the example caption
+			ImVec2 windowSize;
+			windowSize.x = tabWidth;
+			windowSize.y = height - captionWindowSize.z - TFE_A11Y::DEFAULT_LINE_HEIGHT * 2;
+			ImGui::SetWindowSize(windowSize);
+		}
+		else // Captions not enabled
+		{
+			ImGui::SetWindowSize(ImVec2(tabWidth, height));
+		}
+
+		// CAPTIONS -------------------------------------------
+		ImGui::PushFont(s_dialogFont);
+		ImGui::LabelText("##ConfigLabel", "Captions");
+		ImGui::PopFont();
 
 		// Check status, and init the caption system if necessary.
 		if (TFE_A11Y::getCaptionSystemStatus() == TFE_A11Y::CC_NOT_LOADED) 
@@ -2723,48 +2745,49 @@ namespace TFE_FrontEndUI
 		}
 
 		// CUTSCENES -----------------------------------------
-		ImGui::PushFont(s_dialogFont);
+		ImGui::Dummy(ImVec2(0.0f, 10.0f));
+		ImGui::PushFont(s_versionFont);
 		ImGui::LabelText("##ConfigLabel", "Cutscenes");
 		ImGui::PopFont();
 
-		ImGui::Checkbox("Subtitles (voice)##Cutscenes", &a11y->showCutsceneSubtitles);
+		ImGui::Checkbox("Subtitles (voice)##Cutscenes", &a11ySettings->showCutsceneSubtitles);
 		ImGui::SameLine(0, 22);
-		ImGui::Checkbox("Captions (SFX)##Cutscenes", &a11y->showCutsceneCaptions);
+		ImGui::Checkbox("Captions (SFX)##Cutscenes", &a11ySettings->showCutsceneCaptions);
 		
-		DrawFontSizeCombo(labelW, valueW, "Font Size##Cutscenes", "##CFS", (s32*)&a11y->cutsceneFontSize);
-		DrawRGBFields(labelW, valueW, "Font Color##Cutscenes", &a11y->cutsceneFontColor);
-		DrawLabelledFloatSlider(labelW, valueW * 0.5f - 2, "Background Opacity", "##CBO", &a11y->cutsceneTextBackgroundAlpha, 0.0f, 1.0f);
+		DrawFontSizeCombo(labelW, valueW, "Font Size##Cutscenes", "##CFS", (s32*)&a11ySettings->cutsceneFontSize);
+		DrawRGBFields(labelW, valueW, "Font Color##Cutscenes", &a11ySettings->cutsceneFontColor);
+		DrawLabelledFloatSlider(labelW, valueW * 0.5f - 2, "Background Opacity", "##CBO", &a11ySettings->cutsceneTextBackgroundAlpha, 0.0f, 1.0f);
 		ImGui::SameLine(0, 40);
-		ImGui::Checkbox("Border##Cutscenes", &a11y->showCutsceneTextBorder);
-		DrawLabelledFloatSlider(labelW, valueW, "Text speed", "##CTS", &a11y->cutsceneTextSpeed, 0.5f, 2.0f);
+		ImGui::Checkbox("Border##Cutscenes", &a11ySettings->showCutsceneTextBorder);
+		DrawLabelledFloatSlider(labelW, valueW, "Text speed", "##CTS", &a11ySettings->cutsceneTextSpeed, 0.5f, 2.0f);
 
-		ImGui::Separator();
-
-		// GAMEPLAY------------------------------------------
-		ImGui::PushFont(s_dialogFont);
+		// GAMEPLAY ------------------------------------------
+		ImGui::Dummy(ImVec2(0.0f, 10.0f));
+		ImGui::PushFont(s_versionFont);
 		ImGui::LabelText("##ConfigLabel3", "Gameplay");
 		ImGui::PopFont();
 
-		ImGui::Checkbox("Subtitles (voice)##Gameplay", &a11y->showGameplaySubtitles);
+		ImGui::Checkbox("Subtitles (voice)##Gameplay", &a11ySettings->showGameplaySubtitles);
 		ImGui::SameLine(0, 22);
-		ImGui::Checkbox("Captions (SFX)##Gameplay", &a11y->showGameplayCaptions);
+		ImGui::Checkbox("Captions (SFX)##Gameplay", &a11ySettings->showGameplayCaptions);
 
-		DrawFontSizeCombo(labelW, valueW, "Font Size##Gameplay", "##GFS", (s32*)&a11y->gameplayFontSize);
-		DrawRGBFields(labelW, valueW, "Font Color##Gameplay", &a11y->gameplayFontColor);
-		DrawLabelledFloatSlider(labelW, valueW * 0.5f - 2, "Background Opacity", "##GBO", &a11y->gameplayTextBackgroundAlpha, 0.0f, 1.0f);
+		DrawFontSizeCombo(labelW, valueW, "Font Size##Gameplay", "##GFS", (s32*)&a11ySettings->gameplayFontSize);
+		DrawRGBFields(labelW, valueW, "Font Color##Gameplay", &a11ySettings->gameplayFontColor);
+		DrawLabelledFloatSlider(labelW, valueW * 0.5f - 2, "Background Opacity", "##GBO", &a11ySettings->gameplayTextBackgroundAlpha, 0.0f, 1.0f);
 		ImGui::SameLine(0, 40);
-		ImGui::Checkbox("Border##Gameplay", &a11y->showGameplayTextBorder);
-		DrawLabelledFloatSlider(labelW, valueW, "Text speed", "##GTS", &a11y->gameplayTextSpeed, 0.5f, 2.0f);
+		ImGui::Checkbox("Border##Gameplay", &a11ySettings->showGameplayTextBorder);
+		DrawLabelledFloatSlider(labelW, valueW, "Text speed", "##GTS", &a11ySettings->gameplayTextSpeed, 0.5f, 2.0f);
 
-		DrawLabelledIntSlider(labelW, valueW, "Max Lines", "##CML", &a11y->gameplayMaxTextLines, 2, 7);
-		DrawLabelledIntSlider(labelW, valueW, "Min. Volume", "##CMV", &a11y->gameplayCaptionMinVolume, 0, 127);
+		DrawLabelledIntSlider(labelW, valueW, "Max Lines", "##CML", &a11ySettings->gameplayMaxTextLines, 2, 7);
+		DrawLabelledIntSlider(labelW, valueW, "Min. Volume", "##CMV", &a11ySettings->gameplayCaptionMinVolume, 0, 127);
 
+		// MOTION SICKNESS -------------------------------------
+		ImGui::Dummy(ImVec2(0.0f, 10.0f));
+		ImGui::Separator();
 		ImGui::PushFont(s_dialogFont);
 		ImGui::LabelText("##ConfigLabel4", "Motion Sickess");
 		ImGui::PopFont();
-		ImGui::Checkbox("Enable headwave", &a11y->enableHeadwave);
-
-		TFE_A11Y::drawExampleCaptions();
+		ImGui::Checkbox("Enable headwave", &a11ySettings->enableHeadwave);
 	}
 
 	void pickCurrentResolution()

--- a/TheForceEngine/TFE_Settings/settings.h
+++ b/TheForceEngine/TFE_Settings/settings.h
@@ -278,6 +278,11 @@ struct TFE_Settings_A11y
 	f32 gameplayTextSpeed = 1.0f;
 	s32 gameplayCaptionMinVolume = 32; // In range 0 - 127
 
+	bool captionSystemEnabled()
+	{
+		return showCutsceneSubtitles || showCutsceneCaptions || showGameplaySubtitles || showGameplayCaptions;
+	}
+
 	// Motion sickness settings
 	bool enableHeadwave = true;
 };


### PR DESCRIPTION
- If none of the caption modes are enabled when TFE starts, we now skip the caption initialization process. Captions will be initialized if the user navigates to the Accessibility menu.
- Improved UI layout for Accessibility settings menu; fixed issue where the example caption was obscuring some settings on small screens.
- Restored functionality that adjusts the maximum number of caption lines during cutscenes based on the selected font size.