### PR TITLE
Fixes for GCC LTO (Link Time Optimizations)

### DIFF
--- a/TheForceEngine/TFE_Asset/levelObjectsAsset.cpp
+++ b/TheForceEngine/TFE_Asset/levelObjectsAsset.cpp
@@ -17,7 +17,7 @@ namespace TFE_LevelObjects
 
 	bool parseObjects();
 	ObjectClass getObjectClass(const char* name);
-	LogicType getLogicType(const char* name);
+	AssetLogicType getLogicType(const char* name);
 
 	bool load(const char* name)
 	{
@@ -112,7 +112,7 @@ namespace TFE_LevelObjects
 
 			// Logics
 			const u32 logicCount = (u32)obj->logics.size();
-			const Logic* logic = obj->logics.data();
+			const AssetLogic* logic = obj->logics.data();
 			bool isScenery = false;
 			for (u32 l = 0; l < logicCount; l++, logic++)
 			{
@@ -193,7 +193,7 @@ namespace TFE_LevelObjects
 		u32 objectIndex = 0;
 		u32 podIndex=0, sprIndex=0, fmeIndex=0, sndIndex=0;
 		LevelObject* object = nullptr;
-		Logic* logic = nullptr;
+		AssetLogic* logic = nullptr;
 		EnemyGenerator* generator = nullptr;
 		bool sequence = false;
 		while (bufferPos < len)
@@ -453,13 +453,13 @@ namespace TFE_LevelObjects
 		return CLASS_INAVLID;
 	}
 
-	LogicType getLogicType(const char* name)
+	AssetLogicType getLogicType(const char* name)
 	{
 		for (u32 i = 0; i < LOGIC_COUNT; i++)
 		{
 			if (strcasecmp(name, c_logicName[i]) == 0)
 			{
-				return LogicType(i);
+				return AssetLogicType(i);
 			}
 		}
 		assert(0);

--- a/TheForceEngine/TFE_Asset/levelObjectsAsset.h
+++ b/TheForceEngine/TFE_Asset/levelObjectsAsset.h
@@ -33,7 +33,7 @@ enum Difficulty
 // Will not generate enemies when the player can see the generator.
 struct EnemyGenerator
 {
-	LogicType type;		// type of enemy to be generated.
+	AssetLogicType type;		// type of enemy to be generated.
 	f32 delay;			// time in seconds that needs to pass from the start of a level before the generator starts operating.
 	f32 interval;		// time in seconds between each generation.
 	f32 minDist;		// min/max distance from player when enemy can be generated.
@@ -45,9 +45,9 @@ struct EnemyGenerator
 // For Scripts
 typedef EnemyGenerator GenParam;
 
-struct Logic
+struct AssetLogic
 {
-	LogicType type = LOGIC_INVALID;
+	AssetLogicType type = LOGIC_INVALID;
 	u32 flags      = 0;		// logic specific flags.
 	f32 frameRate  = 0.0f;
 	Vec3f rotation = { 0.0f, 0.0f, 0.0f };
@@ -58,7 +58,7 @@ struct Logic
 	s32 vueAppendId = -1;
 };
 // For scripts
-typedef Logic LogicParam;
+typedef AssetLogic LogicParam;
 
 struct LevelObject
 {
@@ -75,7 +75,7 @@ struct LevelObject
 	f32 height = 0.0f;
 
 	// Logics
-	std::vector<Logic> logics;
+	std::vector<AssetLogic> logics;
 	std::vector<EnemyGenerator> generators;
 };
 

--- a/TheForceEngine/TFE_Asset/logicTypes.h
+++ b/TheForceEngine/TFE_Asset/logicTypes.h
@@ -4,7 +4,7 @@
 //////////////////////////////////////////////////////////////////////
 #include <TFE_System/types.h>
 
-enum LogicType
+enum AssetLogicType
 {
 	// Player
 	LOGIC_PLAYER,		//  Player controlled object

--- a/TheForceEngine/TFE_DarkForces/Actor/actor.cpp
+++ b/TheForceEngine/TFE_DarkForces/Actor/actor.cpp
@@ -177,6 +177,8 @@ namespace TFE_DarkForces
 	ActorDispatch* actor_createDispatch(SecObject* obj, LogicSetupFunc* setupFunc)
 	{
 		ActorDispatch* dispatch = (ActorDispatch*)allocator_newItem(s_istate.actorDispatch);
+		if (!dispatch)
+			return nullptr;
 		memset(dispatch->modules, 0, sizeof(ActorModule*) * 6);
 
 		dispatch->moveMod = nullptr;

--- a/TheForceEngine/TFE_DarkForces/Actor/actorSerialization.cpp
+++ b/TheForceEngine/TFE_DarkForces/Actor/actorSerialization.cpp
@@ -58,6 +58,8 @@ namespace TFE_DarkForces
 		else
 		{
 			dispatch = (ActorDispatch*)allocator_newItem(s_istate.actorDispatch);
+			if (!dispatch)
+				return;
 			memset(dispatch, 0, sizeof(ActorDispatch));
 
 			logic = (Logic*)dispatch;

--- a/TheForceEngine/TFE_DarkForces/Landru/ldraw.cpp
+++ b/TheForceEngine/TFE_DarkForces/Landru/ldraw.cpp
@@ -18,36 +18,36 @@ namespace TFE_DarkForces
 		s32 bitmapWidth = 0;
 		s32 bitmapHeight = 0;
 	};
-	static LDrawState s_state = {};
+	static LDrawState ldraw_state = {};
 
 	void ldraw_init(s16 w, s16 h)
 	{
-		if (w != s_state.bitmapWidth || h != s_state.bitmapHeight || !s_state.bitmap)
+		if (w != ldraw_state.bitmapWidth || h != ldraw_state.bitmapHeight || !ldraw_state.bitmap)
 		{
-			landru_free(s_state.bitmap);
-			s_state.bitmap = (u8*)landru_alloc(w * h);
-			memset(s_state.bitmap, 0, w * h);
+			landru_free(ldraw_state.bitmap);
+			ldraw_state.bitmap = (u8*)landru_alloc(w * h);
+			memset(ldraw_state.bitmap, 0, w * h);
 
-			s_state.bitmapWidth  = w;
-			s_state.bitmapHeight = h;
+			ldraw_state.bitmapWidth  = w;
+			ldraw_state.bitmapHeight = h;
 		}
 	}
 
 	void ldraw_destroy()
 	{
-		landru_free(s_state.bitmap);
-		s_state = {};
+		landru_free(ldraw_state.bitmap);
+		ldraw_state = {};
 	}
 
 	u8* ldraw_getBitmap()
 	{
-		return s_state.bitmap;
+		return ldraw_state.bitmap;
 	}
 
 	JBool drawClippedColorRect(LRect* rect, u8 color)
 	{
-		u8* framebuffer  = s_state.bitmap;
-		const u32 stride = s_state.bitmapWidth;
+		u8* framebuffer  = ldraw_state.bitmap;
+		const u32 stride = ldraw_state.bitmapWidth;
 
 		LRect clipRect;
 		lcanvas_getClip(&clipRect);
@@ -154,13 +154,13 @@ namespace TFE_DarkForces
 
 	void deltaImage(s16* data, s16 x, s16 y)
 	{
-		drawDeltaIntoBitmap(data, x, y, s_state.bitmap, s_state.bitmapWidth);
+		drawDeltaIntoBitmap(data, x, y, ldraw_state.bitmap, ldraw_state.bitmapWidth);
 	}
 
 	void deltaClip(s16* data, s16 x, s16 y)
 	{
-		u8* framebuffer = s_state.bitmap;
-		const u32 stride = s_state.bitmapWidth;
+		u8* framebuffer = ldraw_state.bitmap;
+		const u32 stride = ldraw_state.bitmapWidth;
 
 		LRect clipRect;
 		lcanvas_getClip(&clipRect);
@@ -233,8 +233,8 @@ namespace TFE_DarkForces
 
 	void deltaFlip(s16* data, s16 x, s16 y, s16 w)
 	{
-		u8* framebuffer = s_state.bitmap;
-		const u32 stride = s_state.bitmapWidth;
+		u8* framebuffer = ldraw_state.bitmap;
+		const u32 stride = ldraw_state.bitmapWidth;
 
 		const u8* srcImage = (u8*)data;
 		while (1)
@@ -295,8 +295,8 @@ namespace TFE_DarkForces
 
 	void deltaFlipClip(s16* data, s16 x, s16 y, s16 w)
 	{
-		u8* framebuffer = s_state.bitmap;
-		const u32 stride = s_state.bitmapWidth;
+		u8* framebuffer = ldraw_state.bitmap;
+		const u32 stride = ldraw_state.bitmapWidth;
 
 		LRect clipRect;
 		lcanvas_getClip(&clipRect);

--- a/TheForceEngine/TFE_DarkForces/animLogic.cpp
+++ b/TheForceEngine/TFE_DarkForces/animLogic.cpp
@@ -114,6 +114,8 @@ namespace TFE_DarkForces
 		}
 
 		SpriteAnimLogic* anim = (SpriteAnimLogic*)allocator_newItem(s_spriteAnimList);
+		if (!anim)
+			return nullptr;
 		const WaxAnim* waxAnim = WAX_AnimPtr(obj->wax, 0);
 
 		obj_addLogic(obj, (Logic*)anim, LOGIC_ANIM, s_spriteAnimTask, spriteAnimLogicCleanupFunc);
@@ -153,10 +155,14 @@ namespace TFE_DarkForces
 			if (!s_spriteAnimList)
 			{
 				s_spriteAnimList = allocator_create(sizeof(SpriteAnimLogic));
+				if (!s_spriteAnimList)
+					return;
 			}
 			task_makeActive(s_spriteAnimTask);
 
 			anim = (SpriteAnimLogic*)allocator_newItem(s_spriteAnimList);
+			if (!anim)
+				return;
 			logic = (Logic*)anim;
 		}
 		SERIALIZE(ObjState_InitVersion, anim->firstFrame, 0);

--- a/TheForceEngine/TFE_DarkForces/generator.cpp
+++ b/TheForceEngine/TFE_DarkForces/generator.cpp
@@ -133,6 +133,8 @@ namespace TFE_DarkForces
 					}
 
 					SecObject** entityPtr = (SecObject**)allocator_newItem(gen->entities);
+					if (!entityPtr)
+						return;
 					*entityPtr = spawn;
 					actor_removeRandomCorpse();
 				}
@@ -330,6 +332,8 @@ namespace TFE_DarkForces
 				if (entityId < 0) { continue; }
 
 				SecObject** entityPtr = (SecObject**)allocator_newItem(gen->entities);
+				if (!entityPtr)
+					return;
 				*entityPtr = objData_getObjectBySerializationId_NoValidation(entityId);
 			}
 		}

--- a/TheForceEngine/TFE_DarkForces/hitEffect.cpp
+++ b/TheForceEngine/TFE_DarkForces/hitEffect.cpp
@@ -245,6 +245,8 @@ namespace TFE_DarkForces
 		if (hitEffectId != HEFFECT_NONE)
 		{
 			HitEffect* effect = (HitEffect*)allocator_newItem(s_hitEffects);
+			if (!effect)
+				return;
 			effect->type = hitEffectId;
 			effect->sector = sector;
 			effect->x = pos.x;

--- a/TheForceEngine/TFE_DarkForces/logic.cpp
+++ b/TheForceEngine/TFE_DarkForces/logic.cpp
@@ -55,6 +55,8 @@ namespace TFE_DarkForces
 		}
 
 		Logic** logicItem = (Logic**)allocator_newItem((Allocator*)obj->logic);
+		if (!logicItem)
+			return;
 		*logicItem = logic;
 		logic->obj = obj;
 		logic->type = type;

--- a/TheForceEngine/TFE_DarkForces/projectile.cpp
+++ b/TheForceEngine/TFE_DarkForces/projectile.cpp
@@ -157,7 +157,14 @@ namespace TFE_DarkForces
 	Logic* createProjectile(ProjectileType type, RSector* sector, fixed16_16 x, fixed16_16 y, fixed16_16 z, SecObject* obj)
 	{
 		ProjectileLogic* projLogic = (ProjectileLogic*)allocator_newItem(s_projectiles);
+		if (!projLogic)
+			return nullptr;
 		SecObject* projObj = allocateObject();
+		if (!projObj)
+		{
+			allocator_deleteItem(s_projectiles, projLogic);
+			return nullptr;
+		}
 
 		projObj->entityFlags |= ETFLAG_PROJECTILE;
 		projObj->flags &= ~OBJ_FLAG_MOVABLE;
@@ -1592,6 +1599,8 @@ namespace TFE_DarkForces
 		else
 		{
 			proj = (ProjectileLogic*)allocator_newItem(s_projectiles);
+			if (!proj)
+				return;
 			logic = (Logic*)proj;
 
 			proj->logic.task = s_projectileTask;

--- a/TheForceEngine/TFE_DarkForces/sound.cpp
+++ b/TheForceEngine/TFE_DarkForces/sound.cpp
@@ -51,7 +51,7 @@ namespace TFE_DarkForces
 	static const s32 c_soundInstanceMask = 0x7fff;
 	static const s32 s_tPan[32] = { 00,-06,-12,-18,-24,-30,-36,-42,-48,-42,-36,-30,-24,-18,-12,-06,00,06,12,18,24,30,36,42,48,42,36,30,24,18,12,06 };
 	
-	static SoundState s_state = {};
+	static SoundState sound_state = {};
 	s32 s_lastMaintainVolume;
 
 	SoundEffectId soundInstance(SoundSourceId soundId, s32 instance);
@@ -64,8 +64,8 @@ namespace TFE_DarkForces
 	// Called at game startup and shutdown.
 	void sound_open(MemoryRegion* memRegion)
 	{
-		s_state = {};
-		s_state.gameSoundList = allocator_create(sizeof(GameSound), s_gameRegion);
+		sound_state = {};
+		sound_state.gameSoundList = allocator_create(sizeof(GameSound), s_gameRegion);
 		ImInitialize(memRegion);
 		
 		TFE_Settings_Sound* sound = TFE_Settings::getSoundSettings();
@@ -78,9 +78,9 @@ namespace TFE_DarkForces
 	void sound_close()
 	{
 		sound_levelStop();
-		allocator_free(s_state.gameSoundList);
+		allocator_free(sound_state.gameSoundList);
 		ImTerminate();
-		s_state = {};
+		sound_state = {};
 	}
 
 	// Called at level startup and shutdown.
@@ -91,7 +91,7 @@ namespace TFE_DarkForces
 		TFE_MidiPlayer::setVolume(soundSettings->musicVolume * soundSettings->masterVolume);
 
 		ImSetResourceCallback(sound_getResource);
-		s_state.instance = 1;
+		sound_state.instance = 1;
 
 		// Unload any existing level sounds.
 		sound_clearLevelSounds();
@@ -107,12 +107,12 @@ namespace TFE_DarkForces
 	{
 		if (!id) { return -1; }
 		GameSound* sound = getSoundPtr(id);
-		return allocator_getIndex(s_state.gameSoundList, sound);
+		return allocator_getIndex(sound_state.gameSoundList, sound);
 	}
 
 	SoundSourceId sound_getSoundFromIndex(s32 index, bool refCount)
 	{
-		GameSound* sound = (GameSound*)allocator_getByIndex(s_state.gameSoundList, index);
+		GameSound* sound = (GameSound*)allocator_getByIndex(sound_state.gameSoundList, index);
 		if (sound)
 		{
 			if (refCount) { sound->refCount++; }
@@ -123,7 +123,7 @@ namespace TFE_DarkForces
 		
 	void sound_setLevelStart()
 	{
-		s_state.soundLevelStart = allocator_getCount(s_state.gameSoundList);
+		sound_state.soundLevelStart = allocator_getCount(sound_state.gameSoundList);
 	}
 
 	void sound_serializeLevelSounds(Stream* stream)
@@ -131,23 +131,23 @@ namespace TFE_DarkForces
 		s32 count;
 		if (serialization_getMode() == SMODE_WRITE)
 		{
-			count = max(0, allocator_getCount(s_state.gameSoundList) - s_state.soundLevelStart);
+			count = max(0, allocator_getCount(sound_state.gameSoundList) - sound_state.soundLevelStart);
 		}
 		SERIALIZE(SaveVersionInit, count, 0);
 		if (serialization_getMode() == SMODE_WRITE)
 		{
-			allocator_saveIter(s_state.gameSoundList);
-			allocator_setPos(s_state.gameSoundList, s_state.soundLevelStart);
-			GameSound* sound = (GameSound*)allocator_getIter(s_state.gameSoundList);
+			allocator_saveIter(sound_state.gameSoundList);
+			allocator_setPos(sound_state.gameSoundList, sound_state.soundLevelStart);
+			GameSound* sound = (GameSound*)allocator_getIter(sound_state.gameSoundList);
 			while (sound)
 			{
 				u8 length = (u8)strlen(sound->name);
 				SERIALIZE(SaveVersionInit, length, 0);
 				SERIALIZE_BUF(SaveVersionInit, sound->name, length);
 				SERIALIZE(SaveVersionInit, sound->priority, 64);
-				sound = (GameSound*)allocator_getNext(s_state.gameSoundList);
+				sound = (GameSound*)allocator_getNext(sound_state.gameSoundList);
 			}
-			allocator_restoreIter(s_state.gameSoundList);
+			allocator_restoreIter(sound_state.gameSoundList);
 		}
 		else
 		{
@@ -168,20 +168,20 @@ namespace TFE_DarkForces
 
 	void sound_clearLevelSounds()
 	{
-		if (s_state.soundLevelStart < 0) { return; }
-		allocator_setPos(s_state.gameSoundList, s_state.soundLevelStart);
-		GameSound* sound = (GameSound*)allocator_getIter(s_state.gameSoundList);
+		if (sound_state.soundLevelStart < 0) { return; }
+		allocator_setPos(sound_state.gameSoundList, sound_state.soundLevelStart);
+		GameSound* sound = (GameSound*)allocator_getIter(sound_state.gameSoundList);
 		while (sound)
 		{
 			sound_alwaysFree(sound);
-			sound = (GameSound*)allocator_getNext(s_state.gameSoundList);
+			sound = (GameSound*)allocator_getNext(sound_state.gameSoundList);
 		}
 	}
 
 	SoundSourceId sound_load(const char* fileName, u32 priority)
 	{
 		SoundSourceId newId = NULL_SOUND;
-		GameSound* sound = (GameSound*)allocator_getHead(s_state.gameSoundList);
+		GameSound* sound = (GameSound*)allocator_getHead(sound_state.gameSoundList);
 		while (sound)
 		{
 			if (!strcasecmp(fileName, sound->name))
@@ -189,14 +189,14 @@ namespace TFE_DarkForces
 				sound->refCount++;
 				return soundInstance((SoundSourceId)sound, 0);
 			}
-			sound = (GameSound*)allocator_getNext(s_state.gameSoundList);
+			sound = (GameSound*)allocator_getNext(sound_state.gameSoundList);
 		}
 
 		u32 size = 0;
 		u8* data = readVocFileData(fileName, &size);
 		if (data)
 		{
-			sound = (GameSound*)allocator_newItem(s_state.gameSoundList);
+			sound = (GameSound*)allocator_newItem(sound_state.gameSoundList);
 			sound->id = (SoundSourceId)sound;
 			sound->time = s_curTick;
 			sound->data = data;
@@ -225,7 +225,7 @@ namespace TFE_DarkForces
 					game_free(sound->data);
 				}
 				sound->data = nullptr;
-				allocator_deleteItem(s_state.gameSoundList, sound);
+				allocator_deleteItem(sound_state.gameSoundList, sound);
 			}
 		}
 	}
@@ -239,7 +239,7 @@ namespace TFE_DarkForces
 				game_free(sound->data);
 			}
 			sound->data = nullptr;
-			allocator_deleteItem(s_state.gameSoundList, sound);
+			allocator_deleteItem(sound_state.gameSoundList, sound);
 		}
 	}
 
@@ -279,7 +279,7 @@ namespace TFE_DarkForces
 		if (!id) { return 0; }
 
 		GameSound* sound = getSoundPtr(id);
-		SoundEffectId idInstance = soundInstance(sound->id, s_state.instance++);
+		SoundEffectId idInstance = soundInstance(sound->id, sound_state.instance++);
 
 		if (!sound->data)
 		{

--- a/TheForceEngine/TFE_DarkForces/sound.cpp
+++ b/TheForceEngine/TFE_DarkForces/sound.cpp
@@ -197,6 +197,8 @@ namespace TFE_DarkForces
 		if (data)
 		{
 			sound = (GameSound*)allocator_newItem(sound_state.gameSoundList);
+			if (!sound)
+				return NULL_SOUND;
 			sound->id = (SoundSourceId)sound;
 			sound->time = s_curTick;
 			sound->data = data;

--- a/TheForceEngine/TFE_DarkForces/updateLogic.cpp
+++ b/TheForceEngine/TFE_DarkForces/updateLogic.cpp
@@ -81,6 +81,8 @@ namespace TFE_DarkForces
 		if (!s_logicUpdateList)
 		{
 			s_logicUpdateList = allocator_create(sizeof(UpdateLogic));
+			if (!s_logicUpdateList)
+				return nullptr;
 		}
 		if (!s_logicUpdateTask)
 		{
@@ -92,6 +94,8 @@ namespace TFE_DarkForces
 		}
 
 		UpdateLogic* updateLogic = (UpdateLogic*)allocator_newItem(s_logicUpdateList);
+		if (!updateLogic)
+			return nullptr;
 		updateLogic->flags = ULFLAG_ALL;
 		updateLogic->zVel = 0;
 		updateLogic->yVel = 0;
@@ -104,8 +108,12 @@ namespace TFE_DarkForces
 		if (!obj->logic)
 		{
 			obj->logic = allocator_create(sizeof(Logic**));
+			if (!obj->logic)
+				return nullptr;
 		}
 		Logic** logicItem = (Logic**)allocator_newItem((Allocator*)obj->logic);
+		if (!logicItem)
+			return nullptr;
 		*logicItem = (Logic*)updateLogic;
 
 		updateLogic->logic.obj = obj;

--- a/TheForceEngine/TFE_DarkForces/vueLogic.cpp
+++ b/TheForceEngine/TFE_DarkForces/vueLogic.cpp
@@ -194,6 +194,8 @@ namespace TFE_DarkForces
 			for (s32 i = 0; i < frameCount; i++)
 			{
 				VueFrame* frame = (VueFrame*)allocator_newItem(vueLogic->frames);
+				if (!frame)
+					return;
 				SERIALIZE(ObjState_InitVersion, (*frame), { 0 });
 			}
 		}
@@ -222,6 +224,8 @@ namespace TFE_DarkForces
 					y1 = -y1;
 					y2 = -y2;
 					VueFrame* frame = (VueFrame*)allocator_newItem(vueList);
+					if (!frame)
+						return;
 					frame->offset.x = floatToFixed16(x1);
 					frame->offset.y = floatToFixed16(y1);
 					frame->offset.z = floatToFixed16(z1);
@@ -262,6 +266,8 @@ namespace TFE_DarkForces
 			mtx1[8] = 1;
 
 			VueFrame* frame = (VueFrame*)allocator_newItem(vueList);
+			if (!frame)
+				return;
 			frame->flags = VFRAME_FIRST;
 
 			while (1)
@@ -281,6 +287,8 @@ namespace TFE_DarkForces
 					if (transformName[0] == '*' || strcasecmp(name, transformName) == 0)
 					{
 						frame = (VueFrame*)allocator_newItem(vueList);
+						if (!frame)
+							return;
 
 						// Rotation/Scale matrix.
 						fixed16_16 frameMtx[9];
@@ -627,6 +635,8 @@ namespace TFE_DarkForces
 							const fixed16_16 MAX_INTERP_DISTANCE = FIXED(2500); // FIXED(50 * 50)
 
 							if (!local(interpolatedFrame)) { local(interpolatedFrame) = (VueFrame*)allocator_newItem(local(vue)->frames); }
+							if (!local(interpolatedFrame))
+								return;
 							if (local(frame) && local(current) && local(previous))
 							{
 								const fixed16_16 dist = fixedSquaredDistance(local(current)->offset, local(previous)->offset);

--- a/TheForceEngine/TFE_Jedi/InfSystem/infState.cpp
+++ b/TheForceEngine/TFE_Jedi/InfSystem/infState.cpp
@@ -111,6 +111,8 @@ namespace TFE_Jedi
 					linkSector->infLink = allocator_create(sizeof(InfLink));
 				}
 				elevLink = (InfLink*)allocator_newItem(linkSector->infLink);
+				if (!elevLink)
+					return;
 			}
 		}
 		if (elevLink)
@@ -152,6 +154,8 @@ namespace TFE_Jedi
 			for (s32 s = 0; s < stopCount; s++)
 			{
 				Stop* stop = (Stop*)allocator_newItem(elev->stops);
+				if (!stop)
+					return;
 				inf_serializeStop(stream, stop);
 			}
 
@@ -190,6 +194,8 @@ namespace TFE_Jedi
 			for (s32 s = 0; s < slaveCount; s++)
 			{
 				Slave* slave = (Slave*)allocator_newItem(elev->slaves);
+				if (!slave)
+					return;
 				inf_serializeSlave(stream, slave);
 			}
 		}
@@ -280,6 +286,8 @@ namespace TFE_Jedi
 				}
 				Allocator* parent = linkSector->infLink;
 				InfLink* link = (InfLink*)allocator_newItem(parent);
+				if (!link)
+					return;
 				inf_serializeLink(stream, link, parent);
 			}
 		}
@@ -379,6 +387,8 @@ namespace TFE_Jedi
 				}
 				parent = parentSector->infLink;
 				link = (InfLink*)allocator_newItem(parentSector->infLink);
+				if (!link)
+					return;
 			}
 			else if (parentSector && parentWallIndex >= 0)
 			{
@@ -390,6 +400,8 @@ namespace TFE_Jedi
 				parent = wall->infLink;
 				triggerWall = wall;
 				link = (InfLink*)allocator_newItem(wall->infLink);
+				if (!link)
+					return;
 			}
 			trigger->link = link;
 		}
@@ -420,6 +432,8 @@ namespace TFE_Jedi
 			for (s32 i = 0; i < targetCount; i++)
 			{
 				TriggerTarget* target = (TriggerTarget*)allocator_newItem(trigger->targets);
+				if (!target)
+					return;
 				inf_serializeTarget(stream, target);
 			}
 		}
@@ -512,6 +526,8 @@ namespace TFE_Jedi
 			for (s32 i = 0; i < elevCount; i++)
 			{
 				InfElevator* elev = (InfElevator*)allocator_newItem(s_infSerState.infElevators);
+				if (!elev)
+					return;
 				inf_serializeElevator(stream, elev);
 			}
 		}
@@ -533,6 +549,8 @@ namespace TFE_Jedi
 			for (s32 i = 0; i < teleCount; i++)
 			{
 				Teleport* teleport = (Teleport*)allocator_newItem(s_infSerState.infTeleports);
+				if (!teleport)
+					return;
 				inf_serializeTeleport(stream, teleport);
 			}
 		}
@@ -554,6 +572,8 @@ namespace TFE_Jedi
 			for (s32 i = 0; i < trigCount; i++)
 			{
 				InfTrigger* trigger = (InfTrigger*)allocator_newItem(s_infSerState.infTriggers);
+				if (!trigger)
+					return;
 				inf_serializeTrigger(stream, trigger);
 			}
 		}
@@ -658,6 +678,8 @@ namespace TFE_Jedi
 			for (s32 m = 0; m < msgCount; m++)
 			{
 				InfMessage* msg = (InfMessage*)allocator_newItem(stop->messages);
+				if (!msg)
+					return;
 				inf_serializeMessage(stream, msg);
 			}
 		}
@@ -686,6 +708,8 @@ namespace TFE_Jedi
 			for (s32 a = 0; a < adjCount; a++)
 			{
 				AdjoinCmd* adjCmd = (AdjoinCmd*)allocator_newItem(stop->adjoinCmds);
+				if (!adjCmd)
+					return;
 				inf_serializeAdjoin(stream, stop, adjCmd);
 			}
 		}

--- a/TheForceEngine/TFE_Jedi/InfSystem/infSystem.cpp
+++ b/TheForceEngine/TFE_Jedi/InfSystem/infSystem.cpp
@@ -140,6 +140,8 @@ namespace TFE_Jedi
 	InfLink* allocateLink(Allocator* infLinks, InfElevator* elev)
 	{
 		InfLink* link = (InfLink*)allocator_newItem(infLinks);
+		if (!link)
+			return nullptr;
 		link->type = LTYPE_SECTOR;
 		link->entityMask = INF_ENTITY_PLAYER;
 		link->eventMask = INF_EVENT_NONE;
@@ -165,6 +167,8 @@ namespace TFE_Jedi
 		s32 index = allocator_getCount(stops);
 
 		Stop* stop = (Stop*)allocator_newItem(stops);
+		if (!stop)
+			return nullptr;
 		stop->value = 0;
 		stop->delay = TICKS(4);	// 4 seconds.
 		stop->messages = 0;
@@ -240,6 +244,8 @@ namespace TFE_Jedi
 	InfElevator* inf_allocateElevItem(RSector* sector, InfElevatorType type)
 	{
 		InfElevator* elev = (InfElevator*)allocator_newItem(s_infSerState.infElevators);
+		if (!elev)
+			return nullptr;
 		elev->trigMove = TRIGMOVE_HOLD;
 		elev->key = KEY_NONE;
 		elev->fixedStep = 0;
@@ -659,6 +665,8 @@ namespace TFE_Jedi
 			elev->slaves = allocator_create(sizeof(Slave));
 		}
 		Slave* slave = (Slave*)allocator_newItem(elev->slaves);
+		if (!slave)
+			return;
 		slave->sector = sector;
 		slave->value = value;
 	}
@@ -671,6 +679,8 @@ namespace TFE_Jedi
 	TriggerTarget* inf_addTriggerTarget(InfTrigger* trigger, RSector* targetSector, RWall* targetWall, u32 eventMask)
 	{
 		TriggerTarget* target = (TriggerTarget*)allocator_newItem(trigger->targets);
+		if (!target)
+			return nullptr;
 		target->sector = targetSector;
 		target->wall = targetWall;
 		target->eventMask = eventMask;
@@ -681,6 +691,8 @@ namespace TFE_Jedi
 	Teleport* inf_createTeleport(TeleportType type, RSector* sector)
 	{
 		Teleport* teleport = (Teleport*)allocator_newItem(s_infSerState.infTeleports);
+		if (!teleport)
+			return nullptr;
 		teleport->dstAngle[0] = 0;
 		teleport->dstAngle[1] = 0;
 		teleport->dstAngle[2] = 0;
@@ -694,6 +706,8 @@ namespace TFE_Jedi
 		}
 
 		InfLink* link = (InfLink*)allocator_newItem(sector->infLink);
+		if (!link)
+			return nullptr;
 		link->type = LTYPE_TELEPORT;
 		link->entityMask = INF_ENTITY_ANY;
 		link->eventMask = INF_EVENT_ENTER_SECTOR;
@@ -2048,6 +2062,8 @@ namespace TFE_Jedi
 						stop->adjoinCmds = allocator_create(sizeof(AdjoinCmd));
 					}
 					AdjoinCmd* adjoinCmd = (AdjoinCmd*)allocator_newItem(stop->adjoinCmds);
+					if (!adjoinCmd)
+						return JFALSE;
 					MessageAddress* msgAddr0 = message_getAddress(s_infArg1);
 					MessageAddress* msgAddr1 = message_getAddress(s_infArg3);
 					RSector* sector0 = msgAddr0->sector;
@@ -2106,6 +2122,8 @@ namespace TFE_Jedi
 					}
 
 					InfMessage* msg = (InfMessage*)allocator_newItem(stop->messages);
+					if (!msg)
+						return JFALSE;
 					RSector* targetSector;
 					RWall* targetWall;
 					inf_getMessageTarget(s_infArg1, &targetSector, &targetWall);
@@ -3240,6 +3258,8 @@ namespace TFE_Jedi
 	InfTrigger* inf_createTrigger(TriggerType type, InfTriggerObject obj)
 	{
 		InfTrigger* trigger = (InfTrigger*)allocator_newItem(s_infSerState.infTriggers);
+		if (!trigger)
+			return nullptr;
 		memset(trigger, 0, sizeof(InfTrigger));
 		s_infSerState.activeTriggerCount++;
 
@@ -3258,6 +3278,8 @@ namespace TFE_Jedi
 					wall->infLink = allocator_create(sizeof(InfLink));
 				}
 				link = (InfLink*)allocator_newItem(wall->infLink);
+				if (!link)
+					return nullptr;
 				link->type = LTYPE_TRIGGER;
 				link->entityMask = INF_ENTITY_PLAYER;
 				link->eventMask = INF_EVENT_ANY;
@@ -3275,6 +3297,8 @@ namespace TFE_Jedi
 					sector->infLink = allocator_create(sizeof(InfLink));
 				}
 				link = (InfLink*)allocator_newItem(sector->infLink);
+				if (!link)
+					return nullptr;
 				link->type = LTYPE_TRIGGER;
 				link->entityMask = INF_ENTITY_PLAYER;
 				link->eventMask = INF_EVENT_ANY;
@@ -3295,6 +3319,8 @@ namespace TFE_Jedi
 					wall->infLink = allocator_create(sizeof(InfLink));
 				}
 				link = (InfLink*)allocator_newItem(wall->infLink);
+				if (!link)
+					return nullptr;
 				link->type = LTYPE_TRIGGER;
 				link->entityMask = INF_ENTITY_PLAYER;
 				link->eventMask = INF_EVENT_ANY;

--- a/TheForceEngine/TFE_Jedi/InfSystem/message.cpp
+++ b/TheForceEngine/TFE_Jedi/InfSystem/message.cpp
@@ -35,6 +35,8 @@ namespace TFE_Jedi
 			s_messageAddr = allocator_create(sizeof(MessageAddress));
 		}
 		MessageAddress* msgAddr = (MessageAddress*)allocator_newItem(s_messageAddr);
+		if (!msgAddr)
+			return;
 
 		assert(strlen(name) <= 16);
 		strncpy(msgAddr->name, name, 16);

--- a/TheForceEngine/TFE_Jedi/Level/level.cpp
+++ b/TheForceEngine/TFE_Jedi/Level/level.cpp
@@ -691,6 +691,8 @@ namespace TFE_Jedi
 			s_levelIntState.ambientSoundTask = createSubTask("AmbientSound", ambientSoundTaskFunc);
 		}
 		AmbientSound* ambientSound = (AmbientSound*)allocator_newItem(s_levelState.ambientSounds);
+		if (!ambientSound)
+			return;
 		ambientSound->soundId = soundId;
 		ambientSound->instanceId = 0;
 		ambientSound->pos = pos;
@@ -958,6 +960,8 @@ namespace TFE_Jedi
 									s_levelState.safeLoc = allocator_create(sizeof(Safe));
 								}
 								Safe* safe = (Safe*)allocator_newItem(s_levelState.safeLoc);
+								if (!safe)
+									return JFALSE;
 								safe->sector = sector;
 								safe->x = obj->posWS.x;
 								safe->z = obj->posWS.z;
@@ -986,6 +990,8 @@ namespace TFE_Jedi
 									s_levelState.safeLoc = allocator_create(sizeof(Safe));
 								}
 								Safe* safe = (Safe*)allocator_newItem(s_levelState.safeLoc);
+								if (!safe)
+									return JFALSE;
 								safe->sector = obj->sector;
 								safe->x = obj->posWS.x;
 								safe->z = obj->posWS.z;

--- a/TheForceEngine/TFE_Jedi/Level/levelData.cpp
+++ b/TheForceEngine/TFE_Jedi/Level/levelData.cpp
@@ -193,6 +193,8 @@ namespace TFE_Jedi
 				for (s32 s = 0; s < safeCount; s++)
 				{
 					Safe* safe = (Safe*)allocator_newItem(s_levelState.safeLoc);
+					if (!safe)
+						return;
 					level_serializeSafe(stream, safe);
 				}
 			}
@@ -206,6 +208,8 @@ namespace TFE_Jedi
 				for (s32 s = 0; s < ambientSoundCount; s++)
 				{
 					AmbientSound* sound = (AmbientSound*)allocator_newItem(s_levelState.ambientSounds);
+					if (!sound)
+						return;
 					level_serializeAmbientSound(stream, sound);
 				}
 				if (!s_levelIntState.ambientSoundTask)

--- a/TheForceEngine/TFE_Jedi/Level/robjData.cpp
+++ b/TheForceEngine/TFE_Jedi/Level/robjData.cpp
@@ -227,6 +227,8 @@ namespace TFE_Jedi
 					if (!logic) { continue; }
 
 					Logic** logicItem = (Logic**)allocator_newItem((Allocator*)obj->logic);
+					if (!logicItem)
+						return;
 					logic->parent = logicItem;
 					logic->obj = obj;
 					*logicItem = logic;

--- a/TheForceEngine/TFE_Jedi/Level/rtexture.cpp
+++ b/TheForceEngine/TFE_Jedi/Level/rtexture.cpp
@@ -551,6 +551,8 @@ namespace TFE_Jedi
 		// In the original DOS code, this is directly set to pointers. But since TFE is compiled as 64-bit, pointers are not the correct size.
 		const u32* textureOffsets = (u32*)(tex->image + 2);
 		AnimatedTexture* anim = (AnimatedTexture*)allocator_newItem(s_texState.textureAnimAlloc);
+		if (!anim)
+			return nullptr;
 
 		// 64 bit pointers are larger than the offsets, so we have to allocate more space (for now).
 		anim->frame = 0;

--- a/TheForceEngine/TFE_Jedi/Renderer/RClassic_GPU/modelGPU.cpp
+++ b/TheForceEngine/TFE_Jedi/Renderer/RClassic_GPU/modelGPU.cpp
@@ -102,7 +102,7 @@ namespace TFE_Jedi
 
 	static ModelShaderSettings s_shaderSettings = {};
 
-	struct ShaderInputs
+	struct ShaderInputsMGPU
 	{
 		s32 cameraPosId;
 		s32 cameraViewId;
@@ -119,7 +119,7 @@ namespace TFE_Jedi
 		s32 palFxFlash;
 		s32 textureSettings;
 	};
-	static ShaderInputs s_shaderInputs[MGPU_SHADER_COUNT];
+	static ShaderInputsMGPU s_shaderInputs[MGPU_SHADER_COUNT];
 	static std::vector<ModelDraw> s_modelDrawList[MGPU_SHADER_COUNT];
 
 	extern Mat3  s_cameraMtx;

--- a/TheForceEngine/TFE_Jedi/Renderer/RClassic_GPU/rsectorGPU.cpp
+++ b/TheForceEngine/TFE_Jedi/Renderer/RClassic_GPU/rsectorGPU.cpp
@@ -79,7 +79,7 @@ namespace TFE_Jedi
 		Frustum  frustum;
 		RWall*   wall;
 	};
-	struct ShaderInputs
+	struct ShaderInputsGPU
 	{
 		s32 cameraPosId;
 		s32 cameraViewId;
@@ -107,7 +107,7 @@ namespace TFE_Jedi
 	static ShaderBuffer s_wallGpuBuffer;
 	static Shader s_spriteShader;
 	static Shader s_wallShader[SECTOR_PASS_COUNT];
-	static ShaderInputs s_shaderInputs[SECTOR_PASS_COUNT + 1];
+	static ShaderInputsGPU s_shaderInputs[SECTOR_PASS_COUNT + 1];
 	static ShaderSkyInputs s_shaderSkyInputs[SECTOR_PASS_COUNT];
 	static s32 s_cameraRightId;
 
@@ -132,7 +132,7 @@ namespace TFE_Jedi
 	static bool s_mipmapping = false;
 	static bool s_forceTextureUpdate = false;
 
-	struct ShaderSettings
+	struct ShaderSettingsSGPU
 	{
 		SkyMode skyMode = SKYMODE_CYLINDER;
 		bool colormapInterp = false;
@@ -141,7 +141,7 @@ namespace TFE_Jedi
 		bool trueColor = false;
 	};
 
-	static ShaderSettings s_shaderSettings = {};
+	static ShaderSettingsSGPU s_shaderSettings = {};
 	static RSector* s_clipSector;
 	static Vec3f s_clipObjPos;
 
@@ -1832,7 +1832,7 @@ namespace TFE_Jedi
 		TexturePacker* texturePacker = texturepacker_getGlobal();
 		const TextureGpu* palette  = TFE_RenderBackend::getPaletteTexture();
 		const TextureGpu* textures = texturePacker->texture;
-		const ShaderInputs* inputs = &s_shaderInputs[pass];
+		const ShaderInputsGPU* inputs = &s_shaderInputs[pass];
 		const ShaderSkyInputs* skyInputs = &s_shaderSkyInputs[pass];
 		const ShaderBuffer* textureTable = &texturePacker->textureTableGPU;
 

--- a/TheForceEngine/TFE_Jedi/Renderer/RClassic_GPU/screenDrawGPU.cpp
+++ b/TheForceEngine/TFE_Jedi/Renderer/RClassic_GPU/screenDrawGPU.cpp
@@ -54,12 +54,12 @@ namespace TFE_Jedi
 	static u32 s_scrQuadsWidth;
 	static u32 s_scrQuadsHeight;
 
-	struct ShaderSettings
+	struct ShaderSettingsSDGPU
 	{
 		bool bloom = false;
 		bool trueColor = false;
 	};
-	static ShaderSettings s_shaderSettings = {};
+	static ShaderSettingsSDGPU s_shaderSettings = {};
 
 	enum Constants
 	{

--- a/TheForceEngine/TFE_RenderShared/modelDraw.cpp
+++ b/TheForceEngine/TFE_RenderShared/modelDraw.cpp
@@ -37,7 +37,7 @@ namespace TFE_RenderShared
 		TexProjection proj;
 	};
 	
-	struct ShaderState
+	struct ShaderStateMDRAW
 	{
 		s32 svCameraPos = -1;
 		s32 svCameraView = -1;
@@ -51,7 +51,7 @@ namespace TFE_RenderShared
 	};
 
 	static std::vector<u8> s_cmdBuffer;
-	static ShaderState s_shaderState;
+	static ShaderStateMDRAW s_shaderState;
 	static Shader s_shader;
 
 	bool modelDraw_loadShader(u32 defineCount, ShaderDefine* defines)

--- a/TheForceEngine/TFE_RenderShared/triDraw3d.cpp
+++ b/TheForceEngine/TFE_RenderShared/triDraw3d.cpp
@@ -44,7 +44,7 @@ namespace TFE_RenderShared
 	};
 	static const u32 c_tri3dAttrCount = TFE_ARRAYSIZE(c_tri3dAttrMapping);
 
-	struct ShaderState
+	struct ShaderStateTRIDRAW
 	{
 		s32 svCameraPos = -1;
 		s32 svCameraView = -1;
@@ -54,7 +54,7 @@ namespace TFE_RenderShared
 		s32 skyParam0Id = -1;
 		s32 skyParam1Id = -1;
 	};
-	static ShaderState s_shaderState[TRIMODE_COUNT];
+	static ShaderStateTRIDRAW s_shaderState[TRIMODE_COUNT];
 
 	static Shader s_shader[TRIMODE_COUNT];
 	static VertexBuffer s_vertexBuffer;


### PR DESCRIPTION
While building with -flto and gcc on Linux does succeed, the resulting binary crashes early during sound loading due to the Allocator returning nullptrs.  This set of 3 patches removes all warnings emitted by GCC during the LTO run, and the resulting binary actually works fine as well (played a few levels, mods, saved/loaded savegames from both the lto-patched and vanilla binary, no issues whatsoever).

Comparison of binary size (-O3 -march=znver4):
```
   text    data     bss     dec     hex filename
5754171   84401 3355328 9193900  8c49ac theforceengine-gcc15
4317669   48488 3215256 7581413  73aee5 theforceengine-gcc15-lto
```
Size reduction of 1.54MiB or ~17,5%

The thing that LTO was most confused by is apparently the wraparound-to-nullptr design in the TFE_Jedi Allocator,  I changed it a bit to use regular nullptrs.
The rest is namespace cleanups to get rid of C++ ODR violations which only appear with lto enabled,
and nullpointer checks to call allocator_newItem() callsites (which fixes an lto-only allocator pointer corruption encountered with dark tide 1 mod).

Clang LTO also works, but generates a 10% bigger binary (compared to non-lto build).
