### PR TITLE
Rename functions and variables for consistency & code readability

### DIFF
--- a/TheForceEngine/TFE_Jedi/InfSystem/infSystem.cpp
+++ b/TheForceEngine/TFE_Jedi/InfSystem/infSystem.cpp
@@ -3467,7 +3467,7 @@ namespace TFE_Jedi
 	fixed16_16 infUpdate_moveWall(InfElevator* elev, fixed16_16 delta)
 	{
 		// First attempt to move walls in the sector.
-		if (!sector_moveWalls(elev->sector, delta, elev->dirOrCenter.x, elev->dirOrCenter.z, elev->flags))
+		if (!sector_canMoveWalls(elev->sector, delta, elev->dirOrCenter.x, elev->dirOrCenter.z, elev->flags))
 		{
 			return elev->iValue;
 		}
@@ -3476,7 +3476,7 @@ namespace TFE_Jedi
 		Slave* child = (Slave*)allocator_getHead(elev->slaves);
 		while (child)
 		{
-			sector_moveWalls(child->sector, delta, elev->dirOrCenter.x, elev->dirOrCenter.z, elev->flags);
+			sector_canMoveWalls(child->sector, delta, elev->dirOrCenter.x, elev->dirOrCenter.z, elev->flags);
 			child = (Slave*)allocator_getNext(elev->slaves);
 		}
 

--- a/TheForceEngine/TFE_Jedi/Level/rsector.cpp
+++ b/TheForceEngine/TFE_Jedi/Level/rsector.cpp
@@ -29,7 +29,7 @@ namespace TFE_Jedi
 	void sector_computeWallDirAndLength(RWall* wall);
 	void sector_moveWallVertex(RWall* wall, fixed16_16 offsetX, fixed16_16 offsetZ);
 	JBool sector_objOverlapsWall(RWall* wall, SecObject* obj, s32* objSide);
-	JBool sector_isWallBlockedByPlayer(RWall* wall, fixed16_16 offsetX, fixed16_16 offsetZ);
+	JBool sector_movingWallCollidesWithPlayer(RWall* wall, fixed16_16 offsetX, fixed16_16 offsetZ);
 	void sector_moveObjects(RSector* sector, u32 flags, fixed16_16 offsetX, fixed16_16 offsetZ);
 
 	f32 isLeft(Vec2f p0, Vec2f p1, Vec2f p2);
@@ -229,29 +229,29 @@ namespace TFE_Jedi
 		return maxObjHeight;
 	}
 			
-	JBool sector_moveWalls(RSector* sector, fixed16_16 delta, fixed16_16 dirX, fixed16_16 dirZ, u32 flags)
+	JBool sector_canMoveWalls(RSector* sector, fixed16_16 delta, fixed16_16 dirX, fixed16_16 dirZ, u32 flags)
 	{
 		fixed16_16 offsetX = mul16(delta, dirX);
 		fixed16_16 offsetZ = mul16(delta, dirZ);
 
-		JBool sectorBlocked = JFALSE;
+		JBool playerCollides = JFALSE;
 		s32 wallCount = sector->wallCount;
 		RWall* wall = sector->walls;
-		for (s32 i = 0; i < wallCount && !sectorBlocked; i++, wall++)
+		for (s32 i = 0; i < wallCount && !playerCollides; i++, wall++)
 		{
 			if (wall->flags1 & WF1_WALL_MORPHS)
 			{
-				sectorBlocked |= sector_isWallBlockedByPlayer(wall, offsetX, offsetZ);
+				playerCollides |= sector_movingWallCollidesWithPlayer(wall, offsetX, offsetZ);
 
 				RWall* mirror = wall->mirrorWall;
 				if (mirror && (mirror->flags1 & WF1_WALL_MORPHS))
 				{
-					sectorBlocked |= sector_isWallBlockedByPlayer(mirror, offsetX, offsetZ);
+					playerCollides |= sector_movingWallCollidesWithPlayer(mirror, offsetX, offsetZ);
 				}
 			}
 		}
 
-		if (!sectorBlocked)
+		if (!playerCollides)
 		{
 			sector->dirtyFlags |= SDF_VERTICES;
 
@@ -273,7 +273,7 @@ namespace TFE_Jedi
 			sector_computeBounds(sector);
 		}
 
-		return ~sectorBlocked;
+		return ~playerCollides;
 	}
 
 	void sector_changeWallLight(RSector* sector, fixed16_16 delta)
@@ -1167,7 +1167,7 @@ namespace TFE_Jedi
 	}
 
 	// returns 0 if the wall is free to move, else non-zero.
-	JBool sector_isWallBlockedByPlayer(RWall* wall, fixed16_16 offsetX, fixed16_16 offsetZ)
+	JBool sector_movingWallCollidesWithPlayer(RWall* wall, fixed16_16 offsetX, fixed16_16 offsetZ)
 	{
 		// Test the initial position, the code assumes there is no collision at this point.
 		s32 objSide0 = 0;

--- a/TheForceEngine/TFE_Jedi/Level/rsector.h
+++ b/TheForceEngine/TFE_Jedi/Level/rsector.h
@@ -142,7 +142,7 @@ namespace TFE_Jedi
 	void sector_computeBounds(RSector* sector);
 
 	fixed16_16 sector_getMaxObjectHeight(RSector* sector);
-	JBool sector_moveWalls(RSector* sector, fixed16_16 delta, fixed16_16 dirX, fixed16_16 dirZ, u32 flags);
+	JBool sector_canMoveWalls(RSector* sector, fixed16_16 delta, fixed16_16 dirX, fixed16_16 dirZ, u32 flags);
 	void  sector_changeWallLight(RSector* sector, fixed16_16 delta);
 	void  sector_scrollWalls(RSector* sector, fixed16_16 offsetX, fixed16_16 offsetZ);
 


### PR DESCRIPTION
As discussed in discord

https://discord.com/channels/799331202821521458/911332436707774535/1221183710733406208

The function & variable names for the morph_move and morph_spin elevators will now mirror each other.