### PR TITLE
Allow getting a sector by name

### DIFF
--- a/TheForceEngine/TFE_DarkForces/Scripting/gs_level.cpp
+++ b/TheForceEngine/TFE_DarkForces/Scripting/gs_level.cpp
@@ -46,6 +46,33 @@ namespace TFE_DarkForces
 		return sector;
 	}
 
+	ScriptSector GS_Level::getSectorByName(std::string name)
+	{
+		const char* sectorName = name.c_str();
+		
+		RSector* targetSector;
+		RWall* targetWall;
+		inf_getMessageTarget(sectorName, &targetSector, &targetWall);
+
+		if (targetSector)
+		{
+			u32 sectorCount = s_levelState.sectorCount;
+			for (u32 s = 0; s < sectorCount; s++)
+			{
+				RSector* sec = &s_levelState.sectors[s];
+				if (sec == targetSector)
+				{
+					ScriptSector sector(s);
+					return sector;
+				}
+			}
+		}
+
+		// Could not find the sector
+		ScriptSector sector(-1);
+		return sector;
+	}
+
 	ScriptElev GS_Level::getElevator(s32 id)
 	{
 		if (id < 0 || id >= allocator_getCount(s_infSerState.infElevators))
@@ -215,6 +242,7 @@ namespace TFE_DarkForces
 
 			// Functions
 			ScriptObjMethod("Sector getSector(int)", getSectorById);
+			ScriptObjMethod("Sector getSector(string)", getSectorByName);
 			ScriptObjMethod("Elevator getElevator(int)", getElevator);
 			ScriptObjMethod("void findConnectedSectors(Sector initSector, uint, array<Sector>&)", findConnectedSectors);
 			// -- Getters --

--- a/TheForceEngine/TFE_DarkForces/Scripting/gs_level.h
+++ b/TheForceEngine/TFE_DarkForces/Scripting/gs_level.h
@@ -25,6 +25,7 @@ namespace TFE_DarkForces
 		bool scriptRegister(ScriptAPI api) override;
 
 		ScriptSector getSectorById(s32 id);
+		ScriptSector getSectorByName(std::string name);
 		ScriptElev   getElevator(s32 id);
 		void findConnectedSectors(ScriptSector initSector, u32 matchProp, CScriptArray& results);
 	};

--- a/TheForceEngine/TFE_Jedi/InfSystem/infSystem.h
+++ b/TheForceEngine/TFE_Jedi/InfSystem/infSystem.h
@@ -86,5 +86,8 @@ namespace TFE_Jedi
 	void inf_sendSectorMessage(RSector* sector, MessageType msgType);
 	void inf_sendLinkMessages(Allocator* infLink, SecObject* entity, u32 evt, MessageType msgType);
 
+	// TFE - expose this method for scripting
+	void inf_getMessageTarget(const char* arg, RSector** sector, RWall** targetWall);
+
 	JBool sector_isDoor(RSector* sector);
 }


### PR DESCRIPTION
We can get sectors by name using inf_getMessageTarget()
Happily, the index of sector names is not cleared until a new level is loaded!