### PR TITLE
New optional setting: observe "solid wall" flag when testing if object overlaps a wall

### DIFF
--- a/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
+++ b/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
@@ -3129,6 +3129,7 @@ namespace TFE_FrontEndUI
 				gameSettings->df_bobaFettFacePlayer = true;
 				gameSettings->df_smoothVUEs = true;
 				gameSettings->df_pitchLimit = (temp == TEMPLATE_MODERN) ? PITCH_MAXIMUM : PITCH_VANILLA_PLUS;
+				gameSettings->df_solidWallFlagFix = true;
 				// Graphics
 				graphicsSettings->rendererIndex = RENDERER_HARDWARE;
 				graphicsSettings->skyMode = SKYMODE_CYLINDER;

--- a/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
+++ b/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
@@ -1167,6 +1167,12 @@ namespace TFE_FrontEndUI
 			gameSettings->df_ignoreInfLimit = ignoreInfLimit;
 		}
 
+		bool solidWallFlagFix = gameSettings->df_solidWallFlagFix;
+		if (ImGui::Checkbox("Enforce solid wall flag for moving walls", &solidWallFlagFix))
+		{
+			gameSettings->df_solidWallFlagFix = solidWallFlagFix;
+		}
+
 		if (s_drawNoGameDataMsg)
 		{
 			ImGui::Separator();
@@ -3171,6 +3177,7 @@ namespace TFE_FrontEndUI
 				gameSettings->df_showSecretFoundMsg = false;
 				gameSettings->df_bobaFettFacePlayer = false;
 				gameSettings->df_smoothVUEs = false;
+				gameSettings->df_solidWallFlagFix = false;
 				// Graphics
 				graphicsSettings->rendererIndex = RENDERER_SOFTWARE;
 				graphicsSettings->widescreen = false;

--- a/TheForceEngine/TFE_Jedi/Level/rsector.cpp
+++ b/TheForceEngine/TFE_Jedi/Level/rsector.cpp
@@ -13,6 +13,7 @@
 #include <TFE_Jedi/Collision/collision.h>
 #include <TFE_Jedi/InfSystem/infSystem.h>
 #include <TFE_Jedi/InfSystem/message.h>
+#include <TFE_Settings/settings.h>
 // TODO: Find a better way to handle this.
 #include <TFE_Jedi/InfSystem/infTypesInternal.h>
 
@@ -1129,13 +1130,17 @@ namespace TFE_Jedi
 		RSector* next = wall->nextSector;
 		if (next)
 		{
-			RSector* sector = wall->sector;
-			if (sector->floorHeight >= obj->posWS.y)
+			TFE_Settings_Game* gameSettings = TFE_Settings::getGameSettings();
+			if (!gameSettings->df_solidWallFlagFix || !(wall->flags3 & WF3_SOLID_WALL || wall->mirrorWall->flags3 & WF3_SOLID_WALL))
 			{
-				fixed16_16 objTop = obj->posWS.y - obj->worldHeight;
-				if (sector->ceilingHeight < objTop)
+				RSector* sector = wall->sector;
+				if (sector->floorHeight >= obj->posWS.y)
 				{
-					return JFALSE;
+					fixed16_16 objTop = obj->posWS.y - obj->worldHeight;
+					if (sector->ceilingHeight < objTop)
+					{
+						return JFALSE;
+					}
 				}
 			}
 		}

--- a/TheForceEngine/TFE_Settings/settings.cpp
+++ b/TheForceEngine/TFE_Settings/settings.cpp
@@ -462,6 +462,7 @@ namespace TFE_Settings
 				writeKeyValue_Bool(settings, "crouchToggle", s_gameSettings.df_crouchToggle);
 				writeKeyValue_Bool(settings, "ignoreInfLimit", s_gameSettings.df_ignoreInfLimit);
 				writeKeyValue_Int(settings, "pitchLimit", s_gameSettings.df_pitchLimit);
+				writeKeyValue_Bool(settings, "solidWallFlagFix", s_gameSettings.df_solidWallFlagFix);
 			}
 		}
 	}
@@ -1034,6 +1035,10 @@ namespace TFE_Settings
 		else if (strcasecmp("pitchLimit", key) == 0)
 		{
 			s_gameSettings.df_pitchLimit = PitchLimit(parseInt(value));
+		}
+		else if (strcasecmp("solidWallFlagFix", key) == 0)
+		{
+			s_gameSettings.df_solidWallFlagFix = parseBool(value);
 		}
 	}
 

--- a/TheForceEngine/TFE_Settings/settings.h
+++ b/TheForceEngine/TFE_Settings/settings.h
@@ -205,7 +205,7 @@ struct TFE_Settings_Game
 	bool df_autorun = false;			// Run by default instead of walk.
 	bool df_crouchToggle = false;		// Use toggle instead of hold for crouch.
 	bool df_ignoreInfLimit = true;		// Ignore the vanilla INF limit.
-	bool df_solidWallFlagFix = false;	// Solid wall flag is enforced for collision with moving walls.
+	bool df_solidWallFlagFix = true;	// Solid wall flag is enforced for collision with moving walls.
 	PitchLimit df_pitchLimit  = PITCH_VANILLA_PLUS;
 };
 

--- a/TheForceEngine/TFE_Settings/settings.h
+++ b/TheForceEngine/TFE_Settings/settings.h
@@ -205,6 +205,7 @@ struct TFE_Settings_Game
 	bool df_autorun = false;			// Run by default instead of walk.
 	bool df_crouchToggle = false;		// Use toggle instead of hold for crouch.
 	bool df_ignoreInfLimit = true;		// Ignore the vanilla INF limit.
+	bool df_solidWallFlagFix = false;	// Solid wall flag is enforced for collision with moving walls.
 	PitchLimit df_pitchLimit  = PITCH_VANILLA_PLUS;
 };
 


### PR DESCRIPTION
This will cause the player to collide with a "solid" adjoined wall that is moving or rotating
Results in a fix for maps like Harkov and Dark Tide 3 which feature a morph_move or morph_spin elevator surrounded by "solid" adjoined walls to simulate riding in a vehicle
