### PR TITLE
CMake: automatically make system midi optional

### DIFF
--- a/.github/workflows/ubuntu-gcc.yml
+++ b/.github/workflows/ubuntu-gcc.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DDISABLE_SYSMIDI=ON -DENABLE_FORCE_SCRIPT=ON -DENABLE_EDITOR=ON
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DENABLE_FORCE_SCRIPT=ON -DENABLE_EDITOR=ON
 
     - name: Build
       # Build your program with the given configuration

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ include(GNUInstallDirs)
 
 ## Options
 option(ENABLE_TFE "Enable building “The Force Engine”" ON)
-option(DISABLE_SYSMIDI "Disable System-MIDI Output" OFF)
+option(ENABLE_SYSMIDI "Enable System-MIDI Output if RTMidi is available" ON)
 option(ENABLE_EDITOR "Enable TFE Editor" OFF)
 option(ENABLE_FORCE_SCRIPT "Enable Force Script" OFF)
 option(ENABLE_ADJUSTABLEHUD_MOD "Install the build‑in “AdjustableHud mod” with TFE" ON)
@@ -72,11 +72,6 @@ if(ENABLE_TFE)
 					${GLEW_LIBRARIES}
 		)
 
-		if(NOT DISABLE_SYSMIDI)
-			pkg_check_modules(RTMIDI REQUIRED rtmidi>=5.0.0)
-			target_link_libraries(tfe PRIVATE ${RTMIDI_LIBRARIES})
-		endif()
-
 		# set up build directory to be able to run TFE immediately: symlink
 		# the necessary support file directories into the build env.
 		execute_process(COMMAND ln -sf ${CMAKE_SOURCE_DIR}/TheForceEngine/Captions)
@@ -97,8 +92,15 @@ if(ENABLE_TFE)
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ftrivial-auto-var-init=zero")
 	endif()
 
-	if(DISABLE_SYSMIDI)
-		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DNOSYSMIDI")
+	if(ENABLE_SYSMIDI)
+		pkg_check_modules(RTMIDI rtmidi>=5.0.0)
+		if(RTMIDI_FOUND)
+			add_definitions("-DBUILD_SYSMIDI")
+			target_link_libraries(tfe PRIVATE ${RTMIDI_LIBRARIES})
+		else()
+			set(ENABLE_SYSMIDI 0)
+			message(STATUS "System MIDI Disabled")
+		endif()
 	endif()
 	if(ENABLE_EDITOR)
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBUILD_EDITOR")

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ This can be overridden by defining the `TFE_DATA_HOME` environment variable.
 * [SDL2-image](https://github.com/libsdl-org/SDL_image) Version 2.6.3
 * [GLEW](http://glew.sourceforge.net/) 2.2.0
 * OpenGL 3.3 capable driver (latest [Mesa 3D](https://www.mesa3d.org) or Nvidia proprietary driver recommended)
+
+### Optional Libraries
 * [RtMidi](https://www.music.mcgill.ca/~gary/rtmidi/) 5.0.0 or higher for external MIDI synthesizer support
 
 ### Building from Source

--- a/TheForceEngine/TFE_Audio/CMakeLists.txt
+++ b/TheForceEngine/TFE_Audio/CMakeLists.txt
@@ -3,7 +3,7 @@ if(LINUX)
 	# we use the system libraries on Linux
 	list(REMOVE_ITEM SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/RtMidi.cpp")
 endif()
-if(DISABLE_SYSMIDI)
+if(NOT ENABLE_SYSMIDI)
 	list(REMOVE_ITEM SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/systemMidiDevice.cpp")
 	if(WIN32)
 		list(REMOVE_ITEM SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/RtMidi.cpp")

--- a/TheForceEngine/TFE_Audio/midiDevice.h
+++ b/TheForceEngine/TFE_Audio/midiDevice.h
@@ -6,7 +6,7 @@ enum MidiDeviceType
 {
 	MIDI_TYPE_SF2 = 0,	// Use the Sound Font 2 (SF2) midi synthesizer.
 	MIDI_TYPE_OPL3,		// Use OPL3 emulation (like DosBox).
-#ifndef NOSYSMIDI
+#ifdef BUILD_SYSMIDI
 	MIDI_TYPE_SYSTEM,	// System midi device (hardware, midi server, GM midi on Windows).
 #endif
 	MIDI_TYPE_COUNT,

--- a/TheForceEngine/TFE_Audio/midiPlayer.cpp
+++ b/TheForceEngine/TFE_Audio/midiPlayer.cpp
@@ -1,7 +1,7 @@
 #include "midiPlayer.h"
 #include "midiDevice.h"
 #include "audioDevice.h"
-#ifndef NOSYSMIDI
+#ifdef BUILD_SYSMIDI
 #include "systemMidiDevice.h"
 #endif
 #include <SDL_mutex.h>
@@ -91,7 +91,7 @@ namespace TFE_MidiPlayer
 	{
 		"SF2 Synthesized Midi", // MIDI_TYPE_SF2
 		"OPL3 Synthesized Midi",// MIDI_TYPE_OPL3
-#ifndef NOSYSMIDI
+#ifdef BUILD_SYSMIDI
 		"System Midi",		// MIDI_TYPE_SYSTEM
 #endif
 	};
@@ -541,7 +541,7 @@ namespace TFE_MidiPlayer
 
 		switch (type)
 		{
-#ifndef NOSYSMIDI
+#ifdef BUILD_SYSMIDI
 			case MIDI_TYPE_SYSTEM:
 				s_midiDevice = new SystemMidiDevice();
 				break;


### PR DESCRIPTION
- Flip the system midi CMake configure option to "ENABLE_" like all others and enable it by default.
- Only If ENABLE_SYSMIDI evaluates to true try to find RtMidi.
- If RtMidi is unusable, disable the system midi output module.

This makes RtMidi an optional feature in the linux/unix build.  If it's available at build time, it will be included, but no longer fail if it isn't, since the built in OPL3 and SF2 renderers are already very good.