### PR TITLE
Set Application name SDL Hint

### DIFF
--- a/TheForceEngine/main.cpp
+++ b/TheForceEngine/main.cpp
@@ -298,6 +298,10 @@ bool sdlInit()
 	s_monitorWidth  = mode.w;
 	s_monitorHeight = mode.h;
 
+#ifdef SDL_HINT_APP_NAME  // SDL 2.0.18+
+	SDL_SetHint(SDL_HINT_APP_NAME, "The Force Engine");
+#endif
+
 	return true;
 }
 


### PR DESCRIPTION
Set the "Application Name" SDL Hint.  This fixes a cosmetic issue on at least Linux wrt. to the audio stream name when pipewire/pulseaudio are used as sound servers (before/after):
![image](https://github.com/luciusDXL/TheForceEngine/assets/123231678/bca56c29-a691-482c-9054-f8b8fb62b74c)
