### PR TITLE
frontEndUi.cpp: On Game Settings screen, fixed green text getting cut off 

### DIFF
--- a/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
+++ b/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
@@ -1019,7 +1019,7 @@ namespace TFE_FrontEndUI
 		ImGui::PopFont();
 
 		ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.25f, 1.0f, 0.25f, 1.0f));
-		ImGui::LabelText("##ConfigLabel", "The path should contain the source game exe or gob/lab files.");
+		ImGui::TextWrapped("The path should contain the source game exe or gob/lab files.");
 		ImGui::PopStyleColor();
 		ImGui::Spacing();
 


### PR DESCRIPTION
Fixes #337

Original
![Game Source Data text cutoff](https://github.com/luciusDXL/TheForceEngine/assets/7231744/778096f9-343e-4762-9b0d-bb74d7a352c0)
Fixed
![Game Source Data text fixed](https://github.com/luciusDXL/TheForceEngine/assets/7231744/402743de-c3e6-4cb7-b79a-d8f27ef25d3b)
