### PR TITLE
[RFC] new path handling prototype

### DIFF
--- a/TheForceEngine/TFE_Audio/MidiSynth/soundFontDevice.h
+++ b/TheForceEngine/TFE_Audio/MidiSynth/soundFontDevice.h
@@ -2,6 +2,7 @@
 #include <TFE_System/types.h>
 #include <TFE_Audio/midiDevice.h>
 #include <TFE_Audio/midi.h>
+#include <TFE_FileSystem/fileutil.h>
 
 struct tsf;
 
@@ -33,10 +34,10 @@ namespace TFE_Audio
 		s32  getActiveOutput(void) override;
 
 	private:
-		bool beginStream(const char* soundFont, s32 sampleRate);
+		bool beginStream(FilePath2& soundFont, s32 sampleRate);
 
 		tsf* m_soundFont;
 		s32  m_outputId;
-		FileList m_outputs;
+		FileList2 m_outputs;
 	};
 };

--- a/TheForceEngine/TFE_FileSystem/fileutil.h
+++ b/TheForceEngine/TFE_FileSystem/fileutil.h
@@ -2,13 +2,44 @@
 #include <TFE_System/types.h>
 #include <vector>
 #include <string>
+#include <tuple>
 
 using namespace std;
 typedef vector<string> FileList;
 
+// tuple of path, filename, extension
+typedef std::tuple<std::string, std::string, std::string> FilePath2;
+// List of Files and their paths
+typedef std::vector<FilePath2> FileList2;
+
+// Get the Filename
+static inline std::string& FL2_NAME(FilePath2& entry)
+{
+	return std::get<1>(entry);
+}
+
+// Get the path to the File
+static inline std::string& FL2_PATH(FilePath2& entry)
+{
+	return std::get<0>(entry);
+}
+
+// Get the extension of the file
+static inline std::string& FL2_EXT(FilePath2& entry)
+{
+	return std::get<2>(entry);
+}
+
+// construct a full absolute path to the file
+static inline std::string FL2_FULLFILE(FilePath2& entry)
+{
+	return FL2_PATH(entry) + FL2_NAME(entry) + "." + FL2_EXT(entry);
+}
+
 namespace FileUtil
 {
 	void readDirectory(const char* dir, const char* ext, FileList& fileList);
+	void readTFEDirectory(const char* dir, const char* ext, FileList2& fileList);
 	bool makeDirectory(const char* dir);
 	void getCurrentDirectory(char* dir);
 	void getExecutionDirectory(char* dir);


### PR DESCRIPTION
Based on comment in #310, I implemented (on linux for now) a new scheme for finding TFE Support files
like SoundFonts, Captions, Shaders, ...

You request the function to return all files from subfolder e.g. "SoundFonts", with extension ".sf2", and
you get back a vector of tuples which contain, in order of path preference, a list of  paths, filenames  and extension.  The function makes sure to read all known paths (PATH_PROGRAM with highest priority, PATH_PROGRAM_DATA with 2nd prio, PATH_USER_DOCUMENTS) with least priority.  The priority determines which file to use in case the name exists in more than one directory.  No file is returned more than once (based on the name of the file).

I've implemented this in the soundfont2 device; and symlinked the user_data soundfont folder to the system soundfont cache:
![image](https://github.com/luciusDXL/TheForceEngine/assets/123231678/7d5419cd-9500-4d3b-8eb8-0b0f7ca4bf12)

I think this could also be used for Captions+Fonts (which uses a similar system filePathList) and Mods.
I've opened this PR just for discussing the idea, so please ignore the fileutil-posix.c changes for now.