### PR TITLE
IMuse: handle type 2 VOC  chunks

### DIFF
--- a/TheForceEngine/TFE_Jedi/IMuse/imDigitalSound.cpp
+++ b/TheForceEngine/TFE_Jedi/IMuse/imDigitalSound.cpp
@@ -486,9 +486,12 @@ namespace TFE_Jedi
 			{
 				return imFail;
 			}
-			else if (id == 1)	// found the next useful chunk.
+			else if ((id == 1) || (id == 2))	// found the next useful chunk.
 			{
-				s32 chunkSize = (chunkData[0] | (chunkData[1] << 8) | (chunkData[2] << 16)) - 2;
+				s32 chunkSize = (chunkData[0] | (chunkData[1] << 8) | (chunkData[2] << 16));
+				if (id == 1)
+					chunkSize -= 2;
+					
 				chunkData += 5;
 
 				data->chunkSize = chunkSize;
@@ -501,7 +504,7 @@ namespace TFE_Jedi
 					}
 				}
 
-				data->offset += 6;
+				data->offset += (id == 1) ? 6 : 4;
 				if (data->chunkIndex)
 				{
 					IM_LOG_ERR("data->chunkIndex should be 0 in Dark Forces, it is: %d.", data->chunkIndex);
@@ -538,19 +541,23 @@ namespace TFE_Jedi
 			{
 				if (chunkData[0] != 'r' || chunkData[1] != 'e' || chunkData[2] != 'a')
 				{
-					IM_LOG_ERR("ERR: Illegal chunk in sound %lu...", data->sound->soundId);
+					IM_LOG_ERR("ERR: Not a valid VOC sound %lu...", data->sound->soundId);
 					return imFail;
 				}
 				data->offset += 26;
 				if (data->chunkIndex)
 				{
 					IM_LOG_ERR("data->chunkIndex should be 0 in Dark Forces, it is: %d.", data->chunkIndex);
-					assert(0);
+					return imFail;
 				}
 			}
 			else
 			{
-				IM_LOG_ERR("ERR: Illegal chunk in sound %lu...", data->sound->soundId);
+				// dont warn on silence (3) and ascii text (5)
+				if ((id != 3) && (id != 5))
+				{
+					IM_LOG_ERR("ERR: Illegal chunk %d in sound %lu...", id, data->sound->soundId);
+				}
 				return imFail;
 			}
 		}


### PR DESCRIPTION
In Dark Tide 1, there's the MCHN3.VOC file which contains a voc chunk with id 2, which causes TFE to spam the log with an unending stream of:

```
[Error : iMuse] ERR: Illegal chunk in sound    2561ba3c54df0...
[Error : iMuse] ERR: Illegal chunk in sound    3561ba3cb5658...
[Error : iMuse] ERR: Illegal chunk in sound    5561ba3cb5658...
```

Fix this by handling type 2 chunks.

Also clarify the debug output a bit and stop spamming the log on known but unhandled chunks (3 and 5).

In DT1, there's also the "BUBBLS1.VOC" file which has only 1 chunk but its size is too small, doesn't cover the entire file. This will cause a one-time log entry
```
[Error : iMuse] ERR: Illegal chunk 170 in sound 657844099906576...
```