### PR TITLE
Enable separate building and packaging of TFE and the “AdjustableHud” mod

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,116 +46,139 @@ endif()
 include(GNUInstallDirs)
 
 ## Options
+option(ENABLE_TFE "Enable building “The Force Engine”" ON)
 option(DISABLE_SYSMIDI "Disable System-MIDI Output" OFF)
 option(ENABLE_EDITOR "Enable TFE Editor" OFF)
 option(ENABLE_FORCE_SCRIPT "Enable Force Script" OFF)
+option(ENABLE_ADJUSTABLEHUD_MOD "Install the build‑in “AdjustableHud mod” with TFE" ON)
 
-add_executable(tfe)
-set_target_properties(tfe PROPERTIES OUTPUT_NAME "theforceengine")
+if(ENABLE_TFE)
+	add_executable(tfe)
+	set_target_properties(tfe PROPERTIES OUTPUT_NAME "theforceengine")
 
-if(LINUX)
-	find_package(PkgConfig REQUIRED)
-	find_package(Threads REQUIRED)
-	find_package(SDL2 2.0.20 REQUIRED)
-	pkg_check_modules(SDL2_IMAGE REQUIRED SDL2_image)
-	pkg_check_modules(GLEW REQUIRED glew)
-	set(OpenGL_GL_PREFERENCE GLVND)
-	find_package(OpenGL REQUIRED)
-	target_include_directories(tfe PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-	target_include_directories(tfe PRIVATE ${SDL2_INCLUDE_DIRS})
-	target_include_directories(tfe PRIVATE ${SDL2_IMAGE_INCLUDE_DIRS})
-	target_link_libraries(tfe PRIVATE
-				${OPENGL_LIBRARIES}
-				${GLEW_LIBRARIES}
-				${SDL2_LIBRARIES}
-				${SDL2_IMAGE_LIBRARIES}
-	)
+	if(LINUX)
+		find_package(PkgConfig REQUIRED)
+		find_package(Threads REQUIRED)
+		find_package(SDL2 2.0.20 REQUIRED)
+		pkg_check_modules(SDL2_IMAGE REQUIRED SDL2_image)
+		pkg_check_modules(GLEW REQUIRED glew)
+		set(OpenGL_GL_PREFERENCE GLVND)
+		find_package(OpenGL REQUIRED)
+		target_include_directories(tfe PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+		target_include_directories(tfe PRIVATE ${SDL2_INCLUDE_DIRS})
+		target_include_directories(tfe PRIVATE ${SDL2_IMAGE_INCLUDE_DIRS})
+		target_link_libraries(tfe PRIVATE
+					${OPENGL_LIBRARIES}
+					${GLEW_LIBRARIES}
+					${SDL2_LIBRARIES}
+					${SDL2_IMAGE_LIBRARIES}
+		)
 
-	if(NOT DISABLE_SYSMIDI)
-		pkg_check_modules(RTMIDI REQUIRED rtmidi>=5.0.0)
-		target_link_libraries(tfe PRIVATE ${RTMIDI_LIBRARIES})
+		if(NOT DISABLE_SYSMIDI)
+			pkg_check_modules(RTMIDI REQUIRED rtmidi>=5.0.0)
+			target_link_libraries(tfe PRIVATE ${RTMIDI_LIBRARIES})
+		endif()
+
+		# set up build directory to be able to run TFE immediately: symlink
+		# the necessary support file directories into the build env.
+		execute_process(COMMAND ln -sf ${CMAKE_SOURCE_DIR}/TheForceEngine/Captions)
+		execute_process(COMMAND ln -sf ${CMAKE_SOURCE_DIR}/TheForceEngine/Documentation)
+		execute_process(COMMAND ln -sf ${CMAKE_SOURCE_DIR}/TheForceEngine/Fonts)
+		execute_process(COMMAND ln -sf ${CMAKE_SOURCE_DIR}/TheForceEngine/Mods)
+		execute_process(COMMAND ln -sf ${CMAKE_SOURCE_DIR}/TheForceEngine/Shaders)
+		execute_process(COMMAND ln -sf ${CMAKE_SOURCE_DIR}/TheForceEngine/SoundFonts)
+		execute_process(COMMAND ln -sf ${CMAKE_SOURCE_DIR}/TheForceEngine/UI_Images)
+		execute_process(COMMAND ln -sf ${CMAKE_SOURCE_DIR}/TheForceEngine/UI_Text)
+		execute_process(COMMAND ln -sf ${CMAKE_SOURCE_DIR}/TheForceEngine/EditorDef)
+		include(CreateGitVersionH.cmake)
+		create_git_version_h()
 	endif()
 
-	# set up build directory to be able to run TFE immediately: symlink
-	# the necessary support file directories into the build env.
-	execute_process(COMMAND ln -sf ${CMAKE_SOURCE_DIR}/TheForceEngine/Captions)
-	execute_process(COMMAND ln -sf ${CMAKE_SOURCE_DIR}/TheForceEngine/Documentation)
-	execute_process(COMMAND ln -sf ${CMAKE_SOURCE_DIR}/TheForceEngine/Fonts)
-	execute_process(COMMAND ln -sf ${CMAKE_SOURCE_DIR}/TheForceEngine/Mods)
-	execute_process(COMMAND ln -sf ${CMAKE_SOURCE_DIR}/TheForceEngine/Shaders)
-	execute_process(COMMAND ln -sf ${CMAKE_SOURCE_DIR}/TheForceEngine/SoundFonts)
-	execute_process(COMMAND ln -sf ${CMAKE_SOURCE_DIR}/TheForceEngine/UI_Images)
-	execute_process(COMMAND ln -sf ${CMAKE_SOURCE_DIR}/TheForceEngine/UI_Text)
-	execute_process(COMMAND ln -sf ${CMAKE_SOURCE_DIR}/TheForceEngine/EditorDef)
-	include(CreateGitVersionH.cmake)
-	create_git_version_h()
+	if(COMPILER_ENABLE_AUTOZERO)
+		message(STATUS "enabled -ftrivial-auto-var-init=zero")
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ftrivial-auto-var-init=zero")
+	endif()
+
+	if(DISABLE_SYSMIDI)
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DNOSYSMIDI")
+	endif()
+	if(ENABLE_EDITOR)
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBUILD_EDITOR")
+	endif()
+	if(ENABLE_FORCE_SCRIPT)
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBUILD_FORCE_SCRIPT")
+	endif()
+
+
+	if(ENABLE_FORCE_SCRIPT)
+		target_include_directories(tfe PRIVATE "TheForceEngine/TFE_ForceScript/Angelscript/angelscript/include")
+		target_include_directories(tfe PRIVATE "TheForceEngine/TFE_ForceScript/Angelscript/add_on")
+	endif()
+	target_include_directories(tfe PRIVATE TheForceEngine)
+
+	add_subdirectory(TheForceEngine/)
 endif()
-
-if(COMPILER_ENABLE_AUTOZERO)
-	message(STATUS "enabled -ftrivial-auto-var-init=zero")
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ftrivial-auto-var-init=zero")
-endif()
-
-if(DISABLE_SYSMIDI)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DNOSYSMIDI")
-endif()
-if(ENABLE_EDITOR)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBUILD_EDITOR")
-endif()
-if(ENABLE_FORCE_SCRIPT)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBUILD_FORCE_SCRIPT")
-endif()
-
-
-if(ENABLE_FORCE_SCRIPT)
-	target_include_directories(tfe PRIVATE "TheForceEngine/TFE_ForceScript/Angelscript/angelscript/include")
-	target_include_directories(tfe PRIVATE "TheForceEngine/TFE_ForceScript/Angelscript/add_on")
-endif()
-target_include_directories(tfe PRIVATE TheForceEngine)
-
-
-add_subdirectory(TheForceEngine/)
-
 
 ### installation ###
 
-# Main binary
-install(TARGETS tfe
-	RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
-	BUNDLE  DESTINATION "${CMAKE_INSTALL_BINDIR}"
-)
+if(ENABLE_TFE)
+	# Main binary
+	install(TARGETS tfe
+		RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+		BUNDLE  DESTINATION "${CMAKE_INSTALL_BINDIR}"
+	)
 
-# Support data
-install(DIRECTORY
-	"${CMAKE_CURRENT_SOURCE_DIR}/TheForceEngine/Captions"
-	"${CMAKE_CURRENT_SOURCE_DIR}/TheForceEngine/Documentation"
-	"${CMAKE_CURRENT_SOURCE_DIR}/TheForceEngine/UI_Text"
-	"${CMAKE_CURRENT_SOURCE_DIR}/TheForceEngine/UI_Images"
-	"${CMAKE_CURRENT_SOURCE_DIR}/TheForceEngine/EditorDef"
-	"${CMAKE_CURRENT_SOURCE_DIR}/TheForceEngine/Shaders"
-	"${CMAKE_CURRENT_SOURCE_DIR}/TheForceEngine/SoundFonts"
-	"${CMAKE_CURRENT_SOURCE_DIR}/TheForceEngine/Fonts"
-	"${CMAKE_CURRENT_SOURCE_DIR}/TheForceEngine/Mods"
-	DESTINATION "${CMAKE_INSTALL_DATADIR}"
-        FILE_PERMISSIONS
-          OWNER_READ OWNER_WRITE
-          GROUP_READ
-          WORLD_READ
-        DIRECTORY_PERMISSIONS
-          OWNER_READ OWNER_EXECUTE OWNER_WRITE
-          GROUP_READ GROUP_EXECUTE GROUP_WRITE
-          WORLD_READ WORLD_EXECUTE
-)
+	# Support data
+	install(DIRECTORY
+		"${CMAKE_CURRENT_SOURCE_DIR}/TheForceEngine/Captions"
+		"${CMAKE_CURRENT_SOURCE_DIR}/TheForceEngine/Documentation"
+		"${CMAKE_CURRENT_SOURCE_DIR}/TheForceEngine/UI_Text"
+		"${CMAKE_CURRENT_SOURCE_DIR}/TheForceEngine/UI_Images"
+		"${CMAKE_CURRENT_SOURCE_DIR}/TheForceEngine/EditorDef"
+		"${CMAKE_CURRENT_SOURCE_DIR}/TheForceEngine/Shaders"
+		"${CMAKE_CURRENT_SOURCE_DIR}/TheForceEngine/SoundFonts"
+		"${CMAKE_CURRENT_SOURCE_DIR}/TheForceEngine/Fonts"
+		DESTINATION "${CMAKE_INSTALL_DATADIR}"
+		    FILE_PERMISSIONS
+		      OWNER_READ OWNER_WRITE
+		      GROUP_READ
+		      WORLD_READ
+		    DIRECTORY_PERMISSIONS
+		      OWNER_READ OWNER_EXECUTE OWNER_WRITE
+		      GROUP_READ GROUP_EXECUTE GROUP_WRITE
+		      WORLD_READ WORLD_EXECUTE
+	)
+	# Always install the “Mods” directory but not always the “AdjustableHud” mod
+	install(DIRECTORY
+		DESTINATION "${CMAKE_INSTALL_DATADIR}/TheForceEngine/Mods"
+		DIRECTORY_PERMISSIONS
+			OWNER_READ OWNER_EXECUTE OWNER_WRITE
+			GROUP_READ GROUP_EXECUTE GROUP_WRITE
+			WORLD_READ WORLD_EXECUTE
+	)
 
-# Linux .desktop files
-if(LINUX)
-	install(
-		FILES "${CMAKE_CURRENT_SOURCE_DIR}/TheForceEngine/io.github.theforceengine.tfe.desktop" DESTINATION "share/applications"
-	)
-	install(
-		FILES "${CMAKE_CURRENT_SOURCE_DIR}/TheForceEngine/io.github.theforceengine.tfe.png" DESTINATION "${TFE_ICONDIR}/256x256/apps"
-	)
-	install(
-		FILES "${CMAKE_CURRENT_SOURCE_DIR}/TheForceEngine/io.github.theforceengine.tfe.metainfo.xml" DESTINATION "share/metainfo"
-	)
+	# Linux .desktop files
+	if(LINUX)
+		install(
+			FILES "${CMAKE_CURRENT_SOURCE_DIR}/TheForceEngine/io.github.theforceengine.tfe.desktop" DESTINATION "share/applications"
+		)
+		install(
+			FILES "${CMAKE_CURRENT_SOURCE_DIR}/TheForceEngine/io.github.theforceengine.tfe.png" DESTINATION "${TFE_ICONDIR}/256x256/apps"
+		)
+		install(
+			FILES "${CMAKE_CURRENT_SOURCE_DIR}/TheForceEngine/io.github.theforceengine.tfe.metainfo.xml"
+			DESTINATION "share/metainfo"
+		)
+	endif()
+endif()
+
+if(ENABLE_ADJUSTABLEHUD_MOD)
+	add_subdirectory(TheForceEngine/Mods/TFE/AdjustableHud)
+
+	if(LINUX)
+		install(
+			FILES "${CMAKE_CURRENT_SOURCE_DIR}/TheForceEngine/io.github.theforceengine.tfe.Mod.AdjustableHud.metainfo.xml"
+			DESTINATION "share/metainfo"
+		)
+	endif()
 endif()

--- a/ProjectStructure.md
+++ b/ProjectStructure.md
@@ -91,3 +91,6 @@ The core system module, this covers the logging system, thread management, non-g
 
 ### TFE_UI
 The low-level UI system used by TFE for the System UI. This is built on top of imGUI, which is also included. This adds extra support such as markdown and file dialogs.
+
+### Mods
+The directory where mods go. Each mod must be placed in a separate sub‑directory.

--- a/README.md
+++ b/README.md
@@ -83,3 +83,11 @@ __sudo make install__
 
 ##### Launch
 * Start the Engine by clicking on the __"The Force Engine"__ Desktop icon or by running  __"theforceengine"__ in a shell.
+
+## Packaging
+TFE comes with the build‑in “[AdjustableHud](TheForceEngine/Mods/TFE/AdjustableHud)” mod. Package maintainers may wish and are encouraged to package “AdjustableHud” into a separate *required* or *recommended* package.
+
+By default TFE builds and installs with the “AdjustableHud” mod. If you do not want to install the “AdjustableHud” mod, for example when building separate packages, configure the CMake build with the `-DENABLE_ADJUSTABLEHUD_MOD=OFF` option. If you want to install the “AdjustableHud” mod only use the `-DENABLE_TFE=OFF` option.
+
+### Freedesktop
+On freedesktop compliant systems package maintainers are encouraged to use the provided [AppStream meta data file](TheForceEngine/io.github.theforceengine.tfe.Mod.AdjustableHud.metadata.xml) when packing the “AdjustableHud” mod into a separate package.

--- a/TheForceEngine/Mods/TFE/AdjustableHud/CMakeLists.txt
+++ b/TheForceEngine/Mods/TFE/AdjustableHud/CMakeLists.txt
@@ -1,0 +1,41 @@
+project(
+	AdjustableHud
+	HOMEPAGE_URL "https://theforceengine.github.io"
+	DESCRIPTION "“The Force Engine’s” built‑in “AdjustableHud” mod"
+)
+
+add_custom_target(
+	${PROJECT_NAME}
+	""
+	SOURCES
+		AdjustableHud.txt
+		Credits.txt
+		HudStatusLeftAddon.bm
+		HudStatusLeftAddon.png
+		HudStatusRightAddon.bm
+		HudStatusRightAddon.png
+	BYPRODUCTS
+		"${CMAKE_INSTALL_DATADIR}/Mods/TFE/${PROJECT_NAME}/AdjustableHud.txt"
+		"${CMAKE_INSTALL_DATADIR}/Mods/TFE/${PROJECT_NAME}/Credits.txt"
+		"${CMAKE_INSTALL_DATADIR}/Mods/TFE/${PROJECT_NAME}/HudStatusLeftAddon.bm"
+		"${CMAKE_INSTALL_DATADIR}/Mods/TFE/${PROJECT_NAME}/HudStatusLeftAddon.png"
+		"${CMAKE_INSTALL_DATADIR}/Mods/TFE/${PROJECT_NAME}/HudStatusRightAddon.bm"
+		"${CMAKE_INSTALL_DATADIR}/Mods/TFE/${PROJECT_NAME}/HudStatusRightAddon.png"
+)
+
+install(
+	DIRECTORY
+		"${CMAKE_CURRENT_SOURCE_DIR}"
+	DESTINATION
+		"${CMAKE_INSTALL_DATADIR}/Mods/TFE"
+	FILE_PERMISSIONS
+		OWNER_READ OWNER_WRITE
+		GROUP_READ
+		WORLD_READ
+	DIRECTORY_PERMISSIONS
+		OWNER_READ OWNER_EXECUTE OWNER_WRITE
+		GROUP_READ GROUP_EXECUTE GROUP_WRITE
+		WORLD_READ WORLD_EXECUTE
+	PATTERN
+		CMakeLists.txt EXCLUDE
+)

--- a/TheForceEngine/io.github.theforceengine.tfe.Mod.AdjustableHud.metainfo.xml
+++ b/TheForceEngine/io.github.theforceengine.tfe.Mod.AdjustableHud.metainfo.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>io.github.theforceengine.tfe.Mod.AdjustableHud</id>
+  <name>The&#x00A0;Force&#x00A0;Engine Adjustable Hud Mod</name>
+  <name xml:lang="de">„The&#x00A0;Force&#x00A0;Engine“ Einstellbare Bildschirmanzeigen Modifikation</name>
+  <name xml:lang="pl">Modyfikacja „The&#x00A0;Force&#x00A0;Engine” ustawiania wskaźników</name>
+  <developer id="com.twitter.dzierzan23">
+    <name>Paweł “Dzierzan” Dzierżanowski</name>
+    <name xml:lang="de">Paweł „Dzierzan“ Dzierżanowski</name>
+    <name xml:lang="pl">Paweł „Dzierzan” Dzierżanowski</name>
+    <url type="homepage">https://twitter.com/Dzierzan23</url>
+  </developer>
+  <summary>A “The&#x00A0;Force&#x00A0;Engine” built&#x2011;in mod enabling adjustable floating HUD elements in “STAR&#x00A0;WARS™:&#x00A0;Dark&#x00A0;Forces”</summary>
+  <summary xml:lang="de">Eine in „The&#x00A0;Force&#x00A0;Engine“ eingebaute Mod, die einstellbar bewegliche Bildschirmanzeigen in „STAR&#x00A0;WARS™:&#x00A0;Dark&#x00A0;Forces“ ermöglicht</summary>
+  <summary xml:lang="pl">W „The&#x00A0;Force&#x00A0;Engine” wbudowana modyfikacja, umożliwiająca ustawianie unoszących się wskaźników w „STAR&#x00A0;WARS™:&#x00A0;Dark&#x00A0;Forces”</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-2.0</project_license>
+  <extends>io.github.theforceengine.tfe</extends>
+  <url type="homepage">https://theforceengine.github.io</url>
+  <url type="bugtracker">https://github.com/luciusDXL/TheForceEngine/issues</url>
+  <url type="help">https://theforceengine.github.io/Documentation.html</url>
+  <url type="vcs-browser">https://github.com/luciusDXL/TheForceEngine/tree/master/TheForceEngine/Mods/TFE/AdjustableHud</url>
+  <description>
+    <p>A “The&#x00A0;Force&#x00A0;Engine” built&#x2011;in mod based on the work by Paweł “Dzierzan” Dzierżanowski. The purpose of the mod is to enable the floating HUD elements in “STAR&#x00A0;WARS™:&#x00A0;Dark&#x00A0;Forces” to be adjustable – specifically being able to move them away from the edges of the screen on widescreen displays.</p>
+    <p xml:lang="de">Eine auf der Arbeit von Paweł „Dzierzan“ Dzierżanowski basierende in „The&#x00A0;Force&#x00A0;Engine“ eingebaute Mod. Die Mod hat zum Zwecke die Einstellbarkeit von beweglichen Bildschirmanzeigen in “STAR&#x00A0;WARS™:&#x00A0;Dark&#x00A0;Forces” zu ermöglichen, insbesondere sie weg von den Rändern auf Breitbildschirmen zu bewegen.</p>
+    <p xml:lang="pl">Wbudowana w „The&#x00A0;Force&#x00A0;Engine” modyfikacja na podstawie pracy Pawła „Dzierzan” Dzierżanowskiego. Celem modyfikacji jest umożliwienie ustawienia unoszących się wskaźników w „STAR&#x00A0;WARS™:&#x00A0;Dark&#x00A0;Forces”, zwłaszcza móc je odsunąć od krawędzi ekranu na szerokich ekranach.</p>
+  </description>
+  <categories>
+    <category>Game</category>
+    <category>Shooter</category>
+    <category>ActionGame</category>
+  </categories>
+  <update_contact>https://theforceengine.github.io</update_contact>
+  <requires>
+    <id>io.github.theforceengine.tfe</id>
+    <internet>offline-only</internet>
+  </requires>
+</component>

--- a/TheForceEngine/io.github.theforceengine.tfe.metainfo.xml
+++ b/TheForceEngine/io.github.theforceengine.tfe.metainfo.xml
@@ -1,16 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
-  <id type="desktop">io.github.theforceengine.tfe</id>
-  <name>The Force Engine</name>
+  <id>io.github.theforceengine.tfe</id>
+  <name>The&#x00A0;Force&#x00A0;Engine</name>
   <developer id="io.github.theforceengine">
-    <name>“The Force Engine” Contributors</name>
-    <name xml:lang="de">Die Mitwirkenden an „The Force Engine“</name>
-    <name xml:lang="pl">Współautorzy „The Force Engine”</name>
+    <name>“The&#x00A0;Force&#x00A0;Engine” Contributors</name>
+    <name xml:lang="de">Die Mitwirkenden an „The&#x00A0;Force&#x00A0;Engine“</name>
+    <name xml:lang="pl">Współautorzy „The&#x00A0;Force&#x00A0;Engine”</name>
     <url type="homepage">https://theforceengine.github.io</url>
   </developer>
-  <summary>A modern cross&#x2011;platform port of “STAR WARS: Dark Forces” with mod support</summary>
-  <summary xml:lang="de">Eine moderne Plattformen übergreifende Portierung von „STAR WARS: Dark Forces“ mit Unterstützung für Modifikationen</summary>
-  <summary xml:lang="pl">Nowoczesna wieloplatformowa konwersja „STAR WARS: Dark Forces” z obsługą modyfikacji</summary>
+  <summary>A modern cross&#x2011;platform port of “STAR&#x00A0;WARS™:&#x00A0;Dark&#x00A0;Forces” with mod support</summary>
+  <summary xml:lang="de">Eine moderne Plattformen übergreifende Portierung von „STAR&#x00A0;WARS™:&#x00A0;Dark&#x00A0;Forces“ mit Unterstützung für Modifikationen</summary>
+  <summary xml:lang="pl">Nowoczesna wieloplatformowa konwersja „STAR&#x00A0;WARS™:&#x00A0;Dark&#x00A0;Forces” z obsługą modyfikacji</summary>
+  <icon type="remote" width="256" height="256">https://raw.githubusercontent.com/luciusDXL/TheForceEngine/master/TheForceEngine/io.github.theforceengine.tfe.png</icon>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0</project_license>
   <launchable type="desktop-id">io.github.theforceengine.tfe.desktop</launchable>
@@ -19,13 +20,13 @@
   <url type="help">https://theforceengine.github.io/Documentation.html</url>
   <url type="vcs-browser">https://github.com/luciusDXL/TheForceEngine</url>
   <description>
-    <p>“The Force Engine” is a modernised, reverse engineered port of the “Jedi Engine” used in “STAR WARS: Dark Forces” and “Outlaws”. Currently, only “STAR WARS: Dark Forces” is supported but there are already many technical and quality&#x2011;of&#x2011;life improvements:</p>
-    <p xml:lang="de">„The Force Engine“ ist eine modernisierte, rekonstruierte Portierung der in „STAR WARS: Dark Forces“ und „Outlaws“ verwendeten „Jedi Engine“. Derzeit wird ausschließlich „STAR WARS: Dark Forces“ unterstützt, aber es gibt bereits viele technische und das Leben erleichternde Verbesserungen:</p>
-    <p xml:lang="en-US">“The Force Engine” is a modernized, reverse engineered port of the “Jedi Engine” used in “STAR WARS: Dark Forces” and “Outlaws”. Currently, only “STAR WARS: Dark Forces” is supported but there are already many technical and quality&#x2011;of&#x2011;life improvements:</p>
-    <p xml:lang="pl">„The Force Engine”, to unowocześniona konwersja, odwrotnie inżynierowanego „Jedi Engine”, który wykorzystywano do „STAR WARS: Dark Forces” i „Outlaws”. Na ten czas, wyłącznie „STAR WARS: Dark Forces” jest obsługiwane, lecz istnieje już wiele technicznych i życie ułatwiających ulepszeń:</p>
+    <p>“The&#x00A0;Force&#x00A0;Engine” is a modernised, reverse engineered port of the “Jedi&#x00A0;Engine” used in “STAR&#x00A0;WARS™:&#x00A0;Dark&#x00A0;Forces” and “Outlaws”. Currently, only “STAR&#x00A0;WARS™:&#x00A0;Dark&#x00A0;Forces” is supported but there are already many technical and quality&#x2011;of&#x2011;life improvements:</p>
+    <p xml:lang="de">„The&#x00A0;Force&#x00A0;Engine“ ist eine modernisierte, rekonstruierte Portierung der in „STAR&#x00A0;WARS™:&#x00A0;Dark&#x00A0;Forces“ und „Outlaws“ verwendeten „Jedi&#x00A0;Engine“. Derzeit wird ausschließlich „STAR&#x00A0;WARS™:&#x00A0;Dark&#x00A0;Forces“ unterstützt, aber es gibt bereits viele technische und das Leben erleichternde Verbesserungen:</p>
+    <p xml:lang="en-US">“The&#x00A0;Force&#x00A0;Engine” is a modernized, reverse engineered port of the “Jedi&#x00A0;Engine” used in “STAR&#x00A0;WARS™:&#x00A0;Dark&#x00A0;Forces” and “Outlaws”. Currently, only “STAR&#x00A0;WARS™:&#x00A0;Dark&#x00A0;Forces” is supported but there are already many technical and quality&#x2011;of&#x2011;life improvements:</p>
+    <p xml:lang="pl">„The&#x00A0;Force&#x00A0;Engine”, to unowocześniona konwersja, odwrotnie inżynierowanego „Jedi&#x00A0;Engine”, który wykorzystywano do „STAR&#x00A0;WARS™:&#x00A0;Dark&#x00A0;Forces” i „Outlaws”. Na ten czas, wyłącznie „STAR&#x00A0;WARS™:&#x00A0;Dark&#x00A0;Forces” jest obsługiwane, lecz istnieje już wiele technicznych i życie ułatwiających ulepszeń:</p>
     <ul>
       <li>Controller support (except in menus)</li>
-      <li xml:lang="de">Unterstützung von Steuer&#2011; und Eingabegeräten, ausgenommen in Menüs</li>
+      <li xml:lang="de">Unterstützung von Steuer&#x2011; und Eingabegeräten, ausgenommen in Menüs</li>
       <li xml:lang="pl">Obsługa kontrolerów, za wyjątkiem w menu</li>
       <li>Support for mouselook like in modern first&#x2011;person shooters</li>
       <li xml:lang="de">Unterstützung von Mausumsicht, wie in modernen Ego&#x2011;Shootern</li>
@@ -107,4 +108,30 @@
   <provides>
     <binary>theforceengine</binary>
   </provides>
+  <keywords>
+    <keyword>STAR</keyword>
+    <keyword xml:lang="de">Sterne</keyword>
+    <keyword xml:lang="pl">gwiezdne</keyword>
+    <keyword>WARS</keyword>
+    <keyword xml:lang="de">Krieg</keyword>
+    <keyword xml:lang="pl">wojny</keyword>
+    <keyword>Dark</keyword>
+    <keyword>Forces</keyword>
+    <keyword>Trooper</keyword>
+    <keyword>FPS</keyword>
+    <keyword>first</keyword>
+    <keyword>person</keyword>
+    <keyword>shooter</keyword>
+    <keyword xml:lang="de">Schießerei</keyword>
+    <keyword xml:lang="pl">strzelanka</keyword>
+    <keyword>Kyle</keyword>
+    <keyword>Katarn</keyword>
+    <keyword>Jan</keyword>
+    <keyword>Ors</keyword>
+    <keyword>Death</keyword>
+    <keyword xml:lang="pl">śmierci</keyword>
+    <keyword>Star</keyword>
+    <keyword xml:lang="pl">gwiazda</keyword>
+    <keyword xml:lang="de">Todesstern</keyword>
+  </keywords>
 </component>


### PR DESCRIPTION
Improves the life of package maintainers and paves the way for integrated mod distribution.

Conceptually, building the “AdjustableHud” mod should have been its own CMake target. But, since CMake is conceptually flawed in general and thus custom build target support in CMake is either incomplete or just a disgrace to implement, we have to go the ugly route of adding build configuration options. Yes, it is ugly but it works and is obviously so intended by CMake devs.