### PR TITLE
Fix VUE camera

### DIFF
--- a/TheForceEngine/TFE_DarkForces/player.cpp
+++ b/TheForceEngine/TFE_DarkForces/player.cpp
@@ -219,7 +219,7 @@ namespace TFE_DarkForces
 	SecObject* s_playerObject = nullptr;
 	SecObject* s_playerEye = nullptr;
 	vec3_fixed s_eyePos = { 0 };	// s_camX, s_camY, s_camZ in the DOS code.
-	angle14_32 s_pitch = 0, s_yaw = 0, s_roll = 0;
+	angle14_32 s_eyePitch = 0, s_eyeYaw = 0, s_eyeRoll = 0;
 	u32 s_playerEyeFlags = OBJ_FLAG_NEEDS_TRANSFORM;
 	Tick s_playerTick;
 	Tick s_prevPlayerTick;
@@ -907,9 +907,9 @@ namespace TFE_DarkForces
 		s_eyePos.y = s_playerEye->posWS.y;
 		s_eyePos.z = s_playerEye->posWS.z;
 
-		s_pitch = s_playerEye->pitch;
-		s_yaw   = s_playerEye->yaw;
-		s_roll  = s_playerEye->roll;
+		s_eyePitch = s_playerEye->pitch;
+		s_eyeYaw   = s_playerEye->yaw;
+		s_eyeRoll  = s_playerEye->roll;
 
 		setCameraOffset(0, 0, 0);
 		setCameraAngleOffset(0, 0, 0);
@@ -1265,13 +1265,13 @@ namespace TFE_DarkForces
 			s_eyePos.y = s_playerEye->posWS.y + s_camOffset.y - s_playerEye->worldHeight;
 			s_eyePos.z = s_playerEye->posWS.z + s_camOffset.z;
 
-			s_pitch = s_playerEye->pitch + s_camOffsetPitch;
-			s_yaw   = s_playerEye->yaw   + s_camOffsetYaw;
-			s_roll  = s_playerEye->roll  + s_camOffsetRoll;
+			s_eyePitch = s_playerEye->pitch + s_camOffsetPitch;
+			s_eyeYaw   = s_playerEye->yaw   + s_camOffsetYaw;
+			s_eyeRoll  = s_playerEye->roll  + s_camOffsetRoll;
 
 			if (s_playerEye->sector)
 			{
-				renderer_computeCameraTransform(s_playerEye->sector, s_pitch, s_yaw, s_eyePos.x, s_eyePos.y, s_eyePos.z);
+				renderer_computeCameraTransform(s_playerEye->sector, s_eyePitch, s_eyeYaw, s_eyePos.x, s_eyePos.y, s_eyePos.z);
 			}
 			renderer_setWorldAmbient(s_playerLight);
 		}
@@ -3222,9 +3222,9 @@ namespace TFE_DarkForces
 		}
 
 		SERIALIZE(ObjState_InitVersion, s_eyePos, defV3);
-		SERIALIZE(ObjState_InitVersion, s_pitch, 0);
-		SERIALIZE(ObjState_InitVersion, s_yaw, 0);
-		SERIALIZE(ObjState_InitVersion, s_roll, 0);
+		SERIALIZE(ObjState_InitVersion, s_eyePitch, 0);
+		SERIALIZE(ObjState_InitVersion, s_eyeYaw, 0);
+		SERIALIZE(ObjState_InitVersion, s_eyeRoll, 0);
 		SERIALIZE(ObjState_InitVersion, s_playerEyeFlags, 0);
 		SERIALIZE(ObjState_InitVersion, s_playerTick, 0);
 		SERIALIZE(ObjState_InitVersion, s_prevPlayerTick, 0);

--- a/TheForceEngine/TFE_DarkForces/player.h
+++ b/TheForceEngine/TFE_DarkForces/player.h
@@ -105,7 +105,7 @@ namespace TFE_DarkForces
 	extern fixed16_16 s_playerHeight;
 	extern fixed16_16 s_playerYPos;
 	extern vec3_fixed s_eyePos;	// s_camX, s_camY, s_camZ in the DOS code.
-	extern angle14_32 s_pitch, s_yaw, s_roll;
+	extern angle14_32 s_eyePitch, s_eyeYaw, s_eyeRoll;
 	extern angle14_32 s_playerYaw;
 	extern Tick s_playerTick;
 	extern Tick s_reviveTick;

--- a/TheForceEngine/TFE_DarkForces/sound.cpp
+++ b/TheForceEngine/TFE_DarkForces/sound.cpp
@@ -421,7 +421,7 @@ namespace TFE_DarkForces
 
 		// Calculate the pan.
 		angle14_32 angle = vec2ToAngle(x - s_eyePos.x, z - s_eyePos.z);
-		angle = getAngleDifference(s_yaw, angle);
+		angle = getAngleDifference(s_eyeYaw, angle);
 		*pan = s_tPan[((angle + 8192) / 512) & 31];
 
 		// TFE subtitles/captions

--- a/TheForceEngine/TFE_DarkForces/vueLogic.cpp
+++ b/TheForceEngine/TFE_DarkForces/vueLogic.cpp
@@ -213,6 +213,12 @@ namespace TFE_DarkForces
 		size_t bufferPos = 0;
 		if (!strcasecmp(transformName, "camera"))
 		{
+			// TFE: allocate a VFRAME_FIRST for camera transforms, same as with ordinary transforms
+			VueFrame* frame = (VueFrame*)allocator_newItem(vueList);
+			if (!frame)
+				return;
+			frame->flags = VFRAME_FIRST;
+
 			while (1)
 			{
 				const char* line = parser->readLine(bufferPos);
@@ -231,6 +237,7 @@ namespace TFE_DarkForces
 					frame->offset.z = floatToFixed16(z1);
 					frame->yaw   = vec2ToAngle(floatToFixed16(x2 - x1), floatToFixed16(z2 - z1));
 					
+					// TFE: calculate pitch (this was not done in vanilla)
 					f32 dx = x2 - x1;
 					f32 dz = z2 - z1;
 					double xzVec = sqrt(dx * dx + dz * dz);
@@ -590,7 +597,7 @@ namespace TFE_DarkForces
 
 							local(obj)->posWS = local(frame)->offset;
 							local(obj)->yaw = local(frame)->yaw;
-							local(obj)->pitch = local(frame)->pitch;
+							local(obj)->pitch = local(frame)->pitch;	// TFE: copy pitch and roll to object (not done in vanilla)
 							local(obj)->roll = local(frame)->roll;
 						task_localBlockEnd;
 

--- a/TheForceEngine/TFE_DarkForces/vueLogic.cpp
+++ b/TheForceEngine/TFE_DarkForces/vueLogic.cpp
@@ -230,7 +230,11 @@ namespace TFE_DarkForces
 					frame->offset.y = floatToFixed16(y1);
 					frame->offset.z = floatToFixed16(z1);
 					frame->yaw   = vec2ToAngle(floatToFixed16(x2 - x1), floatToFixed16(z2 - z1));
-					frame->pitch = 0;
+					
+					f32 dx = x2 - x1;
+					f32 dz = z2 - z1;
+					double xzVec = sqrt(dx * dx + dz * dz);
+					frame->pitch = vec2ToAngle(floatToFixed16(y1 - y2), floatToFixed16(xzVec));
 					frame->roll  = angle14_32(r * 16383.0f / 360.0f);
 				}
 			}
@@ -586,6 +590,8 @@ namespace TFE_DarkForces
 
 							local(obj)->posWS = local(frame)->offset;
 							local(obj)->yaw = local(frame)->yaw;
+							local(obj)->pitch = local(frame)->pitch;
+							local(obj)->roll = local(frame)->roll;
 						task_localBlockEnd;
 
 						entity_yield(TASK_NO_DELAY);

--- a/TheForceEngine/TFE_Jedi/Renderer/jediRenderer.cpp
+++ b/TheForceEngine/TFE_Jedi/Renderer/jediRenderer.cpp
@@ -457,10 +457,14 @@ namespace TFE_Jedi
 		}
 	#endif
 
+		// Clamp the pitch to 60 degrees (vanilla plus) for software renderer
+		// Higher values may be passed in if the camera is being moved by a VUE or is attached to a non-player object
+		angle14_32 clampedPitch = clamp(pitch, -2730, 2730);
+
 		// For now compute both fixed-point and floating-point camera transforms so that it is easier to swap between sub-renderers.
 		// TODO: Find a cleaner alternative.
-		RClassic_Fixed::computeCameraTransform(sector, pitch, yaw, camX, camY, camZ);
-		RClassic_Float::computeCameraTransform(sector, f32(pitch), f32(yaw), fixed16ToFloat(camX), fixed16ToFloat(camY), fixed16ToFloat(camZ));
+		RClassic_Fixed::computeCameraTransform(sector, clampedPitch, yaw, camX, camY, camZ);
+		RClassic_Float::computeCameraTransform(sector, f32(clampedPitch), f32(yaw), fixed16ToFloat(camX), fixed16ToFloat(camY), fixed16ToFloat(camZ));
 		RClassic_GPU::computeCameraTransform(sector, f32(pitch), f32(yaw), fixed16ToFloat(camX), fixed16ToFloat(camY), fixed16ToFloat(camZ));
 	}
 		


### PR DESCRIPTION
The (previously unused) camera transform did not calculate pitch, and did not copy pitch to the transformed object. 
It was just set at 0