### PR TITLE
Fix #437

### DIFF
--- a/TheForceEngine/TFE_DarkForces/agent.cpp
+++ b/TheForceEngine/TFE_DarkForces/agent.cpp
@@ -510,6 +510,7 @@ namespace TFE_DarkForces
 	// Also, later, the TFE based save format will likely change - so importing will be necessary anyway.
 	JBool openDarkPilotConfig(FileStream* file)
 	{
+		bool triedonce = false;
 		assert(file);
 
 		// TFE uses its own local copy of the save game data to avoid corrupting existing data.
@@ -542,6 +543,7 @@ namespace TFE_DarkForces
 				{
 					// Finally generate a new one.
 					TFE_System::logWrite(LOG_WARNING, "DarkForcesMain", "Cannot find 'DARKPILO.CFG' at '%s'. Creating a new file for save data.", sourcePath);
+newpilo:
 					createDarkPilotConfig(documentsPath);
 				}
 			}
@@ -549,6 +551,7 @@ namespace TFE_DarkForces
 		// Then try opening the file.
 		if (!file->open(documentsPath, Stream::MODE_READWRITE))
 		{
+			TFE_System::logWrite(LOG_ERROR, "DarkForcesMain", "cannot open DARKPILO.CFG");
 			return JFALSE;
 		}
 		// Then verify the file.
@@ -560,6 +563,12 @@ namespace TFE_DarkForces
 		}
 		// If it is not correct, then close the file and return false.
 		file->close();
+		if (!triedonce)
+		{
+			TFE_System::logWrite(LOG_ERROR, "DarkForcesMain", "DARKPILO.CFG corrupted; creating new");
+			triedonce = true;
+			goto newpilo;
+		}
 		return JFALSE;
 	}
 }  // namespace TFE_DarkForces

--- a/TheForceEngine/TFE_FileSystem/fileutil-posix.cpp
+++ b/TheForceEngine/TFE_FileSystem/fileutil-posix.cpp
@@ -192,10 +192,16 @@ namespace FileUtil
 	void copyFile(const char *src, const char *dst)
 	{
 		ssize_t rd, wr;
-		char buf[1024];
+		char buf[1024], *fnd;
 		int s, d;
 
-		s = open(src, O_RDONLY);
+		// assume the source is case-insensitive
+		fnd = findFileObjectNoCase(src, false);
+		if (!fnd)
+			return;
+
+		s = open(fnd, O_RDONLY);
+		free(fnd);
 		if (!s)
 			return;
 		d = open(dst, O_WRONLY | O_CREAT, 00644);


### PR DESCRIPTION
* recreate DARKPILO.CFG if it's corrupted
* Linux-specific: copyFile source file should also be treated as case-insensitive.
  fixes import of DaRkPiLo.CfG files with non-default uppercase naming.

Fixes #437
