### PR TITLE
Fix external data path mapping on linux machines

### DIFF
--- a/TheForceEngine/TFE_ExternalData/pickupExternal.cpp
+++ b/TheForceEngine/TFE_ExternalData/pickupExternal.cpp
@@ -55,9 +55,13 @@ namespace TFE_ExternalData
 
 	void loadExternalPickups()
 	{
-		const char* programDir = TFE_Paths::getPath(PATH_PROGRAM);
 		char extDataFile[TFE_MAX_PATH];
-		sprintf(extDataFile, "%sExternalData/DarkForces/pickups.json", programDir);
+		strcpy(extDataFile, "ExternalData/DarkForces/pickups.json");
+		if (!TFE_Paths::mapSystemPath(extDataFile))
+		{
+			const char* programDir = TFE_Paths::getPath(PATH_PROGRAM);
+			sprintf(extDataFile, "%sExternalData/DarkForces/pickups.json", programDir);
+		}
 
 		TFE_System::logWrite(LOG_MSG, "EXTERNAL_DATA", "Loading pickup data");
 		FileStream file;

--- a/TheForceEngine/TFE_ExternalData/weaponExternal.cpp
+++ b/TheForceEngine/TFE_ExternalData/weaponExternal.cpp
@@ -81,9 +81,13 @@ namespace TFE_ExternalData
 
 	void loadExternalProjectiles()
 	{
-		const char* programDir = TFE_Paths::getPath(PATH_PROGRAM);
 		char extDataFile[TFE_MAX_PATH];
-		sprintf(extDataFile, "%sExternalData/DarkForces/projectiles.json", programDir);
+		strcpy(extDataFile, "ExternalData/DarkForces/projectiles.json");
+		if (!TFE_Paths::mapSystemPath(extDataFile))
+		{
+			const char* programDir = TFE_Paths::getPath(PATH_PROGRAM);
+			sprintf(extDataFile, "%sExternalData/DarkForces/projectiles.json", programDir);
+		}
 
 		TFE_System::logWrite(LOG_MSG, "EXTERNAL_DATA", "Loading projectile data");
 		FileStream file;
@@ -173,9 +177,13 @@ namespace TFE_ExternalData
 
 	void loadExternalEffects()
 	{
-		const char* programDir = TFE_Paths::getPath(PATH_PROGRAM);
 		char extDataFile[TFE_MAX_PATH];
-		sprintf(extDataFile, "%sExternalData/DarkForces/effects.json", programDir);
+		strcpy(extDataFile, "ExternalData/DarkForces/effects.json");
+		if (!TFE_Paths::mapSystemPath(extDataFile))
+		{
+			const char* programDir = TFE_Paths::getPath(PATH_PROGRAM);
+			sprintf(extDataFile, "%sExternalData/DarkForces/effects.json", programDir);
+		}
 
 		TFE_System::logWrite(LOG_MSG, "EXTERNAL_DATA", "Loading effects data");
 		FileStream file;
@@ -265,9 +273,13 @@ namespace TFE_ExternalData
 
 	void loadExternalWeapons()
 	{
-		const char* programDir = TFE_Paths::getPath(PATH_PROGRAM);
 		char extDataFile[TFE_MAX_PATH];
-		sprintf(extDataFile, "%sExternalData/DarkForces/weapons.json", programDir);
+		strcpy(extDataFile, "ExternalData/DarkForces/weapons.json");
+		if (!TFE_Paths::mapSystemPath(extDataFile))
+		{
+			const char* programDir = TFE_Paths::getPath(PATH_PROGRAM);
+			sprintf(extDataFile, "%sExternalData/DarkForces/weapons.json", programDir);
+		}
 
 		TFE_System::logWrite(LOG_MSG, "EXTERNAL_DATA", "Loading weapon data");
 		FileStream file;


### PR DESCRIPTION
This is intended to fix the issue where the ext data files could not  be loaded from outside of the build directory on linux machines