### PR TITLE
Add mod directory to s_searchPaths when loading from a custom GOB

### DIFF
--- a/TheForceEngine/TFE_DarkForces/darkForcesMain.cpp
+++ b/TheForceEngine/TFE_DarkForces/darkForcesMain.cpp
@@ -1011,10 +1011,13 @@ namespace TFE_DarkForces
 				{
 					TFE_Paths::addLocalArchive(archive);
 
-					// Handle LFD files.
 					char modPath[TFE_MAX_PATH];
 					FileUtil::getFilePath(archivePath.path, modPath);
 
+					// Add the Mod directory to head of search paths - so that assets here will be loaded preferentially
+					TFE_Paths::addAbsoluteSearchPathToHead(modPath);
+
+					// Handle LFD files.
 					// Look for LFD files.
 					lfdCount = 0;
 					briefingIndex = -1;


### PR DESCRIPTION
As discussed in discord
https://discord.com/channels/799331202821521458/799332995373989888/1298733816860643490

As you recommended, I've put the mod path first in the list so things will get loaded from there ahead of other paths; hopefully this is what we want.