### PR TITLE
[Fix] Clear color buffers with opaque black instead of transparent black (noop)

### DIFF
--- a/TheForceEngine/TFE_RenderBackend/Win32OpenGL/renderBackend.cpp
+++ b/TheForceEngine/TFE_RenderBackend/Win32OpenGL/renderBackend.cpp
@@ -59,7 +59,7 @@ namespace TFE_RenderBackend
 	static bool s_useRenderTarget = false;
 	static bool s_bloomEnable = false;
 	static DisplayMode s_displayMode;
-	static f32 s_clearColor[4] = { 0.0f };
+	static f32 s_clearColor[4] = { 0.0f, 0.0f, 0.0f, 1.0f };
 	static u32 s_rtWidth, s_rtHeight;
 
 	static Blit* s_postEffectBlit;
@@ -161,7 +161,7 @@ namespace TFE_RenderBackend
 		s_bloomMerge = new BloomMerge();
 		s_bloomMerge->init();
 		
-		glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
+		glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
 		glClearDepth(0.0f);
 
 		s_palette = new DynamicTexture();

--- a/TheForceEngine/TFE_RenderBackend/Win32OpenGL/renderTarget.cpp
+++ b/TheForceEngine/TFE_RenderBackend/Win32OpenGL/renderTarget.cpp
@@ -85,7 +85,7 @@ void RenderTarget::clear(const f32* color, f32 depth, u8 stencil, bool clearColo
 	if (color)
 		glClearColor(color[0], color[1], color[2], color[3]);
 	else
-		glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
+		glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
 
 	u32 clearFlags = clearColor ? GL_COLOR_BUFFER_BIT : 0;
 	if (m_depthBufferHandle)


### PR DESCRIPTION
The current code does functionally a [noop](https://en.wikipedia.org/wiki/NOP_(code) "NOP (code)") but not effectively. Hence, it still costs cycles. This PR does not fix visibly anything but finally does what was originally intended. We get our electron’s worth. :wink:

Btw, clearing color buffers is quite expensive while gaining very little. It is best to avoid doing it. On the other hand, zeroing Z buffers on modern GPUs is very fast.