### PR TITLE
Add Flatpak CI

### DIFF
--- a/.github/workflows/ubuntu-gcc.yml
+++ b/.github/workflows/ubuntu-gcc.yml
@@ -42,3 +42,46 @@ jobs:
     - name: Build
       shell: bash
       run: cmake --build ./build --config ${{env.BUILD_TYPE}}
+
+  flatpak:
+    name: Build Flatpak
+    runs-on: ${{ matrix.runner }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        runner:
+          - ubuntu-latest
+          - ubuntu-24.04-arm
+
+    steps:
+    - name: Install Flatpak
+      run: |
+        sudo apt-get update -qq && \
+        sudo apt-get install -y flatpak flatpak-builder && \
+        flatpak remote-add --user --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo && \
+        flatpak install --user -y org.freedesktop.Sdk//24.08 org.freedesktop.Platform//24.08 org.flatpak.Builder
+
+    - uses: actions/checkout@v4
+      with:
+        repository: flathub/io.github.theforceengine.tfe
+        ref: master
+        submodules: true
+
+    - name: Patch Flatpak manifest to build current commit and repo
+      run: |
+        sed -i "s!luciusDXL/TheForceEngine!${{ github.repository }}!" io.github.theforceengine.tfe.yml && \
+        sed -i "s/tag: v.*/commit: ${{ github.sha }}/" io.github.theforceengine.tfe.yml
+        echo "::group::Patched manifest"
+        cat io.github.theforceengine.tfe.yml
+        echo "::endgroup::"
+
+    - name: Build Flatpak
+      run: |
+        flatpak-builder --install-deps-from=flathub \
+          build --force-clean --install --user io.github.theforceengine.tfe.yml
+
+    - name: Verify build
+      run: |
+        flatpak run --command=flatpak-builder-lint org.flatpak.Builder \
+          --exceptions builddir build


### PR DESCRIPTION
This is currently failing due to an unnecessary metadata file in the Flatpak build repo which is missing screenshots. I've craeted a [PR](https://github.com/flathub/io.github.theforceengine.tfe/pull/25) over there to remove this if that's okay with the person who contributed it; once that gets merged the Flatpak CI builds will pass here :)

The build does a clever thing where it uses the Flatpak repo as is, thus providing early warning if changes will break the Flatpak builds. To do this, just before building the Flatpak packages it'll patch the manifest to build the latest commit on whatever repository is actually triggering the build; in a PR that should always be the commit on the repo and branch to be merged so those changes are going to get built against whatever the current stable Flatpak build manifest is :)