### PR TITLE
Include limits.h in fileutil-posix for PATH_MAX

### DIFF
--- a/TheForceEngine/TFE_FileSystem/fileutil-posix.cpp
+++ b/TheForceEngine/TFE_FileSystem/fileutil-posix.cpp
@@ -2,6 +2,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <libgen.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
PATH_MAX is canonically provided by limits.h

On some systems, like the ones with GLIBC, it just happens that `dirent.h` also includes a header that defines it.