### PR TITLE
Fix 369 properly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,13 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+## gcc-12+ and clang-15+ have a feature to automatically zero all variables/members/...
+## this mimics what modern MSVC does.  Enable it for release builds (i.e.
+## when not debugging to not hide any real bugs).
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+	check_cxx_compiler_flag("-ftrivial-auto-var-init=zero" COMPILER_ENABLE_AUTOZERO)
+endif()
+
 if (UNIX AND NOT APPLE)
 	set(LINUX ON)
 elseif (UNIX AND APPLE)
@@ -81,6 +88,11 @@ if(LINUX)
 	execute_process(COMMAND ln -sf ${CMAKE_SOURCE_DIR}/TheForceEngine/UI_Text)
 	include(CreateGitVersionH.cmake)
 	create_git_version_h()
+endif()
+
+if(COMPILER_ENABLE_AUTOZERO)
+	message(STATUS "enabled -ftrivial-auto-var-init=zero")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ftrivial-auto-var-init=zero")
 endif()
 
 if(DISABLE_SYSMIDI)

--- a/TheForceEngine/TFE_DarkForces/Landru/lmusic.cpp
+++ b/TheForceEngine/TFE_DarkForces/Landru/lmusic.cpp
@@ -71,10 +71,11 @@ namespace TFE_DarkForces
 		const char* fileData = parser.readLine(bufferPos);
 
 		s32 index = 0;
+		s32 sequence = 0;
 		char name[80];
+
 		while (fileData)
 		{
-			s32 sequence;
 			if (sscanf(fileData, "SEQUENCE: %d", &sequence) == 1)
 			{
 				index = 0;


### PR DESCRIPTION
Proper codefix for #369:
- fix the actual bug in the Landru lmusic code
- revert #371, as it can now be enabled again safely (well, ...)

