### PR TITLE
More little fixes

### DIFF
--- a/TheForceEngine/TFE_DarkForces/darkForcesMain.cpp
+++ b/TheForceEngine/TFE_DarkForces/darkForcesMain.cpp
@@ -230,7 +230,7 @@ namespace TFE_DarkForces
 	void setInitialLevel(const char* levelName);
 	s32  loadLocalMessages();
 	void buildSearchPaths();
-	void openGobFiles();
+	bool openGobFiles();
 	void gameStartup();
 	void loadAgentAndLevelData();
 	void startNextMode();
@@ -295,7 +295,8 @@ namespace TFE_DarkForces
 		buildSearchPaths();
 		processCommandLineArgs(argCount, argv, startLevel);
 		loadLocalMessages();
-		openGobFiles();
+		if (!openGobFiles())
+			return false;
 
 		// Sound is initialized before the task system.
 		sound_open(s_gameRegion);
@@ -1115,7 +1116,7 @@ namespace TFE_DarkForces
 		TFE_Paths::addAbsoluteSearchPath(path);
 	}
 
-	void openGobFiles()
+	bool openGobFiles()
 	{
 		for (s32 i = 0; i < TFE_ARRAYSIZE(c_gobFileNames); i++)
 		{
@@ -1132,6 +1133,7 @@ namespace TFE_DarkForces
 			else
 			{
 				TFE_System::logWrite(LOG_ERROR, "Dark Forces Main", "Cannot find required game data - '%s'.", c_gobFileNames[i]);
+				return false;
 			}
 		}
 		// Optional gobs
@@ -1148,6 +1150,7 @@ namespace TFE_DarkForces
 				}
 			}
 		}
+		return true;
 	}
 		
 	void loadMapNumFont()

--- a/TheForceEngine/TFE_Editor/LevelEditor/userPreferences.cpp
+++ b/TheForceEngine/TFE_Editor/LevelEditor/userPreferences.cpp
@@ -91,7 +91,7 @@ namespace LevelEditor
 	void optionSliderEditFloat(const char* name, const char* precision, f32* value, f32 minValue, f32 maxValue, f32 step)
 	{
 		ImGui::SetNextItemWidth(160);
-		ImGui::LabelText("##Label", name); ImGui::SameLine();
+		ImGui::LabelText("##Label", "%s", name); ImGui::SameLine();
 
 		char labelSlider[256];
 		char labelInput[256];

--- a/TheForceEngine/TFE_Settings/gameSourceData.h
+++ b/TheForceEngine/TFE_Settings/gameSourceData.h
@@ -71,7 +71,7 @@ namespace TFE_Settings
 		"OUTLAWS.LAB",			// Game_Outlaws
 	};
 
-	static const char* c_darkForcesLocations[] =
+	static const char* const c_darkForcesLocations[] =
 	{
 		// C drive
 		"C:/Program Files (x86)/Steam/steamapps/common/dark forces/Game/",
@@ -88,7 +88,7 @@ namespace TFE_Settings
 		"D:/Program Files (x86)/GOG.com/Star Wars - Dark Forces/",
 		"D:/GOG Games/Star Wars - Dark Forces/",
 	};
-	static const char* c_outlawsLocations[] =
+	static const char* const c_outlawsLocations[] =
 	{
 		// C drive
 		"C:/Program Files (x86)/Steam/steamapps/common/outlaws/",
@@ -103,7 +103,7 @@ namespace TFE_Settings
 	};
 	static const u32 c_hardcodedPathCount = TFE_ARRAYSIZE(c_darkForcesLocations);
 
-	static const char** c_gameLocations[] =
+	static const char* const * c_gameLocations[] =
 	{
 		c_darkForcesLocations,
 		c_outlawsLocations

--- a/TheForceEngine/TFE_Settings/settings.cpp
+++ b/TheForceEngine/TFE_Settings/settings.cpp
@@ -231,7 +231,7 @@ namespace TFE_Settings
 			if (!pathValid)
 			{
 				// Try various possible locations.
-				const char** locations = c_gameLocations[gameId];
+				const char* const * locations = c_gameLocations[gameId];
 				for (u32 i = 0; i < c_hardcodedPathCount; i++)
 				{
 					if (FileUtil::directoryExits(locations[i]))

--- a/TheForceEngine/main.cpp
+++ b/TheForceEngine/main.cpp
@@ -49,6 +49,7 @@
 #ifdef min
 #undef min
 #undef max
+#pragma comment(lib, "SDL2main.lib")
 #endif
 #endif
 
@@ -61,7 +62,6 @@
 #define INSTALL_CRASH_HANDLER 0
 #endif
 
-#pragma comment(lib, "SDL2main.lib")
 using namespace TFE_Input;
 using namespace TFE_A11Y;
 


### PR DESCRIPTION
More little things encountered so far:
*  move the sdl2main.lib #pragma under the _WIN32 ifdef, because the lld linker on not-windows adheres to it
* Abort DF launch early if not all GOBs can be found, to avoid a crash later. Found while playing with flatpak.
* address a new -Wformat-security warning in the Editor code
* constify the pointers in the game source data header even more to fix a broken lld, fixes #430, although in my opinion this is a problem with the OPs linker, not TFE, but the fix is harmless.
