### PR TITLE
A11y: added a new setting to disable player weapon lighting

### DIFF
--- a/TheForceEngine/TFE_DarkForces/player.cpp
+++ b/TheForceEngine/TFE_DarkForces/player.cpp
@@ -2236,7 +2236,15 @@ namespace TFE_DarkForces
 				headlamp = floor16(mul16(batteryPower, FIXED(64)));
 				headlamp = min(MAX_LIGHT_LEVEL, headlamp);
 			}
-			s32 atten = max(headlamp, s_weaponLight + s_levelAtten);
+			s32 atten;
+			if (TFE_Settings::getA11ySettings()->disablePlayerWeaponLighting)
+			{
+				atten = max(headlamp, s_levelAtten);
+			}
+			else
+			{
+				atten = max(headlamp, s_weaponLight + s_levelAtten);
+			}
 			s_baseAtten = atten;
 			if (s_nightvisionActive)
 			{

--- a/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
+++ b/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
@@ -2930,9 +2930,12 @@ namespace TFE_FrontEndUI
 		ImGui::Dummy(ImVec2(0.0f, 10.0f));
 		ImGui::Separator();
 		ImGui::PushFont(s_dialogFont);
-		ImGui::LabelText("##ConfigLabel5", "Misc");
+		ImGui::LabelText("##ConfigLabel5", "Photosensitivity");
 		ImGui::PopFont();
 		ImGui::Checkbox("Disable screen flashes", &a11ySettings->disableScreenFlashes);
+		Tooltip("Disable screen flashes when taking damage or collecting powerups.");
+		ImGui::Checkbox("Disable weapon lighting", &a11ySettings->disablePlayerWeaponLighting);
+		Tooltip("Disable illumination around the player caused by firing weapons.");
 	}
 
 	void pickCurrentResolution()

--- a/TheForceEngine/TFE_Settings/settings.cpp
+++ b/TheForceEngine/TFE_Settings/settings.cpp
@@ -427,6 +427,7 @@ namespace TFE_Settings
 		
 		writeKeyValue_Bool(settings, "enableHeadwave", s_a11ySettings.enableHeadwave);
 		writeKeyValue_Bool(settings, "disableScreenFlashes", s_a11ySettings.disableScreenFlashes);
+		writeKeyValue_Bool(settings, "disablePlayerWeaponLighting", s_a11ySettings.disablePlayerWeaponLighting);
 	}
 
 	void writeGameSettings(FileStream& settings)
@@ -940,6 +941,10 @@ namespace TFE_Settings
 		else if (strcasecmp("disableScreenFlashes", key) == 0)
 		{
 			s_a11ySettings.disableScreenFlashes = parseBool(value);
+		}
+		else if (strcasecmp("disablePlayerWeaponLighting", key) == 0)
+		{
+			s_a11ySettings.disablePlayerWeaponLighting = parseBool(value);
 		}
 	}
 

--- a/TheForceEngine/TFE_Settings/settings.h
+++ b/TheForceEngine/TFE_Settings/settings.h
@@ -237,7 +237,9 @@ struct TFE_Settings_A11y
 
 	// Motion sickness settings
 	bool enableHeadwave = true;
+	// Photosensitivity settings
 	bool disableScreenFlashes = false;
+	bool disablePlayerWeaponLighting = false;
 };
 
 namespace TFE_Settings


### PR DESCRIPTION
Adds a new A11y setting to disable illumination around the player caused by firing the player's weapons. May improve the player experience for players with photosensitive epilepsy or other conditions aggravated by flashing lights.