### PR TITLE
TFE_Asset: fix copy-paste bug in hd sprite asset cleanup

### DIFF
--- a/TheForceEngine/TFE_Asset/spriteAsset_Jedi.cpp
+++ b/TheForceEngine/TFE_Asset/spriteAsset_Jedi.cpp
@@ -712,7 +712,7 @@ namespace TFE_Sprite_Jedi
 
 		const size_t hdWaxCount = s_hdSpriteList[pool].size();
 		HdWax** hdWaxList = s_hdSpriteList[pool].data();
-		for (size_t i = 0; i < waxCount; i++)
+		for (size_t i = 0; i < hdWaxCount; i++)
 		{
 			for (s32 e = 0; e < hdWaxList[i]->entryCount; e++)
 			{


### PR DESCRIPTION
This fixes a copy-paste bug which leads to a crash on shutdown when no HD assets are available.
```
Thread 1 "theforceengine" received signal SIGSEGV, Segmentation fault.
TFE_Sprite_Jedi::freePool (pool=pool@entry=POOL_GAME) at TheForceEngine/TFE_Asset/spriteAsset_Jedi.cpp: 717
717                             for (s32 e = 0; e < hdWaxList[i]->entryCount; e++)
```