### PR TITLE
Added workaround for GLEW on wayland

### DIFF
--- a/TheForceEngine/TFE_RenderBackend/Win32OpenGL/renderBackend.cpp
+++ b/TheForceEngine/TFE_RenderBackend/Win32OpenGL/renderBackend.cpp
@@ -109,6 +109,15 @@ namespace TFE_RenderBackend
 		//Sets all functions available
 		glewExperimental = GL_TRUE;
 		const GLenum err = glewInit();
+	#if defined(GLEW_ERROR_NO_GLX_DISPLAY) && !defined(_WIN32)
+		if (err == GLEW_ERROR_NO_GLX_DISPLAY &&
+			strcmp(SDL_GetCurrentVideoDriver(), "wayland") == 0)
+		{
+			// workaround for GLEW on Wayland
+			// see https://github.com/nigels-com/glew/issues/172
+		}
+		else
+	#endif
 		if (err != GLEW_OK)
 		{
 			printf("Failed to initialize GLEW");


### PR DESCRIPTION
This patch adds a workaround to make GLEW initialize successfully on wayland, allowing the force engine to work properly when using wayland on linux, more information and existing workarounds can be found on the following issue:

https://github.com/nigels-com/glew/issues/172

I'm not sure if this kind of workarounds are desired, so feel free to close this PR if you have no desire for such a thing!