### PR TITLE
MidiPlayer: select OPL3 as default midi device

### DIFF
--- a/TheForceEngine/TFE_Audio/midiPlayer.cpp
+++ b/TheForceEngine/TFE_Audio/midiPlayer.cpp
@@ -534,6 +534,8 @@ namespace TFE_MidiPlayer
 				break;
 			default:
 				TFE_System::logWrite(LOG_ERROR, "Midi", "Invalid midi type selected: %d", (s32)type);
+				s_midiDevice = new Fm4Opl3Device();
+				break;
 		}
 	}
 }


### PR DESCRIPTION
if an invalid midi-system ID is passed in (e.g. via config file), TFE only complains about it, but this will lead to a crash as soon as the midi device is queried (either Sound settings page or game).

Install the OPL3 device as fallback.