### PR TITLE
Externalise pickups

### DIFF
--- a/TheForceEngine/ExternalData/DarkForces/pickups.json
+++ b/TheForceEngine/ExternalData/DarkForces/pickups.json
@@ -1,0 +1,493 @@
+{
+    "maxAmounts": {
+        "ammoEnergy": 500,
+        "ammoPower": 500,
+        "ammoShell": 50,
+        "ammoPlasma": 400,
+        "ammoDetonator": 50,
+        "ammoMine": 30,
+        "ammoMissile": 20,
+        "shields": 200,
+        "batteryPower": 100,
+        "health": 100
+    },
+    "pickups": [
+        {
+            "name": "PLANS",
+            "data": {
+                "type": "objective",
+                "playerItem": "itemPlans",
+                "message1": 400,
+                "fullbright": true,
+                "noRemove": true,
+                "asset": "IDPLANS.WAX"
+            }
+        },
+        {
+            "name": "PHRIK",
+            "data": {
+                "type": "objective",
+                "playerItem": "itemPhrik",
+                "message1": 401,
+                "fullbright": true,
+                "noRemove": true,
+                "asset": "IPHRIK.WAX"
+            }
+        },
+        {
+            "name": "NAVA",
+            "data": {
+                "type": "objective",
+                "playerItem": "itemNava",
+                "message1": 402,
+                "fullbright": true,
+                "noRemove": true,
+                "asset": "INAVA.WAX"
+            }
+        },
+        {
+            "name": "DT_WEAPON",
+            "data": {
+                "type": "objective",
+                "playerItem": "itemDtWeapon",
+                "message1": 405,
+                "noRemove": true,
+                "asset": "IDTGUN.WAX"
+            }
+        },
+        {
+            "name": "DATATAPE",
+            "data": {
+                "type": "objective",
+                "playerItem": "itemDatatape",
+                "message1": 406,
+                "noRemove": true,
+                "asset": "IDATA.FME"
+            }
+        },
+        {
+            "name": "ITEM10",
+            "data": {
+                "type": "objective",
+                "playerItem": "itemUnused",
+                "message1": 403,
+                "noRemove": true,
+                "asset": "ITEM10.WAX"
+            }
+        },
+        {
+            "name": "RIFLE",
+            "data": {
+                "weaponIndex": 2,
+                "type": "weapon",
+                "playerItem": "itemRifle",
+                "playerAmmo": "ammoEnergy",
+                "amount": 15,
+                "message1": 100,
+                "message2": 101,
+                "asset": "IST-GUNI.FME"
+            }
+        },
+        {
+            "name": "AUTOGUN",
+            "data": {
+                "weaponIndex": 4,
+                "type": "weapon",
+                "playerItem": "itemAutogun",
+                "playerAmmo": "ammoPower",
+                "amount": 30,
+                "message1": 103,
+                "message2": 104,
+                "asset": "IAUTOGUN.FME"
+            }
+        },
+        {
+            "name": "MORTAR",
+            "data": {
+                "weaponIndex": 6,
+                "type": "weapon",
+                "playerItem": "itemMortar",
+                "playerAmmo": "ammoShell",
+                "amount": 3,
+                "message1": 105,
+                "message2": 106,
+                "asset": "IMORTAR.FME"
+            }
+        },
+        {
+            "name": "FUSION",
+            "data": {
+                "weaponIndex": 5,
+                "type": "weapon",
+                "playerItem": "itemFusion",
+                "playerAmmo": "ammoPower",
+                "amount": 50,
+                "message1": 107,
+                "message2": 108,
+                "asset": "IFUSION.FME"
+            }
+        },
+        {
+            "name": "CONCUSSION",
+            "data": {
+                "weaponIndex": 8,
+                "type": "weapon",
+                "playerItem": "itemConcussion",
+                "playerAmmo": "ammoPower",
+                "amount": 100,
+                "message1": 110,
+                "message2": 111,
+                "asset": "ICONCUS.FME"
+            }
+        },
+        {
+            "name": "CANNON",
+            "data": {
+                "weaponIndex": 9,
+                "type": "weapon",
+                "playerItem": "itemCannon",
+                "playerAmmo": "ammoPlasma",
+                "amount": 30,
+                "message1": 112,
+                "message2": 113,
+                "asset": "ICANNON.FME"
+            }
+        },
+        {
+            "name": "ENERGY",
+            "data": {
+                "type": "ammo",
+                "playerAmmo": "ammoEnergy",
+                "amount": 15,
+                "message1": 200,
+                "asset": "IENERGY.FME"
+            }
+        },
+        {
+            "name": "POWER",
+            "data": {
+                "type": "ammo",
+                "playerAmmo": "ammoPower",
+                "amount": 10,
+                "message1": 201,
+                "asset": "IPOWER.FME"
+            }
+        },
+        {
+            "name": "PLASMA",
+            "data": {
+                "type": "ammo",
+                "playerAmmo": "ammoPlasma",
+                "amount": 20,
+                "message1": 202,
+                "asset": "IPLAZMA.FME"
+            }
+        },
+        {
+            "name": "DETONATOR",
+            "data": {
+                "type": "ammo",
+                "playerAmmo": "ammoDetonator",
+                "amount": 1,
+                "message1": 203,
+                "asset": "IDET.FME"
+            }
+        },
+        {
+            "name": "DETONATORS",
+            "data": {
+                "type": "ammo",
+                "playerAmmo": "ammoDetonator",
+                "amount": 5,
+                "message1": 204,
+                "asset": "IDETS.FME"
+            }
+        },
+        {
+            "name": "SHELL",
+            "data": {
+                "type": "ammo",
+                "playerAmmo": "ammoShell",
+                "amount": 1,
+                "message1": 205,
+                "asset": "ISHELL.FME"
+            }
+        },
+        {
+            "name": "SHELLS",
+            "data": {
+                "type": "ammo",
+                "playerAmmo": "ammoShell",
+                "amount": 5,
+                "message1": 206,
+                "asset": "ISHELLS.FME"
+            }
+        },
+        {
+            "name": "MINE",
+            "data": {
+                "type": "ammo",
+                "playerAmmo": "ammoMine",
+                "amount": 1,
+                "message1": 207,
+                "asset": "IMINE.FME"
+            }
+        },
+        {
+            "name": "MINES",
+            "data": {
+                "type": "ammo",
+                "playerAmmo": "ammoMine",
+                "amount": 5,
+                "message1": 208,
+                "asset": "IMINES.FME"
+            }
+        },
+        {
+            "name": "MISSILE",
+            "data": {
+                "type": "ammo",
+                "playerAmmo": "ammoMissile",
+                "amount": 1,
+                "message1": 209,
+                "asset": "IMSL.FME"
+            }
+        },
+        {
+            "name": "MISSILES",
+            "data": {
+                "type": "ammo",
+                "playerAmmo": "ammoMissile",
+                "amount": 5,
+                "message1": 210,
+                "asset": "IMSLS.FME"
+            }
+        },
+        {
+            "name": "SHIELD",
+            "data": {
+                "type": "ammo",
+                "playerAmmo": "shields",
+                "amount": 20,
+                "message1": 114,
+                "asset": "IARMOR.WAX"
+            }
+        },
+        {
+            "name": "RED_KEY",
+            "data": {
+                "type": "usable",
+                "playerItem": "itemRedKey",
+                "message1": 300,
+                "asset": "IKEYR.FME"
+            }
+        },
+        {
+            "name": "YELLOW_KEY",
+            "data": {
+                "type": "usable",
+                "playerItem": "itemYellowKey",
+                "message1": 301,
+                "asset": "IKEYY.FME"
+            }
+        },
+        {
+            "name": "BLUE_KEY",
+            "data": {
+                "type": "usable",
+                "playerItem": "itemBlueKey",
+                "message1": 302,
+                "asset": "IKEYB.FME"
+            }
+        },
+        {
+            "name": "GOGGLES",
+            "data": {
+                "type": "usable",
+                "playerItem": "itemGoggles",
+                "playerAmmo": "batteryPower",
+                "message1": 303,
+                "amount": 50,
+                "asset": "IGOGGLES.FME"
+            }
+        },
+        {
+            "name": "CLEATS",
+            "data": {
+                "type": "usable",
+                "playerItem": "itemCleats",
+                "message1": 304,
+                "asset": "ICLEATS.FME"
+            }
+        },
+        {
+            "name": "MASK",
+            "data": {
+                "type": "usable",
+                "playerItem": "itemMask",
+                "playerAmmo": "batteryPower",
+                "message1": 305,
+                "amount": 50,
+                "asset": "IMASK.FME"
+            }
+        },
+        {
+            "name": "BATTERY",
+            "data": {
+                "type": "ammo",
+                "playerAmmo": "batteryPower",
+                "message1": 211,
+                "amount": 50,
+                "asset": "IBATTERY.FME"
+            }
+        },
+        {
+            "name": "CODE1",
+            "data": {
+                "type": "codekey",
+                "playerItem": "itemCode1",
+                "message1": 501,
+                "fullbright": true,
+                "noRemove": true,
+                "asset": "DET_CODE.FME"
+            }
+        },
+        {
+            "name": "CODE2",
+            "data": {
+                "type": "codekey",
+                "playerItem": "itemCode2",
+                "message1": 502,
+                "fullbright": true,
+                "noRemove": true,
+                "asset": "DET_CODE.FME"
+            }
+        },
+        {
+            "name": "CODE3",
+            "data": {
+                "type": "codekey",
+                "playerItem": "itemCode3",
+                "message1": 503,
+                "fullbright": true,
+                "noRemove": true,
+                "asset": "DET_CODE.FME"
+            }
+        },
+        {
+            "name": "CODE4",
+            "data": {
+                "type": "codekey",
+                "playerItem": "itemCode4",
+                "message1": 504,
+                "fullbright": true,
+                "noRemove": true,
+                "asset": "DET_CODE.FME"
+            }
+        },
+        {
+            "name": "CODE5",
+            "data": {
+                "type": "codekey",
+                "playerItem": "itemCode5",
+                "message1": 505,
+                "fullbright": true,
+                "noRemove": true,
+                "asset": "DET_CODE.FME"
+            }
+        },
+        {
+            "name": "CODE6",
+            "data": {
+                "type": "codekey",
+                "playerItem": "itemCode6",
+                "message1": 506,
+                "fullbright": true,
+                "noRemove": true,
+                "asset": "DET_CODE.FME"
+            }
+        },
+        {
+            "name": "CODE7",
+            "data": {
+                "type": "codekey",
+                "playerItem": "itemCode7",
+                "message1": 507,
+                "fullbright": true,
+                "noRemove": true,
+                "asset": "DET_CODE.FME"
+            }
+        },
+        {
+            "name": "CODE8",
+            "data": {
+                "type": "codekey",
+                "playerItem": "itemCode8",
+                "message1": 508,
+                "fullbright": true,
+                "noRemove": true,
+                "asset": "DET_CODE.FME"
+            }
+        },
+        {
+            "name": "CODE9",
+            "data": {
+                "type": "codekey",
+                "playerItem": "itemCode9",
+                "message1": 509,
+                "fullbright": true,
+                "noRemove": true,
+                "asset": "DET_CODE.FME"
+            }
+        },
+        {
+            "name": "INVINCIBLE",
+            "data": {
+                "type": "powerup",
+                "message1": 306,
+                "asset": "IINVINC.WAX"
+            }
+        },
+        {
+            "name": "SUPERCHARGE",
+            "data": {
+                "type": "powerup",
+                "message1": 307,
+                "asset": "ICHARGE.FME"
+            }
+        },
+        {
+            "name": "REVIVE",
+            "data": {
+                "type": "powerup",
+                "message1": 308,
+                "asset": "IREVIVE.WAX"
+            }
+        },
+        {
+            "name": "LIFE",
+            "data": {
+                "type": "powerup",
+                "message1": 310,
+                "asset": "ILIFE.WAX"
+            }
+        },
+        {
+            "name": "MEDKIT",
+            "data": {
+                "type": "ammo",
+                "playerAmmo": "health",
+                "amount": 20,
+                "message1": 311,
+                "asset": "IMEDKIT.FME"
+            }
+        },
+        {
+            "name": "PILE",
+            "data": {
+                "type": "special",
+                "asset": "IPILE.FME"
+            }
+        }
+    ]
+}

--- a/TheForceEngine/TFE_DarkForces/agent.cpp
+++ b/TheForceEngine/TFE_DarkForces/agent.cpp
@@ -271,16 +271,16 @@ namespace TFE_DarkForces
 		memset(&saveData, 0, sizeof(LevelSaveData));
 		memset(data, 0, sizeof(AgentData));
 
-		saveData.inv[0]  = 0xff;
-		saveData.inv[2]  = 0xff;
-		saveData.inv[6]  = 0xff;
-		saveData.inv[30] = WPN_PISTOL;
-		saveData.inv[31] = 3;
+		saveData.inv[0]  = 0xff;			// bryar pistol
+		saveData.inv[2]  = 0xff;			// s_itemUnknown1
+		saveData.inv[6]  = 0xff;			// s_itemUnknown2
+		saveData.inv[30] = WPN_PISTOL;		// current weapon
+		saveData.inv[31] = 3;				// lives
 
-		saveData.ammo[0] = 100;
-		saveData.ammo[7] = 100;
-		saveData.ammo[8] = 100;
-		saveData.ammo[9] = FIXED(2);
+		saveData.ammo[0] = min(s_ammoEnergyMax, 100);	// energy
+		saveData.ammo[7] = 100;				// shields
+		saveData.ammo[8] = 100;				// health
+		saveData.ammo[9] = FIXED(2);		// battery
 
 		strCopyAndZero(data->name, name, 32);
 		data->difficulty = 1;

--- a/TheForceEngine/TFE_DarkForces/hud.cpp
+++ b/TheForceEngine/TFE_DarkForces/hud.cpp
@@ -706,7 +706,7 @@ namespace TFE_DarkForces
 				s_hudWorkPalette[3] = 55;
 				s_hudWorkPalette[4] = 55;
 
-				strcpy(shieldStr, "200");
+				sprintf(shieldStr, "%03d", s_shieldsMax);
 			}
 			else
 			{
@@ -984,7 +984,7 @@ namespace TFE_DarkForces
 					s_hudWorkPalette[3] = 55;
 					s_hudWorkPalette[4] = 55;
 
-					strcpy(shieldStr, "200");
+					sprintf(shieldStr, "%03d", s_shieldsMax);
 				}
 				else
 				{

--- a/TheForceEngine/TFE_DarkForces/item.cpp
+++ b/TheForceEngine/TFE_DarkForces/item.cpp
@@ -4,6 +4,7 @@
 #include "pickup.h"
 #include "animLogic.h"
 #include <TFE_FileSystem/paths.h>
+#include <TFE_ExternalData/pickupExternal.h>
 
 using namespace TFE_Jedi;
 
@@ -12,7 +13,8 @@ namespace TFE_DarkForces
 	///////////////////////////////////////////
 	// Constants
 	///////////////////////////////////////////
-	// TODO: Move into data file for TFE, rather than hardcoding here.
+	
+	/* TFE: Moved to external data 
 	static const char* c_itemResoure[ITEM_COUNT] =
 	{
 		"IDPLANS.WAX",  // ITEM_PLANS
@@ -61,7 +63,7 @@ namespace TFE_DarkForces
 		"IMEDKIT.FME",  // ITEM_MEDKIT
 		"IPILE.FME",    // ITEM_PILE
 		"ITEM10.WAX",	// ITEM_UNUSED
-	};
+	}; */
 
 	///////////////////////////////////////////
 	// Shared State
@@ -80,10 +82,13 @@ namespace TFE_DarkForces
 		s_objectivePickupSnd = sound_load("complete.voc", SOUND_PRIORITY_HIGH5);
 		s_itemPickupSnd     = sound_load("key.voc", SOUND_PRIORITY_MED5);
 
+		TFE_ExternalData::ExternalPickup* externalPickups = TFE_ExternalData::getExternalPickups();
+		char ext[16];
 		for (s32 i = 0; i < ITEM_COUNT; i++)
 		{
-			const char* item = c_itemResoure[i];
-			if (strstr(item, ".WAX"))
+			const char* item = externalPickups[i].asset;
+			FileUtil::getFileExtension(item, ext);
+			if (strcasecmp(ext, "WAX") == 0)
 			{
 				s_itemData[i].wax = TFE_Sprite_Jedi::getWax(item, POOL_GAME);
 				s_itemData[i].isWax = JTRUE;
@@ -93,6 +98,7 @@ namespace TFE_DarkForces
 				s_itemData[i].frame = TFE_Sprite_Jedi::getFrame(item, POOL_GAME);
 				s_itemData[i].isWax = JFALSE;
 			}
+			// TODO: should we also add support for 3DO dropitems??
 		}
 	}
 
@@ -108,6 +114,7 @@ namespace TFE_DarkForces
 		{
 			frame_setData(newObj, s_itemData[itemId].frame);
 		}
+		// TODO: should we also add support for 3DO dropitems??
 
 		obj_createPickup(newObj, itemId);
 		if (s_itemData[itemId].isWax)

--- a/TheForceEngine/TFE_DarkForces/item.cpp
+++ b/TheForceEngine/TFE_DarkForces/item.cpp
@@ -67,8 +67,8 @@ namespace TFE_DarkForces
 	// Shared State
 	///////////////////////////////////////////
 	SoundSourceId s_powerupPickupSnd;
-	SoundSourceId s_invItemPickupSnd;
-	SoundSourceId s_wpnPickupSnd;
+	SoundSourceId s_objectivePickupSnd;
+	SoundSourceId s_itemPickupSnd;
 	ItemData      s_itemData[ITEM_COUNT];
 	
 	///////////////////////////////////////////
@@ -77,8 +77,8 @@ namespace TFE_DarkForces
 	void item_loadData()
 	{
 		s_powerupPickupSnd = sound_load("bonus.voc", SOUND_PRIORITY_HIGH4);
-		s_invItemPickupSnd = sound_load("complete.voc", SOUND_PRIORITY_HIGH5);
-		s_wpnPickupSnd     = sound_load("key.voc", SOUND_PRIORITY_MED5);
+		s_objectivePickupSnd = sound_load("complete.voc", SOUND_PRIORITY_HIGH5);
+		s_itemPickupSnd     = sound_load("key.voc", SOUND_PRIORITY_MED5);
 
 		for (s32 i = 0; i < ITEM_COUNT; i++)
 		{

--- a/TheForceEngine/TFE_DarkForces/item.h
+++ b/TheForceEngine/TFE_DarkForces/item.h
@@ -67,8 +67,8 @@ namespace TFE_DarkForces
 		ITYPE_OBJECTIVE= 1,  // Mission objective item.
 		ITYPE_WEAPON   = 2,  // Weapons
 		ITYPE_AMMO     = 4,  // Pickups that refill ammo, health, shields, etc.
-		ITYPE_KEY_ITEM = 8,  // Keys and usable inventory items.
-		ITYPE_INV_ITEM = 16, // Non-usable Inventory Items
+		ITYPE_USABLE   = 8,  // Keys and usable inventory items.
+		ITYPE_CODEKEY  = 16, // Code keys (Non-usable Inventory Items)
 		ITYPE_POWERUP  = 32, // Powerups & Extra lives.
 		ITYPE_SPECIAL  = 64, // Special - only a single item fits in this type (ITEM_PILE).
 	};
@@ -84,8 +84,8 @@ namespace TFE_DarkForces
 	};
 
 	extern SoundSourceId s_powerupPickupSnd;
-	extern SoundSourceId s_invItemPickupSnd;
-	extern SoundSourceId s_wpnPickupSnd;
+	extern SoundSourceId s_objectivePickupSnd;
+	extern SoundSourceId s_itemPickupSnd;
 	extern ItemData      s_itemData[ITEM_COUNT];
 
 	void item_loadData();

--- a/TheForceEngine/TFE_DarkForces/pickup.cpp
+++ b/TheForceEngine/TFE_DarkForces/pickup.cpp
@@ -9,6 +9,7 @@
 #include <TFE_Jedi/Level/levelData.h>
 #include <TFE_Jedi/Task/task.h>
 #include <TFE_Jedi/Serialization/serialization.h>
+#include <TFE_ExternalData/pickupExternal.h>
 #include <cstring>
 
 using namespace TFE_Jedi;
@@ -267,11 +268,11 @@ namespace TFE_DarkForces
 				} break;
 				case ITEM_REVIVE:
 				{
-					if (s_playerInfo.health < 100 || s_playerInfo.shields < 200)
+					if (s_playerInfo.health < s_healthMax || s_playerInfo.shields < s_shieldsMax)
 					{
 						player_revive();
 						// The function sets shields to 100, so set it to the proper value here.
-						s_playerInfo.shields = 200;
+						s_playerInfo.shields = s_shieldsMax;
 					}
 					else
 					{
@@ -382,7 +383,75 @@ namespace TFE_DarkForces
 		task_end;
 	}
 
-	// TODO: Move pickup data to an external data file to avoid hardcoding.
+	// TFE: Pickups are set from external data instead of hardcoded as in vanilla DF
+	void setPickup(Pickup*& pickup, SecObject* obj, ItemId itemId, TFE_ExternalData::ExternalPickup* externalPickups)
+	{
+		// itemId will correspond to position in externalPickups array
+		pickup->type = ItemType(externalPickups[itemId].type);
+		pickup->weaponIndex = externalPickups[itemId].weaponIndex;
+		pickup->playerItem = externalPickups[itemId].playerItem;
+		pickup->playerAmmo = externalPickups[itemId].playerAmmo;
+		pickup->amount = pickup->playerAmmo == s_playerBatteryPower
+			? s32(externalPickups[itemId].amount / 100.0 * 2 * ONE_16)	// convert battery from a percentage
+			: externalPickups[itemId].amount;
+		
+		pickup->msgId[0] = externalPickups[itemId].message1;
+		pickup->msgId[1] = externalPickups[itemId].message2;
+
+		if (externalPickups[itemId].fullBright)
+		{
+			obj->flags |= OBJ_FLAG_FULLBRIGHT;
+		}
+
+		if (externalPickups[itemId].noRemove)
+		{
+			obj->flags |= OBJ_FLAG_NO_REMOVE;
+		}
+
+		// Set max amounts based on ammo type
+		TFE_ExternalData::MaxAmounts* maxAmounts = TFE_ExternalData::getMaxAmounts();
+		if (externalPickups[itemId].playerAmmo == s_playerAmmoEnergy)
+		{
+			pickup->maxAmount = maxAmounts->ammoEnergyMax;
+		}
+		else if (externalPickups[itemId].playerAmmo == s_playerAmmoPower)
+		{
+			pickup->maxAmount = maxAmounts->ammoPowerMax;
+		}
+		else if (externalPickups[itemId].playerAmmo == s_playerAmmoPlasma)
+		{
+			pickup->maxAmount = maxAmounts->ammoPlasmaMax;
+		}
+		else if (externalPickups[itemId].playerAmmo == s_playerAmmoShell)
+		{
+			pickup->maxAmount = maxAmounts->ammoShellMax;
+		}
+		else if (externalPickups[itemId].playerAmmo == s_playerAmmoDetonators)
+		{
+			pickup->maxAmount = maxAmounts->ammoDetonatorMax;
+		}
+		else if (externalPickups[itemId].playerAmmo == s_playerAmmoMines)
+		{
+			pickup->maxAmount = maxAmounts->ammoMineMax;
+		}
+		else if (externalPickups[itemId].playerAmmo == s_playerAmmoMissiles)
+		{
+			pickup->maxAmount = maxAmounts->ammoMissileMax;
+		}
+		else if (externalPickups[itemId].playerAmmo == s_playerShields)
+		{
+			pickup->maxAmount = maxAmounts->shieldsMax;
+		}
+		else if (externalPickups[itemId].playerAmmo == s_playerHealth)
+		{
+			pickup->maxAmount = maxAmounts->healthMax;
+		}
+		else if (externalPickups[itemId].playerAmmo == s_playerBatteryPower)
+		{
+			pickup->maxAmount = maxAmounts->batteryPowerMax;
+		}
+	}
+
 	Logic* obj_createPickup(SecObject* obj, ItemId id)
 	{
 		Pickup* pickup = (Pickup*)level_alloc(sizeof(Pickup));
@@ -399,382 +468,9 @@ namespace TFE_DarkForces
 		pickup->amount = 0;
 		pickup->msgId[0] = -1;
 		pickup->msgId[1] = -1;
+		pickup->maxAmount = 999;
 
-		switch (id)
-		{
-			// MISSION ITEMS
-			case ITEM_PLANS:
-			{
-				pickup->type = ITYPE_OBJECTIVE;
-				pickup->playerItem = &s_playerInfo.itemPlans;
-				pickup->msgId[0] = 400;
-
-				obj->flags |= (OBJ_FLAG_FULLBRIGHT | OBJ_FLAG_NO_REMOVE);
-			} break;
-			case ITEM_PHRIK:
-			{
-				pickup->type = ITYPE_OBJECTIVE;
-				pickup->playerItem = &s_playerInfo.itemPhrik;
-				pickup->msgId[0] = 401;
-
-				obj->flags |= (OBJ_FLAG_FULLBRIGHT | OBJ_FLAG_NO_REMOVE);
-			} break;
-			case ITEM_NAVA:
-			{
-				pickup->type = ITYPE_OBJECTIVE;
-				pickup->playerItem = &s_playerInfo.itemNava;
-				pickup->msgId[0] = 402;
-
-				obj->flags |= (OBJ_FLAG_FULLBRIGHT | OBJ_FLAG_NO_REMOVE);
-			} break;
-			case ITEM_DT_WEAPON:
-			{
-				pickup->type = ITYPE_OBJECTIVE;
-				pickup->playerItem = &s_playerInfo.itemDtWeapon;
-				pickup->msgId[0] = 405;
-
-				obj->flags |= OBJ_FLAG_NO_REMOVE;
-			} break;
-			case ITEM_DATATAPE:
-			{
-				pickup->type = ITYPE_OBJECTIVE;
-				pickup->playerItem = &s_playerInfo.itemDatatape;
-				pickup->msgId[0] = 406;
-
-				obj->flags |= OBJ_FLAG_NO_REMOVE;
-			} break;
-			case ITEM_UNUSED:
-			{
-				pickup->type = ITYPE_OBJECTIVE;
-				pickup->playerItem = &s_playerInfo.itemUnused;
-				pickup->msgId[0] = 403;
-
-				obj->flags |= OBJ_FLAG_NO_REMOVE;
-			} break;
-			// WEAPONS
-			case ITEM_RIFLE:
-			{
-				pickup->weaponIndex = 2;
-				pickup->type = ITYPE_WEAPON;
-				pickup->playerItem = &s_playerInfo.itemRifle;
-				pickup->playerAmmo = &s_playerInfo.ammoEnergy;
-				pickup->amount = 15;
-				pickup->msgId[0] = 100;
-				pickup->msgId[1] = 101;
-				pickup->maxAmount = 500;
-			} break;
-			case ITEM_AUTOGUN:
-			{
-				pickup->weaponIndex = 4;
-				pickup->type = ITYPE_WEAPON;
-				pickup->playerItem = &s_playerInfo.itemAutogun;
-				pickup->playerAmmo = &s_playerInfo.ammoPower;
-				pickup->amount = 30;
-				pickup->msgId[0] = 103;
-				pickup->msgId[1] = 104;
-				pickup->maxAmount = 500;
-			} break;
-			case ITEM_MORTAR:
-			{
-				pickup->weaponIndex = 6;
-				pickup->type = ITYPE_WEAPON;
-				pickup->playerItem = &s_playerInfo.itemMortar;
-				pickup->playerAmmo = &s_playerInfo.ammoShell;
-				pickup->amount = 3;
-				pickup->msgId[0] = 105;
-				pickup->msgId[1] = 106;
-				pickup->maxAmount = 50;
-			} break;
-			case ITEM_FUSION:
-			{
-				pickup->weaponIndex = 5;
-				pickup->type = ITYPE_WEAPON;
-				pickup->playerItem = &s_playerInfo.itemFusion;
-				pickup->playerAmmo = &s_playerInfo.ammoPower;
-				pickup->amount = 50;
-				pickup->msgId[0] = 107;
-				pickup->msgId[1] = 108;
-				pickup->maxAmount = 500;
-			} break;
-			case ITEM_CONCUSSION:
-			{
-				pickup->weaponIndex = 8;
-				pickup->type = ITYPE_WEAPON;
-				pickup->playerItem = &s_playerInfo.itemConcussion;
-				pickup->playerAmmo = &s_playerInfo.ammoPower;
-				pickup->amount = 100;
-				pickup->msgId[0] = 110;
-				pickup->msgId[1] = 111;
-				pickup->maxAmount = 500;
-			} break;
-			case ITEM_CANNON:
-			{
-				pickup->weaponIndex = 9;
-				pickup->type = ITYPE_WEAPON;
-				pickup->playerItem = &s_playerInfo.itemCannon;
-				pickup->playerAmmo = &s_playerInfo.ammoPlasma;
-				pickup->amount = 30;
-				pickup->msgId[0] = 112;
-				pickup->msgId[1] = 113;
-				pickup->maxAmount = 400;
-			} break;
-			// AMMO
-			case ITEM_ENERGY:
-			{
-				pickup->type = ITYPE_AMMO;
-				pickup->playerAmmo = &s_playerInfo.ammoEnergy;
-				pickup->amount = 15;
-				pickup->msgId[0] = 200;
-				pickup->maxAmount = 500;
-			} break;
-			case ITEM_POWER:
-			{
-				pickup->type = ITYPE_AMMO;
-				pickup->playerAmmo = &s_playerInfo.ammoPower;
-				pickup->amount = 10;
-				pickup->msgId[0] = 201;
-				pickup->maxAmount = 500;
-			} break;
-			case ITEM_PLASMA:
-			{
-				pickup->type = ITYPE_AMMO;
-				pickup->playerAmmo = &s_playerInfo.ammoPlasma;
-				pickup->amount = 20;
-				pickup->msgId[0] = 202;
-				pickup->maxAmount = 400;
-			} break;
-			case ITEM_DETONATOR:
-			{
-				pickup->type = ITYPE_AMMO;
-				pickup->playerAmmo = &s_playerInfo.ammoDetonator;
-				pickup->amount = 1;
-				pickup->msgId[0] = 203;
-				pickup->maxAmount = 50;
-			} break;
-			case ITEM_DETONATORS:
-			{
-				pickup->type = ITYPE_AMMO;
-				pickup->playerAmmo = &s_playerInfo.ammoDetonator;
-				pickup->amount = 5;
-				pickup->msgId[0] = 204;
-				pickup->maxAmount = 50;
-			} break;
-			case ITEM_SHELL:
-			{
-				pickup->type = ITYPE_AMMO;
-				pickup->playerAmmo = &s_playerInfo.ammoShell;
-				pickup->amount = 1;
-				pickup->msgId[0] = 205;
-				pickup->maxAmount = 50;
-			} break;
-			case ITEM_SHELLS:
-			{
-				pickup->type = ITYPE_AMMO;
-				pickup->playerAmmo = &s_playerInfo.ammoShell;
-				pickup->amount = 5;
-				pickup->msgId[0] = 206;
-				pickup->maxAmount = 50;
-			} break;
-			case ITEM_MINE:
-			{
-				pickup->type = ITYPE_AMMO;
-				pickup->playerAmmo = &s_playerInfo.ammoMine;
-				pickup->amount = 1;
-				pickup->msgId[0] = 207;
-				pickup->maxAmount = 30;
-			} break;
-			case ITEM_MINES:
-			{
-				pickup->type = ITYPE_AMMO;
-				pickup->playerAmmo = &s_playerInfo.ammoMine;
-				pickup->amount = 5;
-				pickup->msgId[0] = 208;
-				pickup->maxAmount = 30;
-			} break;
-			case ITEM_MISSILE:
-			{
-				pickup->type = ITYPE_AMMO;
-				pickup->playerAmmo = &s_playerInfo.ammoMissile;
-				pickup->amount = 1;
-				pickup->msgId[0] = 209;
-				pickup->maxAmount = 20;
-			} break;
-			case ITEM_MISSILES:
-			{
-				pickup->type = ITYPE_AMMO;
-				pickup->playerAmmo = &s_playerInfo.ammoMissile;
-				pickup->amount = 5;
-				pickup->msgId[0] = 210;
-				pickup->maxAmount = 20;
-			} break;
-			// PICKUPS & KEYS
-			case ITEM_SHIELD:
-			{
-				pickup->type = ITYPE_AMMO;
-				pickup->playerAmmo = &s_playerInfo.shields;
-				pickup->amount = 20;
-				pickup->msgId[0] = 114;
-				pickup->maxAmount = 200;
-			} break;
-			case ITEM_RED_KEY:
-			{
-				pickup->type = ITYPE_USABLE;
-				pickup->playerItem = &s_playerInfo.itemRedKey;
-				pickup->msgId[0] = 300;
-			} break;
-			case ITEM_YELLOW_KEY:
-			{
-				pickup->type = ITYPE_USABLE;
-				pickup->playerItem = &s_playerInfo.itemYellowKey;
-				pickup->msgId[0] = 301;
-			} break;
-			case ITEM_BLUE_KEY:
-			{
-				pickup->type = ITYPE_USABLE;
-				pickup->playerItem = &s_playerInfo.itemBlueKey;
-				pickup->msgId[0] = 302;
-			} break;
-			case ITEM_GOGGLES:
-			{
-				pickup->type = ITYPE_USABLE;
-				pickup->playerItem = &s_playerInfo.itemGoggles;
-				pickup->playerAmmo = &s_batteryPower;
-				pickup->msgId[0] = 303;
-				pickup->amount = ONE_16;
-				pickup->maxAmount = 2 * ONE_16;
-			} break;
-			case ITEM_CLEATS:
-			{
-				pickup->type = ITYPE_USABLE;
-				pickup->playerItem = &s_playerInfo.itemCleats;
-				pickup->msgId[0] = 304;
-			} break;
-			case ITEM_MASK:
-			{
-				pickup->type = ITYPE_USABLE;
-				pickup->playerItem = &s_playerInfo.itemMask;
-				pickup->playerAmmo = &s_batteryPower;
-				pickup->msgId[0] = 305;
-				pickup->amount = ONE_16;
-				pickup->maxAmount = 2 * ONE_16;
-			} break;
-			case ITEM_BATTERY:
-			{
-				pickup->type = ITYPE_AMMO;
-				pickup->playerAmmo = &s_batteryPower;
-				pickup->msgId[0] = 211;
-				pickup->amount = ONE_16;
-				pickup->maxAmount = 2 * ONE_16;
-			} break;
-			case ITEM_CODE1:
-			{
-				pickup->type = ITYPE_CODEKEY;
-				pickup->playerItem = &s_playerInfo.itemCode1;
-				pickup->msgId[0] = 501;
-
-				obj->flags |= (OBJ_FLAG_FULLBRIGHT | OBJ_FLAG_NO_REMOVE);
-			} break;
-			case ITEM_CODE2:
-			{
-				pickup->type = ITYPE_CODEKEY;
-				pickup->playerItem = &s_playerInfo.itemCode2;
-				pickup->msgId[0] = 502;
-
-				obj->flags |= (OBJ_FLAG_FULLBRIGHT | OBJ_FLAG_NO_REMOVE);
-			} break;
-			case ITEM_CODE3:
-			{
-				pickup->type = ITYPE_CODEKEY;
-				pickup->playerItem = &s_playerInfo.itemCode3;
-				pickup->msgId[0] = 503;
-
-				obj->flags |= (OBJ_FLAG_FULLBRIGHT | OBJ_FLAG_NO_REMOVE);
-			} break;
-			case ITEM_CODE4:
-			{
-				pickup->type = ITYPE_CODEKEY;
-				pickup->playerItem = &s_playerInfo.itemCode4;
-				pickup->msgId[0] = 504;
-
-				obj->flags |= (OBJ_FLAG_FULLBRIGHT | OBJ_FLAG_NO_REMOVE);
-			} break;
-			case ITEM_CODE5:
-			{
-				pickup->type = ITYPE_CODEKEY;
-				pickup->playerItem = &s_playerInfo.itemCode5;
-				pickup->msgId[0] = 505;
-
-				obj->flags |= (OBJ_FLAG_FULLBRIGHT | OBJ_FLAG_NO_REMOVE);
-			} break;
-			case ITEM_CODE6:
-			{
-				pickup->type = ITYPE_CODEKEY;
-				pickup->playerItem = &s_playerInfo.itemCode6;
-				pickup->msgId[0] = 506;
-
-				obj->flags |= (OBJ_FLAG_FULLBRIGHT | OBJ_FLAG_NO_REMOVE);
-			} break;
-			case ITEM_CODE7:
-			{
-				pickup->type = ITYPE_CODEKEY;
-				pickup->playerItem = &s_playerInfo.itemCode7;
-				pickup->msgId[0] = 507;
-
-				obj->flags |= (OBJ_FLAG_FULLBRIGHT | OBJ_FLAG_NO_REMOVE);
-			} break;
-			case ITEM_CODE8:
-			{
-				pickup->type = ITYPE_CODEKEY;
-				pickup->playerItem = &s_playerInfo.itemCode8;
-				pickup->msgId[0] = 508;
-
-				obj->flags |= (OBJ_FLAG_FULLBRIGHT | OBJ_FLAG_NO_REMOVE);
-			} break;
-			case ITEM_CODE9:
-			{
-				pickup->type = ITYPE_CODEKEY;
-				pickup->playerItem = &s_playerInfo.itemCode9;
-				pickup->msgId[0] = 509;
-
-				obj->flags |= (OBJ_FLAG_FULLBRIGHT | OBJ_FLAG_NO_REMOVE);
-			} break;
-			case ITEM_INVINCIBLE:
-			{
-				pickup->type = ITYPE_POWERUP;
-				pickup->playerItem = nullptr;
-				pickup->msgId[0] = 306;
-			} break;
-			case ITEM_SUPERCHARGE:
-			{
-				pickup->type = ITYPE_POWERUP;
-				pickup->playerItem = nullptr;
-				pickup->msgId[0] = 307;
-			} break;
-			case ITEM_REVIVE:
-			{
-				pickup->type = ITYPE_POWERUP;
-				pickup->playerItem = nullptr;
-				pickup->msgId[0] = 308;
-			} break;
-			case ITEM_LIFE:
-			{
-				pickup->type = ITYPE_POWERUP;
-				pickup->playerItem = nullptr;
-				pickup->msgId[0] = 310;
-			} break;
-			case ITEM_MEDKIT:
-			{
-				pickup->type = ITYPE_AMMO;
-				pickup->playerAmmo = &s_playerInfo.health;
-				pickup->amount = 20;
-				pickup->msgId[0] = 311;
-				pickup->maxAmount = 100;
-			} break;
-			case ITEM_PILE:
-			{
-				pickup->type = ITYPE_SPECIAL;
-			} break;
-		}
+		setPickup(pickup, obj, id, TFE_ExternalData::getExternalPickups());
 		return (Logic*)pickup;
 	}
 
@@ -1086,13 +782,13 @@ namespace TFE_DarkForces
 		for (taskCtx->i = 4; taskCtx->i >= 0; taskCtx->i--)
 		{
 			sound_play(s_invCountdownSound);
-			s_playerInfo.shields = 200;
+			s_playerInfo.shields = s_shieldsMax;
 			task_waitWhileIdNotZero(87);	// 0.6 seconds.
 
 			s_playerInfo.shields = 0xffffffff;
 			task_waitWhileIdNotZero(87);	// 0.6 seconds.
 		}
-		s_playerInfo.shields = 200;
+		s_playerInfo.shields = s_shieldsMax;
 		s_invincibility = 0;
 		s_invincibilityTask = nullptr;
 
@@ -1133,7 +829,7 @@ namespace TFE_DarkForces
 	void pickupInvincibility()
 	{
 		s_invincibility = -1;
-		s_playerInfo.shields = JTRUE;	// This seems like a bug...
+		s_playerInfo.shields = -1;		// When set to -1 the HUD will display shields as a special colour (eg. bright yellow)
 		// Free old invincibility task and create a new invincibility task.
 		if (s_invincibilityTask)
 		{
@@ -1185,13 +881,13 @@ namespace TFE_DarkForces
 			level_free(s_playerInvSaved);
 			s_playerInvSaved = nullptr;
 			// Clamp ammo values.
-			s_playerInfo.ammoEnergy    = pickup_addToValue(s_playerInfo.ammoEnergy,    0, 500);
-			s_playerInfo.ammoPower     = pickup_addToValue(s_playerInfo.ammoPower,     0, 500);
-			s_playerInfo.ammoPlasma    = pickup_addToValue(s_playerInfo.ammoPlasma,    0, 400);
-			s_playerInfo.ammoDetonator = pickup_addToValue(s_playerInfo.ammoDetonator, 0,  50);
-			s_playerInfo.ammoShell     = pickup_addToValue(s_playerInfo.ammoShell,     0,  50);
-			s_playerInfo.ammoMine      = pickup_addToValue(s_playerInfo.ammoMine,      0,  30);
-			s_playerInfo.ammoMissile   = pickup_addToValue(s_playerInfo.ammoMissile,   0,  20);
+			s_playerInfo.ammoEnergy    = pickup_addToValue(s_playerInfo.ammoEnergy,    0, s_ammoEnergyMax);
+			s_playerInfo.ammoPower     = pickup_addToValue(s_playerInfo.ammoPower,     0, s_ammoPowerMax);
+			s_playerInfo.ammoPlasma    = pickup_addToValue(s_playerInfo.ammoPlasma,    0, s_ammoPlasmaMax);
+			s_playerInfo.ammoDetonator = pickup_addToValue(s_playerInfo.ammoDetonator, 0, s_ammoDetonatorMax);
+			s_playerInfo.ammoShell     = pickup_addToValue(s_playerInfo.ammoShell,     0, s_ammoShellMax);
+			s_playerInfo.ammoMine      = pickup_addToValue(s_playerInfo.ammoMine,      0, s_ammoMineMax);
+			s_playerInfo.ammoMissile   = pickup_addToValue(s_playerInfo.ammoMissile,   0, s_ammoMissileMax);
 		}
 	}
 }  // TFE_DarkForces

--- a/TheForceEngine/TFE_DarkForces/pickup.h
+++ b/TheForceEngine/TFE_DarkForces/pickup.h
@@ -21,8 +21,8 @@ namespace TFE_DarkForces
 		ItemId id;
 		s32 weaponIndex;
 		ItemType type;
-		JBool* playerItem;	// Player inventory item
-		s32* playerAmmo;	// Player ammo type, shields, or health 
+		JBool* playerItem;	// Points to s_playerInfo inventory item
+		s32* playerAmmo;	// Points to s_playerInfo ammo type, shields, or health 
 		s32 amount;
 		s32 msgId[2];
 		s32 maxAmount;

--- a/TheForceEngine/TFE_DarkForces/pickup.h
+++ b/TheForceEngine/TFE_DarkForces/pickup.h
@@ -19,10 +19,10 @@ namespace TFE_DarkForces
 	{
 		Logic logic;		// Logic header.
 		ItemId id;
-		s32 index;
+		s32 weaponIndex;
 		ItemType type;
-		JBool* item;
-		s32* value;
+		JBool* playerItem;	// Player inventory item
+		s32* playerAmmo;	// Player ammo type, shields, or health 
 		s32 amount;
 		s32 msgId[2];
 		s32 maxAmount;

--- a/TheForceEngine/TFE_DarkForces/player.h
+++ b/TheForceEngine/TFE_DarkForces/player.h
@@ -137,6 +137,28 @@ namespace TFE_DarkForces
 	extern SoundSourceId s_kyleScreamSoundSource;
 	extern SoundSourceId s_playerShieldHitSoundSource;
 
+	extern s32* s_playerAmmoEnergy;
+	extern s32* s_playerAmmoPower;
+	extern s32* s_playerAmmoPlasma;
+	extern s32* s_playerAmmoShell;
+	extern s32* s_playerAmmoDetonators;
+	extern s32* s_playerAmmoMines;
+	extern s32* s_playerAmmoMissiles;
+	extern s32* s_playerShields;
+	extern s32* s_playerHealth;
+	extern fixed16_16* s_playerBatteryPower;
+
+	extern s32 s_ammoEnergyMax;
+	extern s32 s_ammoPowerMax;
+	extern s32 s_ammoShellMax;
+	extern s32 s_ammoPlasmaMax;
+	extern s32 s_ammoDetonatorMax;
+	extern s32 s_ammoMineMax;
+	extern s32 s_ammoMissileMax;
+	extern s32 s_shieldsMax;
+	extern fixed16_16 s_batteryPowerMax;
+	extern s32 s_healthMax;
+
 	void player_init();
 	void player_readInfo(u8* inv, s32* ammo);
 	void player_writeInfo(u8* inv, s32* ammo);

--- a/TheForceEngine/TFE_DarkForces/weaponFireFunc.cpp
+++ b/TheForceEngine/TFE_DarkForces/weaponFireFunc.cpp
@@ -323,7 +323,7 @@ namespace TFE_DarkForces
 				// it is true every other frame.
 				if (superChargeFrame | (s_fireFrame & 1))
 				{
-					*s_curPlayerWeapon->ammo = pickup_addToValue(s_playerInfo.ammoEnergy, -1, 500);
+					*s_curPlayerWeapon->ammo = pickup_addToValue(s_playerInfo.ammoEnergy, -1, s_ammoEnergyMax);
 				}
 
 				ProjectileLogic* projLogic;
@@ -508,7 +508,7 @@ namespace TFE_DarkForces
 				// it is true every other frame.
 				if (superChargeFrame | (s_fireFrame & 1))
 				{
-					*s_curPlayerWeapon->ammo = pickup_addToValue(s_playerInfo.ammoEnergy, -2, 500);
+					*s_curPlayerWeapon->ammo = pickup_addToValue(s_playerInfo.ammoEnergy, -2, s_ammoEnergyMax);
 				}
 
 				ProjectileLogic* projLogic;
@@ -632,7 +632,7 @@ namespace TFE_DarkForces
 		{
 			s_canFireWeaponPrim = 0;
 			s_canFireWeaponSec = 0;
-			*s_curPlayerWeapon->ammo = pickup_addToValue(s_playerInfo.ammoDetonator, -1, 50);
+			*s_curPlayerWeapon->ammo = pickup_addToValue(s_playerInfo.ammoDetonator, -1, s_ammoDetonatorMax);
 
 			// Weapon Frame 0.
 			s_curPlayerWeapon->frame = c_thermalDetAnim[0].waxFrame;
@@ -840,7 +840,7 @@ namespace TFE_DarkForces
 					// it is true every other frame.
 					if (superChargeFrame | (s_fireFrame & 1))
 					{
-						*s_curPlayerWeapon->ammo = pickup_addToValue(s_playerInfo.ammoPower, -3, 500);
+						*s_curPlayerWeapon->ammo = pickup_addToValue(s_playerInfo.ammoPower, -3, s_ammoPowerMax);
 					}
 					
 					fixed16_16 yPos = s_playerObject->posWS.y - s_playerObject->worldHeight + s_headwaveVerticalOffset;
@@ -1002,7 +1002,7 @@ namespace TFE_DarkForces
 					// it is true every other frame.
 					if (superChargeFrame | (s_fireFrame & 1))
 					{
-						*s_curPlayerWeapon->ammo = pickup_addToValue(s_playerInfo.ammoPower, -1, 500);
+						*s_curPlayerWeapon->ammo = pickup_addToValue(s_playerInfo.ammoPower, -1, s_ammoPowerMax);
 					}
 
 					fixed16_16 yPos = s_playerObject->posWS.y - s_playerObject->worldHeight + s_headwaveVerticalOffset;
@@ -1160,7 +1160,7 @@ namespace TFE_DarkForces
 					// it is true every other frame.
 					if (superChargeFrame | (s_fireFrame & 1))
 					{
-						*s_curPlayerWeapon->ammo = pickup_addToValue(s_playerInfo.ammoPower, -8, 500);
+						*s_curPlayerWeapon->ammo = pickup_addToValue(s_playerInfo.ammoPower, -8, s_ammoPowerMax);
 					}
 
 					fixed16_16 yPos = s_playerObject->posWS.y - s_playerObject->worldHeight + s_headwaveVerticalOffset;
@@ -1314,7 +1314,7 @@ namespace TFE_DarkForces
 					// it is true every other frame.
 					if (superChargeFrame | (s_fireFrame & 1))
 					{
-						*s_curPlayerWeapon->ammo = pickup_addToValue(s_playerInfo.ammoPower, -1, 500);
+						*s_curPlayerWeapon->ammo = pickup_addToValue(s_playerInfo.ammoPower, -1, s_ammoPowerMax);
 					}
 
 					fixed16_16 yPlayerPos = s_playerObject->posWS.y - s_playerObject->worldHeight + s_headwaveVerticalOffset;
@@ -1499,7 +1499,7 @@ namespace TFE_DarkForces
 				// it is true every other frame.
 				if (superChargeFrame | (s_fireFrame & 1))
 				{
-					*s_curPlayerWeapon->ammo = pickup_addToValue(s_playerInfo.ammoShell, -1, 50);
+					*s_curPlayerWeapon->ammo = pickup_addToValue(s_playerInfo.ammoShell, -1, s_ammoShellMax);
 				}
 
 				ProjectileLogic* projLogic;
@@ -1611,7 +1611,7 @@ namespace TFE_DarkForces
 		task_begin;
 		if (*s_curPlayerWeapon->ammo)
 		{
-			*s_curPlayerWeapon->ammo = pickup_addToValue(s_playerInfo.ammoMine, -1, 30);
+			*s_curPlayerWeapon->ammo = pickup_addToValue(s_playerInfo.ammoMine, -1, s_ammoMineMax);
 			if (s_curPlayerWeapon->wakeupRange)
 			{
 				vec3_fixed origin = { s_playerObject->posWS.x, s_playerObject->posWS.y, s_playerObject->posWS.z };
@@ -1749,7 +1749,7 @@ namespace TFE_DarkForces
 				// it is true every other frame.
 				if (superChargeFrame | (s_fireFrame & 1))
 				{
-					*s_curPlayerWeapon->ammo = pickup_addToValue(s_playerInfo.ammoPower, -4, 500);
+					*s_curPlayerWeapon->ammo = pickup_addToValue(s_playerInfo.ammoPower, -4, s_ammoPowerMax);
 				}
 
 				ProjectileLogic* projLogic;
@@ -1918,7 +1918,7 @@ namespace TFE_DarkForces
 					s32 superChargeFrame = s_superCharge ? 0 : 1;
 					if (superChargeFrame | (s_fireFrame & 1))
 					{
-						*s_curPlayerWeapon->secondaryAmmo = pickup_addToValue(s_playerInfo.ammoMissile, -1, 20);
+						*s_curPlayerWeapon->secondaryAmmo = pickup_addToValue(s_playerInfo.ammoMissile, -1, s_ammoMissileMax);
 					}
 
 					fixed16_16 yPos = s_playerObject->posWS.y - s_playerObject->worldHeight + s_headwaveVerticalOffset;
@@ -2052,7 +2052,7 @@ namespace TFE_DarkForces
 					s32 superChargeFrame = s_superCharge ? 0 : 1;
 					if (superChargeFrame | (s_fireFrame & 1))
 					{
-						*s_curPlayerWeapon->ammo = pickup_addToValue(s_playerInfo.ammoPlasma, -1, 400);
+						*s_curPlayerWeapon->ammo = pickup_addToValue(s_playerInfo.ammoPlasma, -1, s_ammoPlasmaMax);
 					}
 
 					fixed16_16 yPos = s_playerObject->posWS.y - s_playerObject->worldHeight + s_headwaveVerticalOffset;

--- a/TheForceEngine/TFE_ExternalData/pickupExternal.cpp
+++ b/TheForceEngine/TFE_ExternalData/pickupExternal.cpp
@@ -1,0 +1,581 @@
+#include <cstring>
+#include <vector>
+#include <TFE_System/cJSON.h>
+#include <TFE_System/system.h>
+#include <TFE_FileSystem/filestream.h>
+#include <TFE_DarkForces/item.h>
+#include <TFE_DarkForces/player.h>
+#include "pickupExternal.h"
+#include "logicTables.h"
+
+namespace TFE_ExternalData
+{
+	static MaxAmounts s_externalMaxAmounts;
+	static ExternalPickup s_externalPickups[TFE_DarkForces::ITEM_COUNT];
+	static bool s_externalPickupsFromMod = false;
+
+	////////////////////////////////
+	// Forward Declarations
+	////////////////////////////////
+	int getPickupIndex(char* name);
+	bool tryAssignMaxAmount(cJSON* data);
+	bool tryAssignPickupProperty(cJSON* data, ExternalPickup& pickup);
+
+
+	MaxAmounts* getMaxAmounts()
+	{
+		return &s_externalMaxAmounts;
+	}
+
+	ExternalPickup* getExternalPickups()
+	{
+		return s_externalPickups;
+	}
+
+	void clearExternalPickups()
+	{
+		s_externalPickupsFromMod = false;
+		for (int i = 0; i < TFE_DarkForces::ITEM_COUNT; i++)
+		{
+			s_externalPickups[i].name = nullptr;
+		}
+
+		// Restore defaults
+		s_externalMaxAmounts.ammoEnergyMax = 500;
+		s_externalMaxAmounts.ammoPowerMax = 500;
+		s_externalMaxAmounts.ammoShellMax = 50;
+		s_externalMaxAmounts.ammoPlasmaMax = 400;
+		s_externalMaxAmounts.ammoDetonatorMax = 50;
+		s_externalMaxAmounts.ammoMineMax = 30;
+		s_externalMaxAmounts.ammoMissileMax = 20;
+		s_externalMaxAmounts.shieldsMax = 200;
+		s_externalMaxAmounts.batteryPowerMax = 2 * ONE_16;
+		s_externalMaxAmounts.healthMax = 100;
+	}
+
+	void loadExternalPickups()
+	{
+		const char* programDir = TFE_Paths::getPath(PATH_PROGRAM);
+		char extDataFile[TFE_MAX_PATH];
+		sprintf(extDataFile, "%sExternalData/DarkForces/pickups.json", programDir);
+
+		TFE_System::logWrite(LOG_MSG, "EXTERNAL_DATA", "Loading pickup data");
+		FileStream file;
+		if (!file.open(extDataFile, FileStream::MODE_READ)) { return; }
+
+		const size_t size = file.getSize();
+		char* data = (char*)malloc(size + 1);
+		if (!data || size == 0)
+		{
+			TFE_System::logWrite(LOG_ERROR, "EXTERNAL_DATA", "Pickups.json is %u bytes in size and cannot be read.", size);
+			return;
+		}
+		file.readBuffer(data, (u32)size);
+		data[size] = 0;
+		file.close();
+
+		parseExternalPickups(data, false);
+		free(data);
+	}
+
+	void parseExternalPickups(char* data, bool fromMod)
+	{
+		// If pickups have already been loaded from a mod, don't replace them
+		if (s_externalPickupsFromMod)
+		{
+			return;
+		}
+
+		cJSON* root = cJSON_Parse(data);
+		if (root)
+		{
+			cJSON* section = root->child;
+			while (section)
+			{
+				if (cJSON_IsObject(section) && strcasecmp(section->string, "maxAmounts") == 0)
+				{
+					// parse the Max Amounts
+					cJSON* maxAmt = section->child;
+					while (maxAmt)
+					{
+						if (cJSON_IsNumber(maxAmt))
+						{
+							tryAssignMaxAmount(maxAmt);
+						}
+						
+						maxAmt = maxAmt->next;
+					}
+				}
+				else if (cJSON_IsArray(section) && strcasecmp(section->string, "pickups") == 0)
+				{
+					cJSON* pickup = section->child;
+					while (pickup)
+					{
+						cJSON* pickupName = pickup->child;
+
+						// get the pickup name
+						if (pickupName && cJSON_IsString(pickupName) && strcasecmp(pickupName->string, "name") == 0)
+						{
+							// For now stick with the hardcoded DF list
+							int index = getPickupIndex(pickupName->valuestring);
+
+							if (index >= 0)
+							{
+								ExternalPickup extPickup = {};
+								extPickup.name = pickupName->valuestring;
+
+								cJSON* pickupData = pickupName->next;
+								if (pickupData && cJSON_IsObject(pickupData))
+								{
+									cJSON* dataItem = pickupData->child;
+
+									// iterate through the data and assign properties
+									while (dataItem)
+									{
+										tryAssignPickupProperty(dataItem, extPickup);
+										dataItem = dataItem->next;
+									}
+								}
+
+								s_externalPickups[index] = extPickup;
+							}
+						}
+
+						pickup = pickup->next;
+					}
+				}
+
+				section = section->next;
+			}
+
+			s_externalPickupsFromMod = fromMod && validateExternalPickups();
+		}
+		else
+		{
+			const char* error = cJSON_GetErrorPtr();
+			if (error)
+			{
+				TFE_System::logWrite(LOG_ERROR, "EXTERNAL_DATA", "Failed to parse json before\n%s", error);
+			}
+			else
+			{
+				TFE_System::logWrite(LOG_ERROR, "EXTERNAL_DATA", "Failed to parse json");
+			}
+		}
+	}
+
+	bool validateExternalPickups()
+	{
+		// If the name field is null, we can assume the pickup's data hasn't loaded properly
+		for (int i = 0; i < TFE_DarkForces::ITEM_COUNT; i++)
+		{
+			if (!s_externalPickups[i].name)
+			{
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	int getPickupIndex(char* name)
+	{
+		for (int i = 0; i < TFE_DarkForces::ITEM_COUNT; i++)
+		{
+			if (strcasecmp(name, TFE_ExternalData::df_dropItemTable[i]) == 0)
+			{
+				return i;
+			}
+		}
+
+		return -1;
+	}
+
+	bool tryAssignMaxAmount(cJSON* data)
+	{
+		if (strcasecmp(data->string, "ammoEnergy") == 0)
+		{
+			s_externalMaxAmounts.ammoEnergyMax = data->valueint;
+			return true;
+		}
+
+		if (strcasecmp(data->string, "ammoPower") == 0)
+		{
+			s_externalMaxAmounts.ammoPowerMax = data->valueint;
+			return true;
+		}
+
+		if (strcasecmp(data->string, "ammoShell") == 0)
+		{
+			s_externalMaxAmounts.ammoShellMax = data->valueint;
+			return true;
+		}
+
+		if (strcasecmp(data->string, "ammoPlasma") == 0)
+		{
+			s_externalMaxAmounts.ammoPlasmaMax = data->valueint;
+			return true;
+		}
+
+		if (strcasecmp(data->string, "ammoDetonator") == 0)
+		{
+			s_externalMaxAmounts.ammoDetonatorMax = data->valueint;
+			return true;
+		}
+
+		if (strcasecmp(data->string, "ammoMine") == 0)
+		{
+			s_externalMaxAmounts.ammoMineMax = data->valueint;
+			return true;
+		}
+
+		if (strcasecmp(data->string, "ammoMissile") == 0)
+		{
+			s_externalMaxAmounts.ammoMissileMax = data->valueint;
+			return true;
+		}
+
+		if (strcasecmp(data->string, "shields") == 0)
+		{
+			s_externalMaxAmounts.shieldsMax = data->valueint;
+			return true;
+		}
+
+		if (strcasecmp(data->string, "batteryPower") == 0)
+		{
+			// battery power is exposed as a percentage
+			float fraction = data->valueint / 100.0;
+			s_externalMaxAmounts.batteryPowerMax = s32(fraction * 2 * ONE_16);
+			return true;
+		}
+
+		if (strcasecmp(data->string, "health") == 0)
+		{
+			s_externalMaxAmounts.healthMax = data->valueint;
+			return true;
+		}
+
+		return false;
+	}
+
+	bool tryAssignPickupProperty(cJSON* data, ExternalPickup& pickup)
+	{
+		if (cJSON_IsString(data) && strcasecmp(data->string, "type") == 0)
+		{
+			if (strcasecmp(data->valuestring, "objective") == 0)
+			{
+				pickup.type = TFE_DarkForces::ITYPE_OBJECTIVE;
+				return true;
+			}
+			if (strcasecmp(data->valuestring, "weapon") == 0)
+			{
+				pickup.type = TFE_DarkForces::ITYPE_WEAPON;
+				return true;
+			}
+
+			if (strcasecmp(data->valuestring, "ammo") == 0)
+			{
+				pickup.type = TFE_DarkForces::ITYPE_AMMO;
+				return true;
+			}
+			if (strcasecmp(data->valuestring, "usable") == 0)
+			{
+				pickup.type = TFE_DarkForces::ITYPE_USABLE;
+				return true;
+			}
+			if (strcasecmp(data->valuestring, "codekey") == 0)
+			{
+				pickup.type = TFE_DarkForces::ITYPE_CODEKEY;
+				return true;
+			}
+			if (strcasecmp(data->valuestring, "powerup") == 0)
+			{
+				pickup.type = TFE_DarkForces::ITYPE_POWERUP;
+				return true;
+			}
+			if (strcasecmp(data->valuestring, "special") == 0)
+			{
+				pickup.type = TFE_DarkForces::ITYPE_SPECIAL;
+				return true;
+			}
+
+			return false;
+		}
+
+		if (cJSON_IsNumber(data) && strcasecmp(data->string, "weaponIndex") == 0)
+		{
+			pickup.weaponIndex = data->valueint;
+			return true;
+		}
+		
+		if (cJSON_IsString(data) && strcasecmp(data->string, "playerItem") == 0)
+		{
+			if (strcasecmp(data->valuestring, "itemPlans") == 0)
+			{
+				pickup.playerItem = &TFE_DarkForces::s_playerInfo.itemPlans;
+				return true;
+			}
+
+			if (strcasecmp(data->valuestring, "itemNava") == 0)
+			{
+				pickup.playerItem = &TFE_DarkForces::s_playerInfo.itemNava;
+				return true;
+			}
+
+			if (strcasecmp(data->valuestring, "itemPhrik") == 0)
+			{
+				pickup.playerItem = &TFE_DarkForces::s_playerInfo.itemPhrik;
+				return true;
+			}
+
+			if (strcasecmp(data->valuestring, "itemDtWeapon") == 0)
+			{
+				pickup.playerItem = &TFE_DarkForces::s_playerInfo.itemDtWeapon;
+				return true;
+			}
+
+			if (strcasecmp(data->valuestring, "itemDatatape") == 0)
+			{
+				pickup.playerItem = &TFE_DarkForces::s_playerInfo.itemDatatape;
+				return true;
+			}
+
+			if (strcasecmp(data->valuestring, "itemUnused") == 0)
+			{
+				pickup.playerItem = &TFE_DarkForces::s_playerInfo.itemUnused;
+				return true;
+			}
+
+			if (strcasecmp(data->valuestring, "itemRifle") == 0)
+			{
+				pickup.playerItem = &TFE_DarkForces::s_playerInfo.itemRifle;
+				return true;
+			}
+
+			if (strcasecmp(data->valuestring, "itemAutogun") == 0)
+			{
+				pickup.playerItem = &TFE_DarkForces::s_playerInfo.itemAutogun;
+				return true;
+			}
+
+			if (strcasecmp(data->valuestring, "itemMortar") == 0)
+			{
+				pickup.playerItem = &TFE_DarkForces::s_playerInfo.itemMortar;
+				return true;
+			}
+
+			if (strcasecmp(data->valuestring, "itemFusion") == 0)
+			{
+				pickup.playerItem = &TFE_DarkForces::s_playerInfo.itemFusion;
+				return true;
+			}
+
+			if (strcasecmp(data->valuestring, "itemConcussion") == 0)
+			{
+				pickup.playerItem = &TFE_DarkForces::s_playerInfo.itemConcussion;
+				return true;
+			}
+
+			if (strcasecmp(data->valuestring, "itemCannon") == 0)
+			{
+				pickup.playerItem = &TFE_DarkForces::s_playerInfo.itemCannon;
+				return true;
+			}
+
+			if (strcasecmp(data->valuestring, "itemRedKey") == 0)
+			{
+				pickup.playerItem = &TFE_DarkForces::s_playerInfo.itemRedKey;
+				return true;
+			}
+
+			if (strcasecmp(data->valuestring, "itemYellowKey") == 0)
+			{
+				pickup.playerItem = &TFE_DarkForces::s_playerInfo.itemYellowKey;
+				return true;
+			}
+
+			if (strcasecmp(data->valuestring, "itemBlueKey") == 0)
+			{
+				pickup.playerItem = &TFE_DarkForces::s_playerInfo.itemBlueKey;
+				return true;
+			}
+
+			if (strcasecmp(data->valuestring, "itemGoggles") == 0)
+			{
+				pickup.playerItem = &TFE_DarkForces::s_playerInfo.itemGoggles;
+				return true;
+			}
+
+			if (strcasecmp(data->valuestring, "itemCleats") == 0)
+			{
+				pickup.playerItem = &TFE_DarkForces::s_playerInfo.itemCleats;
+				return true;
+			}
+
+			if (strcasecmp(data->valuestring, "itemMask") == 0)
+			{
+				pickup.playerItem = &TFE_DarkForces::s_playerInfo.itemMask;
+				return true;
+			}
+
+			if (strcasecmp(data->valuestring, "itemCode1") == 0)
+			{
+				pickup.playerItem = &TFE_DarkForces::s_playerInfo.itemCode1;
+				return true;
+			}
+
+			if (strcasecmp(data->valuestring, "itemCode2") == 0)
+			{
+				pickup.playerItem = &TFE_DarkForces::s_playerInfo.itemCode2;
+				return true;
+			}
+
+			if (strcasecmp(data->valuestring, "itemCode3") == 0)
+			{
+				pickup.playerItem = &TFE_DarkForces::s_playerInfo.itemCode3;
+				return true;
+			}
+
+			if (strcasecmp(data->valuestring, "itemCode4") == 0)
+			{
+				pickup.playerItem = &TFE_DarkForces::s_playerInfo.itemCode4;
+				return true;
+			}
+
+			if (strcasecmp(data->valuestring, "itemCode5") == 0)
+			{
+				pickup.playerItem = &TFE_DarkForces::s_playerInfo.itemCode5;
+				return true;
+			}
+
+			if (strcasecmp(data->valuestring, "itemCode6") == 0)
+			{
+				pickup.playerItem = &TFE_DarkForces::s_playerInfo.itemCode6;
+				return true;
+			}
+
+			if (strcasecmp(data->valuestring, "itemCode7") == 0)
+			{
+				pickup.playerItem = &TFE_DarkForces::s_playerInfo.itemCode7;
+				return true;
+			}
+
+			if (strcasecmp(data->valuestring, "itemCode8") == 0)
+			{
+				pickup.playerItem = &TFE_DarkForces::s_playerInfo.itemCode8;
+				return true;
+			}
+
+			if (strcasecmp(data->valuestring, "itemCode9") == 0)
+			{
+				pickup.playerItem = &TFE_DarkForces::s_playerInfo.itemCode9;
+				return true;
+			}
+
+			return false;
+		}
+
+		if (cJSON_IsString(data) && strcasecmp(data->string, "playerAmmo") == 0)
+		{
+			if (strcasecmp(data->valuestring, "ammoEnergy") == 0)
+			{
+				pickup.playerAmmo = &TFE_DarkForces::s_playerInfo.ammoEnergy;
+				return true;
+			}
+
+			if (strcasecmp(data->valuestring, "ammoPower") == 0)
+			{
+				pickup.playerAmmo = &TFE_DarkForces::s_playerInfo.ammoPower;
+				return true;
+			}
+
+			if (strcasecmp(data->valuestring, "ammoPlasma") == 0)
+			{
+				pickup.playerAmmo = &TFE_DarkForces::s_playerInfo.ammoPlasma;
+				return true;
+			}
+
+			if (strcasecmp(data->valuestring, "ammoDetonator") == 0)
+			{
+				pickup.playerAmmo = &TFE_DarkForces::s_playerInfo.ammoDetonator;
+				return true;
+			}
+
+			if (strcasecmp(data->valuestring, "ammoShell") == 0)
+			{
+				pickup.playerAmmo = &TFE_DarkForces::s_playerInfo.ammoShell;
+				return true;
+			}
+
+			if (strcasecmp(data->valuestring, "ammoMine") == 0)
+			{
+				pickup.playerAmmo = &TFE_DarkForces::s_playerInfo.ammoMine;
+				return true;
+			}
+
+			if (strcasecmp(data->valuestring, "ammoMissile") == 0)
+			{
+				pickup.playerAmmo = &TFE_DarkForces::s_playerInfo.ammoMissile;
+				return true;
+			}
+
+			if (strcasecmp(data->valuestring, "shields") == 0)
+			{
+				pickup.playerAmmo = &TFE_DarkForces::s_playerInfo.shields;
+				return true;
+			}
+
+			if (strcasecmp(data->valuestring, "batteryPower") == 0)
+			{
+				pickup.playerAmmo = &TFE_DarkForces::s_batteryPower;
+				return true;
+			}
+
+			if (strcasecmp(data->valuestring, "health") == 0)
+			{
+				pickup.playerAmmo = &TFE_DarkForces::s_playerInfo.health;
+				return true;
+			}
+
+			return false;
+		}
+
+		if (cJSON_IsNumber(data) && strcasecmp(data->string, "amount") == 0)
+		{
+			pickup.amount = data->valueint;
+			return true;
+		}
+
+		if (cJSON_IsNumber(data) && strcasecmp(data->string, "message1") == 0)
+		{
+			pickup.message1 = data->valueint;
+			return true;
+		}
+
+		if (cJSON_IsNumber(data) && strcasecmp(data->string, "message2") == 0)
+		{
+			pickup.message2 = data->valueint;
+			return true;
+		}
+
+		if (cJSON_IsBool(data) && strcasecmp(data->string, "fullBright") == 0)
+		{
+			pickup.fullBright = cJSON_IsTrue(data);
+			return true;
+		}
+
+		if (cJSON_IsBool(data) && strcasecmp(data->string, "noRemove") == 0)
+		{
+			pickup.noRemove = cJSON_IsTrue(data);
+			return true;
+		}
+
+		if (cJSON_IsString(data) && strcasecmp(data->string, "asset") == 0)
+		{
+			pickup.asset = data->valuestring;
+			return true;
+		}
+
+		return false;
+	}
+}

--- a/TheForceEngine/TFE_ExternalData/pickupExternal.h
+++ b/TheForceEngine/TFE_ExternalData/pickupExternal.h
@@ -1,0 +1,47 @@
+#pragma once
+#include <TFE_System/types.h>
+#include <TFE_Jedi/Math/fixedPoint.h>
+
+///////////////////////////////////////////
+// TFE Externalised Pickup data
+///////////////////////////////////////////
+
+namespace TFE_ExternalData
+{
+	struct MaxAmounts
+	{
+		s32 ammoEnergyMax = 500;
+		s32 ammoPowerMax = 500;
+		s32 ammoShellMax = 50;
+		s32 ammoPlasmaMax = 400;
+		s32 ammoDetonatorMax = 50;
+		s32 ammoMineMax = 30;
+		s32 ammoMissileMax = 20;
+		s32 shieldsMax = 200;
+		s32 batteryPowerMax = 2 * ONE_16;
+		s32 healthMax = 100;
+	};
+	
+	struct ExternalPickup
+	{
+		const char* name = "";
+		s32 type;
+		s32 weaponIndex = -1;
+		JBool* playerItem = nullptr;
+		s32* playerAmmo = nullptr;
+		s32 amount = 0;
+		s32 message1 = -1;
+		s32 message2 = -1;
+		bool fullBright = false;
+		bool noRemove = false;
+		const char* asset = "";
+	};
+
+	
+	MaxAmounts* getMaxAmounts();
+	ExternalPickup* getExternalPickups();
+	void clearExternalPickups();
+	void loadExternalPickups();
+	void parseExternalPickups(char* data, bool fromMod);
+	bool validateExternalPickups();
+}

--- a/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
+++ b/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
@@ -29,6 +29,7 @@
 #include <TFE_System/utf8.h>
 #include <TFE_ExternalData/dfLogics.h>
 #include <TFE_ExternalData/weaponExternal.h>
+#include <TFE_ExternalData/pickupExternal.h>
 // Game
 #include <TFE_DarkForces/mission.h>
 #include <TFE_DarkForces/gameMusic.h>
@@ -515,6 +516,7 @@ namespace TFE_FrontEndUI
 		TFE_ExternalData::getExternalLogics()->actorLogics.clear();		// clear custom logics
 		TFE_ExternalData::clearExternalProjectiles();					// clear projectiles
 		TFE_ExternalData::clearExternalEffects();						// clear effects
+		TFE_ExternalData::clearExternalPickups();						// clear pickups
 
 		if (TFE_Settings::getSystemSettings()->returnToModLoader && s_modLoaded)
 		{

--- a/TheForceEngine/TFE_Jedi/Level/robjData.h
+++ b/TheForceEngine/TFE_Jedi/Level/robjData.h
@@ -30,7 +30,7 @@ enum ObjectFlags
 	OBJ_FLAG_FULLBRIGHT      = FLAG_BIT(3),  // Rendered as fullbright (not lit).
 	OBJ_FLAG_MOVABLE         = FLAG_BIT(4),  // Object is movable.
 	OBJ_FLAG_BOSS            = FLAG_BIT(5),  // Boss enemy.
-	OBJ_FLAG_MISSION         = FLAG_BIT(6),
+	OBJ_FLAG_NO_REMOVE       = FLAG_BIT(6),  // Do not remove when crushed
 };
 
 enum EntityTypeFlags

--- a/TheForceEngine/TFE_Jedi/Level/rsector.cpp
+++ b/TheForceEngine/TFE_Jedi/Level/rsector.cpp
@@ -836,7 +836,7 @@ namespace TFE_Jedi
 				i++;
 
 				JBool canRemove = (obj->entityFlags & ETFLAG_CORPSE) != 0;
-				canRemove |= ((obj->entityFlags & ETFLAG_PICKUP) && !(obj->flags & OBJ_FLAG_MISSION));
+				canRemove |= ((obj->entityFlags & ETFLAG_PICKUP) && !(obj->flags & OBJ_FLAG_NO_REMOVE));
 
 				const u32 projType = (obj->projectileLogic) ? ((TFE_DarkForces::ProjectileLogic*)obj->projectileLogic)->type : (0);
 				const JBool isLandMine = projType == PROJ_LAND_MINE || projType == PROJ_LAND_MINE_PROX || projType == PROJ_LAND_MINE_PLACED;

--- a/TheForceEngine/TheForceEngine.vcxproj
+++ b/TheForceEngine/TheForceEngine.vcxproj
@@ -509,6 +509,7 @@ echo ^)";
     <ClInclude Include="TFE_Editor\LevelEditor\tabControl.h" />
     <ClInclude Include="TFE_Editor\LevelEditor\userPreferences.h" />
     <ClInclude Include="TFE_Editor\snapshotReaderWriter.h" />
+    <ClInclude Include="TFE_ExternalData\pickupExternal.h" />
     <ClInclude Include="TFE_FileSystem\filestream.h" />
     <ClInclude Include="TFE_FileSystem\fileutil.h" />
     <ClInclude Include="TFE_FileSystem\memorystream.h" />
@@ -897,6 +898,7 @@ echo ^)";
     <ClCompile Include="TFE_Editor\LevelEditor\tabControl.cpp" />
     <ClCompile Include="TFE_Editor\LevelEditor\userPreferences.cpp" />
     <ClCompile Include="TFE_Editor\snapshotReaderWriter.cpp" />
+    <ClCompile Include="TFE_ExternalData\pickupExternal.cpp" />
     <ClCompile Include="TFE_FileSystem\filestream.cpp" />
     <ClCompile Include="TFE_FileSystem\fileutil.cpp" />
     <ClCompile Include="TFE_FileSystem\memorystream.cpp" />

--- a/TheForceEngine/TheForceEngine.vcxproj.filters
+++ b/TheForceEngine/TheForceEngine.vcxproj.filters
@@ -1411,6 +1411,9 @@
     <ClInclude Include="TFE_ExternalData\weaponExternal.h">
       <Filter>Source\TFE_ExternalData</Filter>
     </ClInclude>
+    <ClInclude Include="TFE_ExternalData\pickupExternal.h">
+      <Filter>Source\TFE_ExternalData</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp">
@@ -2458,6 +2461,9 @@
       <Filter>Source\TFE_ExternalData</Filter>
     </ClCompile>
     <ClCompile Include="TFE_ExternalData\weaponExternal.cpp">
+      <Filter>Source\TFE_ExternalData</Filter>
+    </ClCompile>
+    <ClCompile Include="TFE_ExternalData\pickupExternal.cpp">
       <Filter>Source\TFE_ExternalData</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
As was done with projectiles and effects, I've externalised pickups data to a JSON.

The first commit in this PR renames a number of constants and variables to more accurately reflect what they are.