### PR TITLE
Add glFinish() before buffer swap

### DIFF
--- a/TheForceEngine/TFE_RenderBackend/Win32OpenGL/renderBackend.cpp
+++ b/TheForceEngine/TFE_RenderBackend/Win32OpenGL/renderBackend.cpp
@@ -255,6 +255,7 @@ namespace TFE_RenderBackend
 
 		TFE_ZONE_BEGIN(swapGpu, "GPU Swap Buffers");
 		// Update the window.
+		glFinish();
 		SDL_GL_SwapWindow((SDL_Window*)m_window);
 		TFE_ZONE_END(swapGpu);
 


### PR DESCRIPTION
Just for the sake of completeness (`SDL_GL_SwapWindow()` does not call `glFinish()` for you).
In my understanding, OpenGL commands are *latently asynchronous* by design but please correct if I am wrong. So far, I have not come across any visible negative side effects because of `glFinish()` being absent on SoC (CPU and GPU integrated) systems but could imagine on systems with dedicated GPUs.