### PR TITLE
MIDI fixes

### DIFF
--- a/TheForceEngine/TFE_Audio/midiPlayer.cpp
+++ b/TheForceEngine/TFE_Audio/midiPlayer.cpp
@@ -57,6 +57,7 @@ namespace TFE_MidiPlayer
 	static f32 s_masterVolume = 1.0f;
 	static f32 s_masterVolumeScaled = s_masterVolume * c_musicVolumeScale;
 	static SDL_Thread* s_thread = nullptr;
+	static bool s_tPaused = false;
 
 	static atomic_bool s_runMusicThread;
 	static u8 s_channelSrcVolume[MIDI_CHANNEL_COUNT] = { 0 };
@@ -222,6 +223,24 @@ namespace TFE_MidiPlayer
 	void setMaximumNoteLength(f32 dt)
 	{
 		s_maxNoteLength = f64(dt);
+	}
+
+	void pauseThread()
+	{
+		if (!s_tPaused && s_mutex)
+		{
+			SDL_LockMutex(s_mutex);
+			s_tPaused = true;
+		}
+	}
+
+	void resumeThread()
+	{
+		if (s_tPaused && s_mutex)
+		{
+			SDL_UnlockMutex(s_mutex);
+			s_tPaused = false;
+		}
 	}
 
 	void pause()

--- a/TheForceEngine/TFE_Audio/midiPlayer.h
+++ b/TheForceEngine/TFE_Audio/midiPlayer.h
@@ -31,6 +31,9 @@ namespace TFE_MidiPlayer
 	void midiSetCallback(void(*callback)(void) = nullptr, f64 timeStep = 0.0);
 	void midiClearCallback();
 
+	void pauseThread();
+	void resumeThread();
+
 	// Pause the midi player, which also stops all sound channels.
 	void pause();
 	// Resume midi playback from where it left off.

--- a/TheForceEngine/TFE_Audio/systemMidiDevice.h
+++ b/TheForceEngine/TFE_Audio/systemMidiDevice.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <TFE_System/types.h>
+#include <SDL_mutex.h>
 #include "midiDevice.h"
 
 class RtMidiOut;
@@ -36,6 +37,10 @@ namespace TFE_Audio
 	private:
 		RtMidiOut* m_midiout;
 
+		// serialize access to the physical MIDI port, to at least
+		// prevent a buffer overrun in the Linux ALSA MIDI parser.
+		SDL_mutex* portLock = nullptr;
+		
 		s32  m_outputId;
 		FileList m_outputs;
 	};

--- a/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
+++ b/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
@@ -2514,6 +2514,7 @@ namespace TFE_FrontEndUI
 			if (ImGui::Combo("##Midi Type", &curType, (const char*)outputMidiTypeNames, typeCount))
 			{
 				TFE_Audio::pause();
+				TFE_MidiPlayer::pauseThread();
 
 				TFE_MidiPlayer::setDeviceType(MidiDeviceType(curType));
 				device = TFE_MidiPlayer::getMidiDevice();
@@ -2522,7 +2523,8 @@ namespace TFE_FrontEndUI
 					sound->midiType = (s32)device->getType();
 					sound->midiOutput = device->getActiveOutput();
 				}
-				
+
+				TFE_MidiPlayer::resumeThread();
 				TFE_Audio::resume();
 
 				if (s_game) { s_game->restartMusic(); }
@@ -2555,11 +2557,13 @@ namespace TFE_FrontEndUI
 			if (hasChanged)
 			{
 				TFE_Audio::pause();
+				TFE_MidiPlayer::pauseThread();
 
 				device->selectOutput(curOutput);
 				sound->midiType = (s32)device->getType();
 				sound->midiOutput = device->getActiveOutput();
 
+				TFE_MidiPlayer::resumeThread();
 				TFE_Audio::resume();
 
 				if (s_game) { s_game->restartMusic(); }


### PR DESCRIPTION
- Bring back the midiPlayer::suspend/resumeThread() functions.  While POSIX cannot really suspend a thread like windows can, we can effectively block the midi thread by acquiring the lock: this way the thread can complete it's work and won't run until the lock is released.  Should fix lucius' windows crash when switching the midi device.

- introduce a "(Disabled)" device at index 0: RtMidi tends to spam the log with error messages about writing to non-existing ports. This device is always present and moves all bits to /dev/null.
One can then add and remove midi synthesizers on the fly and they'll show up in the settings screen.
