### PR TITLE
Use external release metadata XML for Flathub info

### DIFF
--- a/TheForceEngine/io.github.theforceengine.tfe.metainfo.xml
+++ b/TheForceEngine/io.github.theforceengine.tfe.metainfo.xml
@@ -88,9 +88,7 @@
     <category>Shooter</category>
     <category>ActionGame</category>
   </categories>
-  <releases>
-    <release version="1.09.540" date="2023-09-30"/>
-  </releases>
+  <releases type="external" url="https://raw.githubusercontent.com/flathub/io.github.theforceengine.tfe/master/io.github.theforceengine.tfe.releases.xml" />
   <content_rating type="oars-1.1">
     <content_attribute id="violence-fantasy">intense</content_attribute>
   </content_rating>


### PR DESCRIPTION
This will reduce the maintenance load over here; I'll maintain the releases.xml in the flathub repo along with the updates over there.