### PR TITLE
Fixup path expectations for Linux

### DIFF
--- a/TheForceEngine/TFE_A11y/accessibility.cpp
+++ b/TheForceEngine/TFE_A11y/accessibility.cpp
@@ -261,7 +261,9 @@ namespace TFE_A11Y  // a11y is industry slang for accessibility
 		// Then we check the Program directory for subtitle files that shipped with TFE.
 		char programCaptionsDir[TFE_MAX_PATH];
 		const char* programDir = TFE_Paths::getPath(PATH_PROGRAM);
-		sprintf(programCaptionsDir, "%sCaptions/", programDir);
+		sprintf(programCaptionsDir, "%s", "Captions/");
+		if (!TFE_Paths::mapSystemPath(programCaptionsDir))
+			sprintf(programCaptionsDir, "%sCaptions/", programDir);
 		s_captionFileList.addFiles(programCaptionsDir, "txt", filterCaptionFile);
 
 		// Try to load captions for the previously selected language.

--- a/TheForceEngine/TFE_Audio/MidiSynth/soundFontDevice.cpp
+++ b/TheForceEngine/TFE_Audio/MidiSynth/soundFontDevice.cpp
@@ -30,7 +30,9 @@ namespace TFE_Audio
 		{
 			char dir[TFE_MAX_PATH];
 			const char* programDir = TFE_Paths::getPath(PATH_PROGRAM);
-			sprintf(dir, "%sSoundFonts/", programDir);
+			sprintf(dir, "%s", "SoundFonts/");
+			if (!TFE_Paths::mapSystemPath(dir))
+				sprintf(dir, "%sSoundFonts/", programDir);
 
 			FileUtil::readDirectory(dir, "sf2", m_outputs);
 			// Remove the extension.
@@ -92,7 +94,9 @@ namespace TFE_Audio
 
 		char filePath[TFE_MAX_PATH];
 		const char* programDir = TFE_Paths::getPath(PATH_PROGRAM);
-		sprintf(filePath, "%sSoundFonts/%s.sf2", programDir, soundFont);
+		sprintf(filePath, "SoundFonts/%s.sf2", soundFont);
+		if (!TFE_Paths::mapSystemPath(filePath))
+			sprintf(filePath, "%sSoundFonts/%s.sf2", programDir, soundFont);
 
 		m_soundFont = tsf_load_filename(filePath);
 		if (m_soundFont)

--- a/TheForceEngine/TFE_DarkForces/darkForcesMain.cpp
+++ b/TheForceEngine/TFE_DarkForces/darkForcesMain.cpp
@@ -1091,11 +1091,15 @@ namespace TFE_DarkForces
 		sprintf(path, "%sMods/", programData);
 		TFE_Paths::addAbsoluteSearchPath(path);
 
-		sprintf(path, "%sMods/", programDir);
+		sprintf(path, "%s", "Mods/");
+		if (!TFE_Paths::mapSystemPath(path))
+			sprintf(path, "%sMods/", programDir);
 		TFE_Paths::addAbsoluteSearchPath(path);
 
 		// Add the adjustable HUD.
-		sprintf(path, "%sMods/TFE/AdjustableHud", programDir);
+		sprintf(path, "%s", "Mods/TFE/AdjustableHud");
+		if (!TFE_Paths::mapSystemPath(path))
+			sprintf(path, "%sMods/TFE/AdjustableHud", programDir);
 		TFE_Paths::addAbsoluteSearchPath(path);
 	}
 

--- a/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
+++ b/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
@@ -937,7 +937,10 @@ namespace TFE_FrontEndUI
 			char path[TFE_MAX_PATH];
 			char fileName[TFE_MAX_PATH];
 			strcpy(fileName, "Documentation/markdown/TheForceEngineManual.md");
-			TFE_Paths::appendPath(PATH_PROGRAM, fileName, path);
+			if (!TFE_Paths::mapSystemPath(fileName))
+				TFE_Paths::appendPath(PATH_PROGRAM, fileName, path);
+			else
+				strcpy(path, fileName);
 
 			FileStream file;
 			if (file.open(path, Stream::MODE_READ))
@@ -962,7 +965,10 @@ namespace TFE_FrontEndUI
 			char path[TFE_MAX_PATH];
 			char fileName[TFE_MAX_PATH];
 			strcpy(fileName, "Documentation/markdown/credits.md");
-			TFE_Paths::appendPath(PATH_PROGRAM, fileName, path);
+			if (!TFE_Paths::mapSystemPath(fileName))
+				TFE_Paths::appendPath(PATH_PROGRAM, fileName, path);
+			else
+				strcpy(path, fileName);
 
 			FileStream file;
 			if (file.open(path, Stream::MODE_READ))
@@ -987,7 +993,10 @@ namespace TFE_FrontEndUI
 			char path[TFE_MAX_PATH];
 			char fileName[TFE_MAX_PATH];
 			strcpy(fileName, "Documentation/markdown/TheForceEngine.md");
-			TFE_Paths::appendPath(PATH_PROGRAM, fileName, path);
+			if (!TFE_Paths::mapSystemPath(fileName))
+				TFE_Paths::appendPath(PATH_PROGRAM, fileName, path);
+			else
+				strcpy(path, fileName);
 
 			FileStream file;
 			if (file.open(path, Stream::MODE_READ))


### PR DESCRIPTION
Fix up some paths to make Captions, Soundfonts and Manual/Credits work again on Linux when not running from the build directory.

fixes #309 