### PR TITLE
Misc Fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
+include(CheckCXXCompilerFlag)
 
 set(CMAKE_DISABLE_SOURCE_CHANGES ON)
 set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
@@ -16,6 +17,13 @@ project(TheForceEngine
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+
+## gcc-12+ and clang-15+ have a feature to automatically zero all variables/members/...
+## this mimics what modern MSVC does.  Enable it for release builds (i.e.
+## when not debugging to not hide any real bugs).
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+	check_cxx_compiler_flag("-ftrivial-auto-var-init=zero" COMPILER_ENABLE_AUTOZERO)
+endif()
 
 if (UNIX AND NOT APPLE)
 	set(LINUX ON)
@@ -82,6 +90,10 @@ if(LINUX)
 	create_git_version_h()
 endif()
 
+if(COMPILER_ENABLE_AUTOZERO)
+	message(STATUS "enabled -ftrivial-auto-var-init=zero")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ftrivial-auto-var-init=zero")
+endif()
 
 if(DISABLE_SYSMIDI)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DNOSYSMIDI")

--- a/TheForceEngine/TFE_Audio/MidiSynth/soundFontDevice.cpp
+++ b/TheForceEngine/TFE_Audio/MidiSynth/soundFontDevice.cpp
@@ -38,7 +38,7 @@ namespace TFE_Audio
 			// Remove the extension.
 			for (size_t i = 0; i < m_outputs.size(); i++)
 			{
-				char name[256];
+				char name[TFE_MAX_PATH];
 				FileUtil::getFileNameFromPath(m_outputs[i].c_str(), name);
 				m_outputs[i] = name;
 			}

--- a/TheForceEngine/TFE_DarkForces/Actor/phaseTwo.cpp
+++ b/TheForceEngine/TFE_DarkForces/Actor/phaseTwo.cpp
@@ -44,7 +44,7 @@ namespace TFE_DarkForces
 		JBool noDeath;
 	};
 
-	struct PhaseThreeShared
+	struct PhaseTwoShared
 	{
 		SoundSourceId phase2aSndID = NULL_SOUND;
 		SoundSourceId phase2bSndID = NULL_SOUND;
@@ -52,7 +52,7 @@ namespace TFE_DarkForces
 		SoundSourceId phase2RocketSndID = NULL_SOUND;
 		s32 trooperNum = 0;
 	};
-	static PhaseThreeShared s_shared = {};
+	static PhaseTwoShared s_shared = {};
 	static PhaseTwo* s_curTrooper = nullptr;
 
 	void phaseTwo_exit()


### PR DESCRIPTION
- fix a buffer overrun in the SF2 midi device (Path handling)
- fix a copy-paste error in DF/Actor/phaseTwo (LTO complains about this)
- enable auto-var-zeroing for cmake release builds if compiler supports it (gcc/clang), should fix issues like #363 
