### PR TITLE
Fix for fist ammo

### DIFF
--- a/TheForceEngine/ExternalData/DarkForces/weapons.json
+++ b/TheForceEngine/ExternalData/DarkForces/weapons.json
@@ -12,6 +12,7 @@
                 "textures": ["rhand1.bm", "punch1.bm", "punch2.bm", "punch3.bm"],
                 "xPos": [172, 55, 59, 56],
                 "yPos": [141, 167, 114, 141],
+                "ammo": "",
                 "wakeupRange": 0,
                 "variation": 0,
                 "animFrames": [

--- a/TheForceEngine/TFE_ExternalData/weaponExternal.cpp
+++ b/TheForceEngine/TFE_ExternalData/weaponExternal.cpp
@@ -763,6 +763,12 @@ namespace TFE_ExternalData
 		
 		if (cJSON_IsString(data) && strcasecmp(data->string, "ammo") == 0)
 		{
+			if (strcasecmp(data->valuestring, "") == 0)
+			{
+				weapon.ammo = nullptr;
+				return true;
+			}
+			
 			if (strcasecmp(data->valuestring, "ammoEnergy") == 0)
 			{
 				weapon.ammo = &TFE_DarkForces::s_playerInfo.ammoEnergy;


### PR DESCRIPTION
Realised that I made a small mistake here.
I made ammoEnergy the default ammo (instead of nullptr), to prevent the game from crashing if `weapons.json` is malformed
But for fists, the ammo needs to be nullptr
