### PR TITLE
CMake: add SDL2-Image include directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ if(LINUX)
 	find_package(OpenGL REQUIRED)
 	target_include_directories(tfe PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 	target_include_directories(tfe PRIVATE ${SDL2_INCLUDE_DIRS})
+	target_include_directories(tfe PRIVATE ${SDL2_IMAGE_INCLUDE_DIRS})
 	target_link_libraries(tfe PRIVATE
 				${OPENGL_LIBRARIES}
 				${GLEW_LIBRARIES}


### PR DESCRIPTION
Some distros decide to package the sdl2-image header files separate from the sdl2 main header directory.
And it's the right thing to do anyway.

Fixes #351 