### PR TITLE
Update README.md remove mention of DISABLE_SYSMIDI

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ This can be overridden by defining the `TFE_DATA_HOME` environment variable.
   ```sh
   cmake -S /path/to/tfe-source
   ```
-  You can add `-DDISABLE_SYSMIDI=ON` to disable RtMidi (external MIDI synthesizer support)
 * Build it:
   ```sh
   make


### PR DESCRIPTION
Hi,

just noticed this while trying to build TFE. Maybe you are interested. Thanks.

    DISABLE_SYSMIDI seems to have been migrated to ENABLE_SYSMIDI in https://github.com/dedeibel/TheForceEngine/commit/da751a97a27a585f77cc168aa53c5e0a6476d6ce and auto discovery has been implemented