### PR TITLE
A11y: call invalidate font atlas indirectly

### DIFF
--- a/TheForceEngine/TFE_A11y/accessibility.cpp
+++ b/TheForceEngine/TFE_A11y/accessibility.cpp
@@ -12,8 +12,6 @@
 #include <TFE_System/parser.h>
 #include <TFE_System/system.h>
 #include <TFE_Ui/imGUI/imgui.h>
-#include <TFE_Ui/imGUI/imgui_impl_sdl.h>
-#include <TFE_Ui/imGUI/imgui_impl_opengl3.h>
 #include <TFE_Ui/ui.h>
 
 using namespace std::chrono;
@@ -243,7 +241,7 @@ namespace TFE_A11Y  // a11y is industry slang for accessibility
 			s_fontMap[path] = s_currentCaptionFont;
 			// If we're loading a new font after the game first initializes, we'll need to clear the 
 			// ImGui font atlas so that it is automatically regenerated at the start of the next frame.
-			if (clearAtlas) { ImGui_ImplOpenGL3_DestroyFontsTexture(); }
+			if (clearAtlas) { TFE_Ui::invalidateFontAtlas(); }
 		}
 		assert(s_currentCaptionFont != nullptr);
 


### PR DESCRIPTION
Don't call the imgui impl function directly in a11y code, use the helper in TFE_Ui instead.
@kevinfoley I think this is what you initially intended?