### PR TITLE
More bugfixes/improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,12 +62,13 @@ if(ENABLE_TFE)
 	if(UNIX)
 		find_package(PkgConfig REQUIRED)
 		find_package(SDL2 2.0.20 REQUIRED)
-		find_package(SDL2_Image REQUIRED)
+		pkg_check_modules(SDL2_IMAGE REQUIRED SDL2_image)
 		pkg_check_modules(GLEW REQUIRED glew)
 		target_include_directories(tfe PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 		target_include_directories(tfe PRIVATE ${SDL2_INCLUDE_DIRS})
 		target_include_directories(tfe PRIVATE ${SDL2_IMAGE_INCLUDE_DIRS})
-		target_link_libraries(tfe PRIVATE SDL2::SDL2main SDL2::SDL2 SDL2_image::SDL2_image
+		target_link_libraries(tfe PRIVATE SDL2::SDL2main SDL2::SDL2
+					${SDL2_IMAGE_LIBRARIES}
 					${GLEW_LIBRARIES}
 		)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,11 @@ if(CMAKE_BUILD_TYPE STREQUAL "Release")
 	check_cxx_compiler_flag("-ftrivial-auto-var-init=zero" COMPILER_ENABLE_AUTOZERO)
 endif()
 
+# disable Clangs excessive warnings about unhandled switch values
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-switch")	
+endif()
+
 if (UNIX AND NOT APPLE)
 	set(LINUX ON)
 elseif (UNIX AND APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,8 +32,6 @@ endif()
 
 if (UNIX AND NOT APPLE)
 	set(LINUX ON)
-elseif (UNIX AND APPLE)
-	set(MACOS ON)
 endif()
 
 if(WIN32)
@@ -61,22 +59,16 @@ if(ENABLE_TFE)
 	add_executable(tfe)
 	set_target_properties(tfe PROPERTIES OUTPUT_NAME "theforceengine")
 
-	if(LINUX)
+	if(UNIX)
 		find_package(PkgConfig REQUIRED)
-		find_package(Threads REQUIRED)
 		find_package(SDL2 2.0.20 REQUIRED)
-		pkg_check_modules(SDL2_IMAGE REQUIRED SDL2_image)
+		find_package(SDL2_Image REQUIRED)
 		pkg_check_modules(GLEW REQUIRED glew)
-		set(OpenGL_GL_PREFERENCE GLVND)
-		find_package(OpenGL REQUIRED)
 		target_include_directories(tfe PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 		target_include_directories(tfe PRIVATE ${SDL2_INCLUDE_DIRS})
 		target_include_directories(tfe PRIVATE ${SDL2_IMAGE_INCLUDE_DIRS})
-		target_link_libraries(tfe PRIVATE
-					${OPENGL_LIBRARIES}
+		target_link_libraries(tfe PRIVATE SDL2::SDL2main SDL2::SDL2 SDL2_image::SDL2_image
 					${GLEW_LIBRARIES}
-					${SDL2_LIBRARIES}
-					${SDL2_IMAGE_LIBRARIES}
 		)
 
 		if(NOT DISABLE_SYSMIDI)

--- a/TheForceEngine/TFE_Audio/audioDevice.cpp
+++ b/TheForceEngine/TFE_Audio/audioDevice.cpp
@@ -17,7 +17,7 @@ namespace TFE_AudioDevice
 	{
 		s32 d = SDL_GetNumAudioDevices(0);
 		s_outputDeviceList.clear();
-		s_outputDeviceList.push_back({"<autoselect>", 0});
+		s_outputDeviceList.push_back({"System Default", 0});
 		for (s32 i = 0; i < d; i++)
 		{
 			const char* dn = SDL_GetAudioDeviceName(i, 0);

--- a/TheForceEngine/TFE_Audio/systemMidiDevice.cpp
+++ b/TheForceEngine/TFE_Audio/systemMidiDevice.cpp
@@ -97,15 +97,18 @@ namespace TFE_Audio
 	u32 SystemMidiDevice::getOutputCount()
 	{
 		m_outputs.clear();
-		m_outputs.push_back("(Disabled)");
 		if (m_midiout)
 		{
 			u32 count = m_midiout->getPortCount();
+
+			m_outputs.push_back(count ? "Disabled" : "Disabled: no ports found");
 
 			for (u32 i = 0; i < count; i++)
 			{
 				m_outputs.push_back(m_midiout->getPortName(i));
 			}
+		} else {
+			m_outputs.push_back("Disabled: internal MIDI error");
 		}
 		return (u32)m_outputs.size();
 	}

--- a/TheForceEngine/TFE_DarkForces/gameMusic.cpp
+++ b/TheForceEngine/TFE_DarkForces/gameMusic.cpp
@@ -472,31 +472,31 @@ namespace TFE_DarkForces
 			if (!strncmp(ptr, "boss ", 5) && (s_oldState == MUS_STATE_BOSS))
 			{
 				ptr += 5;
-				while (buf[i++] = readNumber(&ptr));
+				while (0 != (buf[i++] = readNumber(&ptr)));
 				return buf[0] ? buf : nullptr;
 			}
 			if (!strncmp(ptr, "fight ", 6) && (s_oldState == MUS_STATE_FIGHT))
 			{
 				ptr += 6;
-				while (buf[i++] = readNumber(&ptr));
+				while (0 != (buf[i++] = readNumber(&ptr)));
 				return buf[0] ? buf : nullptr;
 			}
 			if (!strncmp(ptr, "engage ", 7) && (s_oldState == MUS_STATE_ENGAGE))
 			{
 				ptr += 7;
-				while (buf[i++] = readNumber(&ptr));
+				while (0 != (buf[i++] = readNumber(&ptr)));
 				return buf[0] ? buf : nullptr;
 			}
 			if (!strncmp(ptr, "stalk ", 6) && (s_oldState == MUS_STATE_STALK))
 			{
 				ptr += 6;
-				while (buf[i++] = readNumber(&ptr));
+				while (0 != (buf[i++] = readNumber(&ptr)));
 				return buf[0] ? buf : nullptr;
 			}
 			if (!strncmp(ptr, "explore ", 8) && (s_oldState == MUS_STATE_EXPLORE))
 			{
 				ptr += 8;
-				while (buf[i++] = readNumber(&ptr));
+				while (0 != (buf[i++] = readNumber(&ptr)));
 				return buf[0] ? buf : nullptr;
 			}
 		}
@@ -506,31 +506,31 @@ namespace TFE_DarkForces
 			{
 				ptr += 5;
 				ptr += strlen("trans ");
-				while (buf[i++] = readNumber(&ptr));
+				while (0 != (buf[i++] = readNumber(&ptr)));
 				return buf[0] ? buf : nullptr;
 			}
 			if (!strncmp(ptr, "fight ", 6) && (s_currentState == MUS_STATE_FIGHT))
 			{
 				ptr += 6;
-				while (buf[i++] = readNumber(&ptr));
+				while (0 != (buf[i++] = readNumber(&ptr)));
 				return buf[0] ? buf : nullptr;
 			}
 			if (!strncmp(ptr, "engage ", 7) && (s_currentState == MUS_STATE_ENGAGE))
 			{
 				ptr += 7;
-				while (buf[i++] = readNumber(&ptr));
+				while (0 != (buf[i++] = readNumber(&ptr)));
 				return buf[0] ? buf : nullptr;
 			}
 			if (!strncmp(ptr, "stalk ", 6) && (s_currentState == MUS_STATE_STALK))
 			{
 				ptr += 6;
-				while (buf[i++] = readNumber(&ptr));
+				while (0 != (buf[i++] = readNumber(&ptr)));
 				return buf[0] ? buf : nullptr;
 			}
 			if (!strncmp(ptr, "explore ", 8) && (s_currentState == MUS_STATE_EXPLORE))
 			{
 				ptr += 8;
-				while (buf[i++] = readNumber(&ptr));
+				while (0 != (buf[i++] = readNumber(&ptr)));
 				return buf[0] ? buf : nullptr;
 			}
 		}

--- a/TheForceEngine/TFE_Editor/LevelEditor/levelEditorData.cpp
+++ b/TheForceEngine/TFE_Editor/LevelEditor/levelEditorData.cpp
@@ -284,7 +284,7 @@ namespace LevelEditor
 		s32 soundCount = 0;
 		s32 objectCount = 0;
 
-		while (line = parser.readLine(bufferPos))
+		while ((line = parser.readLine(bufferPos)) != nullptr)
 		{
 			if (sscanf(line, "PODS %d", &podCount) == 1)
 			{

--- a/TheForceEngine/TFE_Editor/LevelEditor/levelEditorInf.cpp
+++ b/TheForceEngine/TFE_Editor/LevelEditor/levelEditorInf.cpp
@@ -1365,7 +1365,7 @@ namespace LevelEditor
 					line = parser.readLine(bufferPos);
 					if (line && strstr(line, "SEQ"))
 					{
-						while (line = parser.readLine(bufferPos))
+						while ((line = parser.readLine(bufferPos)) != nullptr)
 						{
 							char itemName[256];
 							s32 argCount = sscanf(line, " %s %s %s %s %s %s %s", itemName, s_infArg0, s_infArg1, s_infArg2, s_infArg3, s_infArgExtra, s_infArgExtra);

--- a/TheForceEngine/TFE_Game/igame.cpp
+++ b/TheForceEngine/TFE_Game/igame.cpp
@@ -17,7 +17,7 @@ MemoryRegion* s_levelRegion = nullptr;
 void displayMemoryUsage(const ConsoleArgList& args)
 {
 	char res[256];
-	size_t blockCount, blockSize;
+	u64 blockCount, blockSize;
 	region_getBlockInfo(s_gameRegion, &blockCount, &blockSize);
 	TFE_Console::addToHistory("-------------------------------------------------------------------");
 	TFE_Console::addToHistory("Region   | Memory Used | Current Capacity | Block Count | BlockSize");

--- a/TheForceEngine/TFE_Jedi/IMuse/imDigitalSound.cpp
+++ b/TheForceEngine/TFE_Jedi/IMuse/imDigitalSound.cpp
@@ -737,7 +737,7 @@ namespace TFE_Jedi
 
 	s32 audioWriteToDriver(f32 systemVolume)
 	{
-		if (!s_audioOut)
+		if (s_audioOutSize < 1)
 		{
 			return imInvalidSound;
 		}

--- a/TheForceEngine/TFE_Jedi/InfSystem/infSystem.cpp
+++ b/TheForceEngine/TFE_Jedi/InfSystem/infSystem.cpp
@@ -1318,7 +1318,7 @@ namespace TFE_Jedi
 					line = parser.readLine(bufferPos);
 					if (line && strstr(line, "SEQ"))
 					{
-						while (line = parser.readLine(bufferPos))
+						while (nullptr != (line = parser.readLine(bufferPos)))
 						{
 							char itemName[256];
 							s32 argCount = sscanf(line, " %s %s %s %s %s %s %s", itemName, s_infArg0, s_infArg1, s_infArg2, s_infArg3, s_infArgExtra, s_infArgExtra);

--- a/TheForceEngine/TFE_Jedi/Level/level.cpp
+++ b/TheForceEngine/TFE_Jedi/Level/level.cpp
@@ -745,7 +745,7 @@ namespace TFE_Jedi
 			return false;
 		}
 
-		while (line = parser.readLine(bufferPos))
+		while (nullptr != (line = parser.readLine(bufferPos)))
 		{
 			if (sscanf(line, "PODS %d", &s_levelIntState.podCount) == 1)
 			{

--- a/TheForceEngine/TFE_Jedi/Level/levelData.cpp
+++ b/TheForceEngine/TFE_Jedi/Level/levelData.cpp
@@ -259,7 +259,7 @@ namespace TFE_Jedi
 			std::ptrdiff_t offset = (std::ptrdiff_t(texData) - std::ptrdiff_t(s_levelState.textures)) / (std::ptrdiff_t)sizeof(TextureData**);
 			if ((*texData)->animIndex >= 0)
 			{
-				const u8 frameIndex = (*texData)->frameIdx < 0 ? 0xfff : (u8)(*texData)->frameIdx;
+				const u8 frameIndex = (*texData)->frameIdx < 0 ? 0xff : (u8)(*texData)->frameIdx;
 				texIndex = LEVTEX_TYPE_ANM | (frameIndex << 4) | ((u32)(*texData)->animIndex << 12u);
 			}
 			else

--- a/TheForceEngine/TFE_Jedi/Math/core_math.h
+++ b/TheForceEngine/TFE_Jedi/Math/core_math.h
@@ -338,17 +338,17 @@ namespace TFE_Jedi
 	}
 
 	// Size_t
-	inline size_t min(size_t a, size_t b)
+	inline u64 min(u64 a, u64 b)
 	{
 		return a < b ? a : b;
 	}
 
-	inline size_t max(size_t a, size_t b)
+	inline u64 max(u64 a, u64 b)
 	{
 		return a > b ? a : b;
 	}
 
-	inline size_t clamp(size_t x, size_t a, size_t b)
+	inline u64 clamp(u64 x, u64 a, u64 b)
 	{
 		return min(max(x, a), b);
 	}

--- a/TheForceEngine/TFE_Memory/memoryRegion.h
+++ b/TheForceEngine/TFE_Memory/memoryRegion.h
@@ -15,17 +15,17 @@ typedef u32 RelativePointer;
 
 namespace TFE_Memory
 {
-	MemoryRegion* region_create(const char* name, size_t blockSize, size_t maxSize = 0u);
+	MemoryRegion* region_create(const char* name, u64 blockSize, u64 maxSize = 0u);
 	void region_clear(MemoryRegion* region);
 	void region_destroy(MemoryRegion* region);
 
-	void* region_alloc(MemoryRegion* region, size_t size);
-	void* region_realloc(MemoryRegion* region, void* ptr, size_t size);
+	void* region_alloc(MemoryRegion* region, u64 size);
+	void* region_realloc(MemoryRegion* region, void* ptr, u64 size);
 	void  region_free(MemoryRegion* region, void* ptr);
 
-	size_t region_getMemoryUsed(MemoryRegion* region);
-	size_t region_getMemoryCapacity(MemoryRegion* region);
-	void region_getBlockInfo(MemoryRegion* region, size_t* blockCount, size_t* blockSize);
+	u64 region_getMemoryUsed(MemoryRegion* region);
+	u64 region_getMemoryCapacity(MemoryRegion* region);
+	void region_getBlockInfo(MemoryRegion* region, u64* blockCount, u64* blockSize);
 
 	RelativePointer region_getRelativePointer(MemoryRegion* region, void* ptr);
 	void* region_getRealPointer(MemoryRegion* region, RelativePointer ptr);

--- a/TheForceEngine/TFE_RenderShared/lineDraw2d.cpp
+++ b/TheForceEngine/TFE_RenderShared/lineDraw2d.cpp
@@ -7,7 +7,7 @@
 #include <TFE_System/system.h>
 #include <vector>
 
-#define LINE_MAX 65536
+#define MAX_LINES 65536
 
 namespace TFE_RenderShared
 {
@@ -88,9 +88,9 @@ namespace TFE_RenderShared
 
 		// Create buffers
 		// Create vertex and index buffers.
-		u32* indices = new u32[6 * LINE_MAX];
+		u32* indices = new u32[6 * MAX_LINES];
 		u32* outIndices = indices;
-		for (u32 i = 0; i < LINE_MAX; i++, outIndices += 6)
+		for (u32 i = 0; i < MAX_LINES; i++, outIndices += 6)
 		{
 			outIndices[0] = i * 4 + 0;
 			outIndices[1] = i * 4 + 1;
@@ -100,10 +100,10 @@ namespace TFE_RenderShared
 			outIndices[4] = i * 4 + 2;
 			outIndices[5] = i * 4 + 3;
 		}
-		s_vertices = new LineVertex[4 * LINE_MAX];
+		s_vertices = new LineVertex[4 * MAX_LINES];
 
-		s_vertexBuffer.create(4 * LINE_MAX, sizeof(LineVertex), c_lineAttrCount, c_lineAttrMapping, true);
-		s_indexBuffer.create(6 * LINE_MAX, sizeof(u32), false, indices);
+		s_vertexBuffer.create(4 * MAX_LINES, sizeof(LineVertex), c_lineAttrCount, c_lineAttrMapping, true);
+		s_indexBuffer.create(6 * MAX_LINES, sizeof(u32), false, indices);
 
 		delete[] indices;
 		s_lineCount = 0;
@@ -134,7 +134,7 @@ namespace TFE_RenderShared
 	void lineDraw2d_addLines(u32 count, f32 width, const Vec2f* lines, const u32* lineColors)
 	{
 		LineVertex* vert = &s_vertices[s_lineCount * 4];
-		for (u32 i = 0; i < count && s_lineCount < LINE_MAX; i++, lines += 2, lineColors += 2, vert += 4)
+		for (u32 i = 0; i < count && s_lineCount < MAX_LINES; i++, lines += 2, lineColors += 2, vert += 4)
 		{
 			s_lineCount++;
 

--- a/TheForceEngine/TFE_RenderShared/quadDraw2d.cpp
+++ b/TheForceEngine/TFE_RenderShared/quadDraw2d.cpp
@@ -5,7 +5,7 @@
 #include <TFE_System/system.h>
 #include <vector>
 
-#define QUAD_MAX 1024
+#define QUAD_MAX_NUM 1024
 
 namespace TFE_RenderShared
 {
@@ -40,7 +40,7 @@ namespace TFE_RenderShared
 	static u32 s_quadCount;
 	static u32 s_quadDrawCount;
 
-	static QuadDraw s_quadDraw[QUAD_MAX];
+	static QuadDraw s_quadDraw[QUAD_MAX_NUM];
 
 	static u32 s_width, s_height;
 
@@ -60,9 +60,9 @@ namespace TFE_RenderShared
 
 		// Create buffers
 		// Create vertex and index buffers.
-		u32* indices = new u32[6 * QUAD_MAX];
+		u32* indices = new u32[6 * QUAD_MAX_NUM];
 		u32* outIndices = indices;
-		for (u32 i = 0; i < QUAD_MAX; i++, outIndices += 6)
+		for (u32 i = 0; i < QUAD_MAX_NUM; i++, outIndices += 6)
 		{
 			outIndices[0] = i * 4 + 0;
 			outIndices[1] = i * 4 + 1;
@@ -72,10 +72,10 @@ namespace TFE_RenderShared
 			outIndices[4] = i * 4 + 2;
 			outIndices[5] = i * 4 + 3;
 		}
-		s_vertices = new QuadVertex[4 * QUAD_MAX];
+		s_vertices = new QuadVertex[4 * QUAD_MAX_NUM];
 
-		s_vertexBuffer.create(4 * QUAD_MAX, sizeof(QuadVertex), c_quadAttrCount, c_quadAttrMapping, true);
-		s_indexBuffer.create(6 * QUAD_MAX, sizeof(u32), false, indices);
+		s_vertexBuffer.create(4 * QUAD_MAX_NUM, sizeof(QuadVertex), c_quadAttrCount, c_quadAttrMapping, true);
+		s_indexBuffer.create(6 * QUAD_MAX_NUM, sizeof(u32), false, indices);
 
 		delete[] indices;
 		s_quadCount = 0;
@@ -110,7 +110,7 @@ namespace TFE_RenderShared
 		s_quadDrawCount++;
 
 		QuadVertex* vert = &s_vertices[s_quadCount * 4];
-		for (u32 i = 0; i < count && s_quadCount < QUAD_MAX; i++, quads += 2, quadColors += 2, vert += 4)
+		for (u32 i = 0; i < count && s_quadCount < QUAD_MAX_NUM; i++, quads += 2, quadColors += 2, vert += 4)
 		{
 			s_quadCount++;
 

--- a/TheForceEngine/TFE_Settings/settings.cpp
+++ b/TheForceEngine/TFE_Settings/settings.cpp
@@ -1355,14 +1355,14 @@ namespace TFE_Settings
 					const cJSON* iter = curElem->child;
 					if (!iter)
 					{
-						TFE_System::logWrite(LOG_WARNING, "MOD_CONF", "Level overrides '%s' is empty, skipping.", ignoreList.levName);
+						TFE_System::logWrite(LOG_WARNING, "MOD_CONF", "Level overrides '%s' is empty, skipping.", ignoreList.levName.c_str());
 					}
 
 					for (; iter; iter = iter->next)
 					{
 						if (!iter->string)
 						{
-							TFE_System::logWrite(LOG_WARNING, "MOD_CONF", "Level override for '%s' has no name, skipping.", ignoreList.levName);
+							TFE_System::logWrite(LOG_WARNING, "MOD_CONF", "Level override for '%s' has no name, skipping.", ignoreList.levName.c_str());
 							continue;
 						}
 


### PR DESCRIPTION
More bug/warningfixes and updates, also to get it building on Apple/Clang toolchains.  based on feedback in #90 

- QUAD_MAX is a reserved symbol in xnu's "limits.h" file
- clang doesn't like passing std::string to logWrite()
- disable clang's excessive warnings about unhandled enum values in switch() statements
- fix lots of clang warnings about assignments inside while() without extra brackets.
- adjust the min/max/clamp(size_t) functions to u64, since size_t == u32 on 32bit targets
- LINE_MAX is another reserved symbol on xnu/apple.
- change the size_t in memoryRegion, which is written out to savegames, to an u64, to keep apple toolchain happy and the savegame format independent of the target architecture size.
- rename the "\<autoselect\>" audio device to "System Default", and change the System Midi "(Disabled)" device to explain why it's disabled (By choice, no synthesizers, or RtMidi error).
