### PR TITLE
Linux/CMake: make RtMidi optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,9 @@ else()
 endif()
 include(GNUInstallDirs)
 
+## Options
+option(DISABLE_SYSMIDI "Disable System-MIDI Output" OFF)
+
 
 add_executable(tfe)
 set_target_properties(tfe PROPERTIES OUTPUT_NAME "theforceengine")
@@ -44,7 +47,6 @@ set_target_properties(tfe PROPERTIES OUTPUT_NAME "theforceengine")
 if(LINUX)
 	find_package(PkgConfig REQUIRED)
 	find_package(Threads REQUIRED)
-	pkg_check_modules(RTMIDI REQUIRED rtmidi>=5.0.0)
 	pkg_check_modules(SDL2 REQUIRED sdl2)
 	pkg_check_modules(GLEW REQUIRED glew)
 	pkg_check_modules(IL REQUIRED IL)
@@ -59,9 +61,13 @@ if(LINUX)
 				${SDL2_LIBRARIES}
 				${IL_LIBRARIES}
 				${ILU_LIBRARIES}
-				${RTMIDI_LIBRARIES}
 	)
-	
+
+	if(NOT DISABLE_SYSMIDI)
+		pkg_check_modules(RTMIDI REQUIRED rtmidi>=5.0.0)
+		target_link_libraries(tfe PRIVATE ${RTMIDI_LIBRARIES})
+	endif()
+
 	# set up build directory to be able to run TFE immediately: symlink
 	# the necessary support file directories into the build env.
 	execute_process(COMMAND ln -sf ${CMAKE_SOURCE_DIR}/TheForceEngine/Captions)
@@ -75,6 +81,12 @@ if(LINUX)
 	include(CreateGitVersionH.cmake)
 	create_git_version_h()
 endif()
+
+
+if(DISABLE_SYSMIDI)
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DNOSYSMIDI")
+endif()
+
 
 target_include_directories(tfe PRIVATE TheForceEngine)
 

--- a/README.md
+++ b/README.md
@@ -56,8 +56,6 @@ This can be overridden by defining the "__TFE_DATA_HOME__" environment variable.
 * [devIL](https://openil.sourceforge.net)
 * [GLEW](http://glew.sourceforge.net/) 2.2.0
 * OpenGL 3.3 capable driver (latest [mesa](https://www.mesa3d.org) or nvidia proprietary driver recommended)
-
-### Optional Libraries
 * [RtMidi](https://www.music.mcgill.ca/~gary/rtmidi/) 5.0.0 or higher for external MIDI Synthesizer support
 
 ### Building from Source
@@ -66,13 +64,14 @@ This can be overridden by defining the "__TFE_DATA_HOME__" environment variable.
 * GCC-11 and newer or equivalent clang version.
 #### How to build
 * Unpack the source or fetch from github
-* Create a build directory and chdir into it:
+* Create a build directory and chdir into it:  
 __mkdir tfe-build; cd tfe-build__
-* Run CMake in the build directory, the build type must be specified (debug or release):
+* Run CMake in the build directory, the build type must be specified (debug or release):  
 __cmake -S /path/to/tfe-source/__
-* Build it:
+[add  -DDISABLE_SYSMIDI=ON   to disable RtMidi (external MIDI Synthesizers) support]
+* Build it:  
 __make__
-* Install it:
+* Install it:  
 __sudo make install__  
 * If no additional parameters were added to CMake, files will be installed in __/usr/local/bin__, __/usr/local/share/TheForceEngine/__
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # The Force Engine (TFE)
 * [Website](https://theforceengine.github.io/)
 * [Release Downloads](https://theforceengine.github.io/downloads.html)
@@ -53,9 +54,11 @@ This can be overridden by defining the "__TFE_DATA_HOME__" environment variable.
 ### Required Libraries
 * [SDL2](TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp) 2.24 or higher
 * [devIL](https://openil.sourceforge.net)
-* [RtMidi](https://www.music.mcgill.ca/~gary/rtmidi/) 5.0.0 or higher
 * [GLEW](http://glew.sourceforge.net/) 2.2.0
 * OpenGL 3.3 capable driver (latest [mesa](https://www.mesa3d.org) or nvidia proprietary driver recommended)
+
+### Optional Libraries
+* [RtMidi](https://www.music.mcgill.ca/~gary/rtmidi/) 5.0.0 or higher for external MIDI Synthesizer support
 
 ### Building from Source
 #### Recommended Tools

--- a/TheForceEngine/TFE_Audio/CMakeLists.txt
+++ b/TheForceEngine/TFE_Audio/CMakeLists.txt
@@ -3,4 +3,11 @@ if(LINUX)
 	# we use the system libraries on Linux
 	list(REMOVE_ITEM SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/RtMidi.cpp")
 endif()
+if(DISABLE_SYSMIDI)
+	list(REMOVE_ITEM SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/systemMidiDevice.cpp")
+	if(WIN32)
+		list(REMOVE_ITEM SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/RtMidi.cpp")
+	endif()
+endif()
+
 target_sources(tfe PRIVATE ${SOURCES})

--- a/TheForceEngine/TFE_Audio/midiDevice.h
+++ b/TheForceEngine/TFE_Audio/midiDevice.h
@@ -4,9 +4,11 @@
 
 enum MidiDeviceType
 {
-	MIDI_TYPE_SYSTEM = 0,	// System midi device (hardware, midi server, GM midi on Windows).
-	MIDI_TYPE_SF2,			// Use the Sound Font 2 (SF2) midi synthesizer.
-	MIDI_TYPE_OPL3,			// Use OPL3 emulation (like DosBox).
+	MIDI_TYPE_SF2 = 0,	// Use the Sound Font 2 (SF2) midi synthesizer.
+	MIDI_TYPE_OPL3,		// Use OPL3 emulation (like DosBox).
+#ifndef NOSYSMIDI
+	MIDI_TYPE_SYSTEM,	// System midi device (hardware, midi server, GM midi on Windows).
+#endif
 	MIDI_TYPE_COUNT,
 	MIDI_TYPE_DEFAULT = MIDI_TYPE_OPL3
 };

--- a/TheForceEngine/TFE_Audio/midiPlayer.cpp
+++ b/TheForceEngine/TFE_Audio/midiPlayer.cpp
@@ -1,7 +1,9 @@
 #include "midiPlayer.h"
 #include "midiDevice.h"
 #include "audioDevice.h"
+#ifndef NOSYSMIDI
 #include "systemMidiDevice.h"
+#endif
 #include <SDL_mutex.h>
 #include <SDL_thread.h>
 #include <TFE_Asset/gmidAsset.h>
@@ -86,9 +88,11 @@ namespace TFE_MidiPlayer
 
 	static const char* c_midiDeviceTypes[] =
 	{
-		"System Midi",			// MIDI_TYPE_SYSTEM
 		"SF2 Synthesized Midi", // MIDI_TYPE_SF2
 		"OPL3 Synthesized Midi",// MIDI_TYPE_OPL3
+#ifndef NOSYSMIDI
+		"System Midi",		// MIDI_TYPE_SYSTEM
+#endif
 	};
 
 	bool init(s32 midiDeviceIndex, MidiDeviceType type)
@@ -517,9 +521,11 @@ namespace TFE_MidiPlayer
 
 		switch (type)
 		{
+#ifndef NOSYSMIDI
 			case MIDI_TYPE_SYSTEM:
 				s_midiDevice = new SystemMidiDevice();
 				break;
+#endif
 			case MIDI_TYPE_SF2:
 				s_midiDevice = new SoundFontDevice();
 				break;

--- a/TheForceEngine/TFE_Audio/midiPlayer.h
+++ b/TheForceEngine/TFE_Audio/midiPlayer.h
@@ -5,7 +5,7 @@ struct GMidiAsset;
 
 namespace TFE_MidiPlayer
 {
-	bool init(s32 midiDeviceIndex, MidiDeviceType type = MIDI_TYPE_SYSTEM);
+	bool init(s32 midiDeviceIndex, MidiDeviceType type = MIDI_TYPE_OPL3);
 	void setDeviceType(MidiDeviceType type);
 	MidiDeviceType getDeviceType();
 	void destroy();


### PR DESCRIPTION
If RtMidi library is not found on build system, the System Midi music device will not be build (SF2 and OPL3 will still be available) and the final binary will not require RtMidi at all.

This could be useful for flatpatk/snap and SteamDeck builds since it gets rid of an external dependency.