### PR TITLE
CMake: Revert compiler flag for auto-var-init

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,13 +18,6 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-## gcc-12+ and clang-15+ have a feature to automatically zero all variables/members/...
-## this mimics what modern MSVC does.  Enable it for release builds (i.e.
-## when not debugging to not hide any real bugs).
-if(CMAKE_BUILD_TYPE STREQUAL "Release")
-	check_cxx_compiler_flag("-ftrivial-auto-var-init=zero" COMPILER_ENABLE_AUTOZERO)
-endif()
-
 if (UNIX AND NOT APPLE)
 	set(LINUX ON)
 elseif (UNIX AND APPLE)
@@ -88,11 +81,6 @@ if(LINUX)
 	execute_process(COMMAND ln -sf ${CMAKE_SOURCE_DIR}/TheForceEngine/UI_Text)
 	include(CreateGitVersionH.cmake)
 	create_git_version_h()
-endif()
-
-if(COMPILER_ENABLE_AUTOZERO)
-	message(STATUS "enabled -ftrivial-auto-var-init=zero")
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ftrivial-auto-var-init=zero")
 endif()
 
 if(DISABLE_SYSMIDI)


### PR DESCRIPTION
Remove the use of this flag for now, since gcc DCEs apparently the landru midi code altogether with this.

Fixes #369 