### PR TITLE
Check for FME extension before attempting to load a FME

### DIFF
--- a/TheForceEngine/TFE_DarkForces/item.cpp
+++ b/TheForceEngine/TFE_DarkForces/item.cpp
@@ -93,7 +93,7 @@ namespace TFE_DarkForces
 				s_itemData[i].wax = TFE_Sprite_Jedi::getWax(item, POOL_GAME);
 				s_itemData[i].isWax = JTRUE;
 			}
-			else
+			else if (strcasecmp(ext, "FME") == 0)
 			{
 				s_itemData[i].frame = TFE_Sprite_Jedi::getFrame(item, POOL_GAME);
 				s_itemData[i].isWax = JFALSE;


### PR DESCRIPTION
Hi Lucius, can I please put in this small amendment.
Now that the data is externalised, it is possible that someone can attempt to list a different kind of asset (eg. BM or 3DO) which may cause a crash
I saw one of our modder friends on Discord try it already :-) 
So I think we should block that by ensuring `getFrame()` is only called on a FME