### PR TITLE
Add ability to disable player movement/rotation/fire via scripting

### DIFF
--- a/TheForceEngine/TFE_DarkForces/Scripting/gs_player.cpp
+++ b/TheForceEngine/TFE_DarkForces/Scripting/gs_player.cpp
@@ -22,6 +22,21 @@ namespace TFE_DarkForces
 		AMMO_MISSILE,
 	};
 
+	enum ActionFlags : u32
+	{
+		ACTION_NONE        = 0u,
+		ACTION_MOVE        = FLAG_BIT(0),
+		ACTION_ROTATE      = FLAG_BIT(1),
+		ACTION_FIRE        = FLAG_BIT(2),
+		ACTION_ALL         = ACTION_MOVE | ACTION_ROTATE | ACTION_FIRE,
+		
+		// Others that could be implemented if desired?
+		// ACTION_PITCH
+		// ACTION_CROUCH
+		// ACTION_USE
+		// ACTION_HEADLAMP
+	};
+
 	void killPlayer()
 	{
 		sound_play(s_playerDeathSoundSource);
@@ -546,6 +561,48 @@ namespace TFE_DarkForces
 		}
 	}
 
+	void disableActions(u32 flags)
+	{
+		if (flags & ACTION_MOVE)
+		{
+			s_disablePlayerMovement = JTRUE;
+		}
+		if (flags & ACTION_ROTATE)
+		{
+			s_disablePlayerRotation = JTRUE;
+		}
+		if (flags & ACTION_FIRE)
+		{
+			s_disablePlayerFire = JTRUE;
+		}
+	}
+
+	void enableActions(u32 flags)
+	{
+		if (flags & ACTION_MOVE)
+		{
+			s_disablePlayerMovement = JFALSE;
+		}
+		if (flags & ACTION_ROTATE)
+		{
+			s_disablePlayerRotation = JFALSE;
+		}
+		if (flags & ACTION_FIRE)
+		{
+			s_disablePlayerFire = JFALSE;
+		}
+	}
+
+	u32 getDisabledActions()
+	{
+		u32 result = 0;
+		if (s_disablePlayerMovement) { result |= ACTION_MOVE; }
+		if (s_disablePlayerRotation) { result |= ACTION_ROTATE; }
+		if (s_disablePlayerFire)     { result |= ACTION_FIRE; }
+		
+		return result;
+	}
+
 	bool GS_Player::scriptRegister(ScriptAPI api)
 	{
 		ScriptClassBegin("Player", "player", api);
@@ -577,8 +634,17 @@ namespace TFE_DarkForces
 			ScriptEnumStr(AMMO_MINE);
 			ScriptEnumStr(AMMO_MISSILE);
 
+			ScriptEnumRegister("PlayerActions");
+			ScriptEnumStr(ACTION_MOVE);
+			ScriptEnumStr(ACTION_ROTATE);
+			ScriptEnumStr(ACTION_FIRE);
+			ScriptEnumStr(ACTION_ALL);
+
 			ScriptObjFunc("void kill()", killPlayer);
-			
+			ScriptObjFunc("void disableActions(uint)", disableActions);
+			ScriptObjFunc("void enableActions(uint)", enableActions);
+			ScriptPropertyGetFunc("uint get_disabledActions()", getDisabledActions);
+
 			// Position and velocity
 			ScriptPropertyGetFunc("float3 get_position()", getPlayerPosition);
 			ScriptPropertySetFunc("void set_position(float3)", setPlayerPosition);

--- a/TheForceEngine/TFE_DarkForces/player.cpp
+++ b/TheForceEngine/TFE_DarkForces/player.cpp
@@ -299,6 +299,11 @@ namespace TFE_DarkForces
 	// TFE - constants which can be overridden
 	s32 s_weaponSuperchargeDuration;
 	s32 s_shieldSuperchargeDuration;
+
+	// Scripting
+	JBool s_disablePlayerMovement = JFALSE;
+	JBool s_disablePlayerRotation = JFALSE;
+	JBool s_disablePlayerFire = JFALSE;
 			   
 	///////////////////////////////////////////
 	// Forward Declarations
@@ -890,6 +895,9 @@ namespace TFE_DarkForces
 		s_playerPrimaryFire = JFALSE;
 		s_playerSecFire     = JFALSE;
 		s_playerJumping     = JFALSE;
+		s_disablePlayerMovement = JFALSE;
+		s_disablePlayerRotation = JFALSE;
+		s_disablePlayerFire     = JFALSE;
 
 		s_crushSoundId = 0;
 		s_kyleScreamSoundId = 0;
@@ -1449,11 +1457,16 @@ namespace TFE_DarkForces
 		{
 			ProjectileLogic* proj = (ProjectileLogic*)s_msgEntity;
 			vec3_fixed pushVel;
-			computeDamagePushVelocity(proj, &pushVel);
+			
+			// TFE: Don't push the player if movement disabled
+			if (!s_disablePlayerMovement)
+			{
+				computeDamagePushVelocity(proj, &pushVel);
 
-			s_playerVelX   += pushVel.x;
-			s_playerUpVel2 += pushVel.y;
-			s_playerVelZ   += pushVel.z;
+				s_playerVelX += pushVel.x;
+				s_playerUpVel2 += pushVel.y;
+				s_playerVelZ += pushVel.z;
+			}
 
 			if (s_invincibility || s_config.superShield)
 			{
@@ -1474,10 +1487,14 @@ namespace TFE_DarkForces
 			vec3_fixed pushDir;
 			computeExplosionPushDir(&pos, &pushDir);
 
-			fixed16_16 force = s_msgArg2;
-			s_playerVelX   += mul16(force, pushDir.x);
-			s_playerUpVel2 += mul16(force, pushDir.y);
-			s_playerVelZ   += mul16(force, pushDir.z);
+			// TFE: Don't push the player if movement disabled
+			if (!s_disablePlayerMovement)
+			{
+				fixed16_16 force = s_msgArg2;
+				s_playerVelX += mul16(force, pushDir.x);
+				s_playerUpVel2 += mul16(force, pushDir.y);
+				s_playerVelZ += mul16(force, pushDir.z);
+			}
 
 			if (s_invincibility || s_config.superShield)
 			{
@@ -1534,6 +1551,9 @@ namespace TFE_DarkForces
 		s_playerCrouchSpd = 0;
 		s_prevDistFromFloor = 0;
 		s_playerObject->worldHeight = 0x5cccc;	// 5.8
+		s_disablePlayerMovement = JFALSE;
+		s_disablePlayerRotation = JFALSE;
+		s_disablePlayerFire = JFALSE;
 	}
 
 	void player_changeSector(RSector* newSector)
@@ -1707,7 +1727,7 @@ namespace TFE_DarkForces
 		InputConfig* inputConfig = TFE_Input::inputMapping_get();
 
 		// Yaw change
-		if (inputConfig->mouseMode == MMODE_TURN || inputConfig->mouseMode == MMODE_LOOK)
+		if ((inputConfig->mouseMode == MMODE_TURN || inputConfig->mouseMode == MMODE_LOOK) && !s_disablePlayerRotation)
 		{
 			s_playerYaw += s32(f32(mdx * PLAYER_MOUSE_TURN_SPD) * inputMapping_getHorzMouseSensitivity());
 			s_playerYaw &= ANGLE_MASK;
@@ -1722,7 +1742,7 @@ namespace TFE_DarkForces
 		}
 
 		// Controls
-		if (s_automapLocked)
+		if (s_automapLocked && !s_disablePlayerMovement)
 		{
 			if (inputMapping_getActionState(IADF_FORWARD))
 			{
@@ -1810,7 +1830,7 @@ namespace TFE_DarkForces
 
 		JBool wasJumping = s_playerJumping;
 		s_playerJumping = JFALSE;
-		if (inputMapping_getActionState(IADF_JUMP))
+		if (inputMapping_getActionState(IADF_JUMP) && !s_disablePlayerMovement)
 		{
 			if (!s_onFloor || wasJumping)
 			{
@@ -1838,12 +1858,10 @@ namespace TFE_DarkForces
 			s_playerUpVel2 = 0;
 		}
 
-		//////////////////////////////////////////
 		// Pitch and Roll controls.
-		//////////////////////////////////////////
 		if (s_automapLocked)
 		{
-			if (inputMapping_getActionState(IADF_TURN_LT))
+			if (inputMapping_getActionState(IADF_TURN_LT) && !s_disablePlayerRotation)
 			{
 				fixed16_16 turnSpeed = PLAYER_KB_TURN_SPD;	// angle units per second.
 				fixed16_16 dYaw = mul16(turnSpeed, s_deltaTime);
@@ -1853,7 +1871,7 @@ namespace TFE_DarkForces
 				s_playerYaw -= dYaw;
 				s_playerYaw &= ANGLE_MASK;
 			}
-			else if (inputMapping_getActionState(IADF_TURN_RT))
+			else if (inputMapping_getActionState(IADF_TURN_RT) && !s_disablePlayerRotation)
 			{
 				fixed16_16 turnSpeed = PLAYER_KB_TURN_SPD;	// angle units per second.
 				fixed16_16 dYaw = mul16(turnSpeed, s_deltaTime);
@@ -1863,7 +1881,7 @@ namespace TFE_DarkForces
 				s_playerYaw += dYaw;
 				s_playerYaw &= ANGLE_MASK;
 			}
-			else if (inputMapping_getAnalogAxis(AA_LOOK_HORZ))
+			else if (inputMapping_getAnalogAxis(AA_LOOK_HORZ) && !s_disablePlayerRotation)
 			{
 				fixed16_16 turnSpeed = mul16(mul16(PLAYER_CONTROLLER_TURN_SPD, s_deltaTime), floatToFixed16(inputMapping_getAnalogAxis(AA_LOOK_HORZ)));
 				s_playerYaw += turnSpeed;
@@ -1901,17 +1919,18 @@ namespace TFE_DarkForces
 				s_playerRoll = 0;
 			}
 
-			if (inputMapping_getActionState(IADF_STRAFE_RT))
+			// Strafe movement
+			if (inputMapping_getActionState(IADF_STRAFE_RT) && !s_disablePlayerMovement)
 			{
 				fixed16_16 speed = mul16(PLAYER_STRAFE_SPEED, s_deltaTime);
 				s_strafeSpd = max(speed, s_strafeSpd);
 			}
-			else if (inputMapping_getActionState(IADF_STRAFE_LT))
+			else if (inputMapping_getActionState(IADF_STRAFE_LT) && !s_disablePlayerMovement)
 			{
 				fixed16_16 speed = -mul16(PLAYER_STRAFE_SPEED, s_deltaTime);
 				s_strafeSpd = min(speed, s_strafeSpd);
 			}
-			else if (inputMapping_getAnalogAxis(AA_STRAFE))
+			else if (inputMapping_getAnalogAxis(AA_STRAFE) && !s_disablePlayerMovement)
 			{
 				fixed16_16 speed = mul16(mul16(PLAYER_STRAFE_SPEED, s_deltaTime), floatToFixed16(clamp(inputMapping_getAnalogAxis(AA_STRAFE), -1.0f, 1.0f)));
 				if (speed < 0)
@@ -1930,11 +1949,11 @@ namespace TFE_DarkForces
 			s_playerUse = JTRUE;
 		}
 
-		if (inputMapping_getActionState(IADF_PRIMARY_FIRE))
+		if (inputMapping_getActionState(IADF_PRIMARY_FIRE) && !s_disablePlayerFire)
 		{
 			s_playerPrimaryFire = JTRUE;
 		}
-		else if (inputMapping_getActionState(IADF_SECONDARY_FIRE))
+		else if (inputMapping_getActionState(IADF_SECONDARY_FIRE) && !s_disablePlayerFire)
 		{
 			s_playerSecFire = JTRUE;
 		}
@@ -2141,8 +2160,16 @@ namespace TFE_DarkForces
 		// Then convert from player velocity to per-frame movement.
 		fixed16_16 moveX = adjustForwardSpeed(s_playerVelX);
 		fixed16_16 moveZ = adjustForwardSpeed(s_playerVelZ);
-		s_playerLogic.move.x = mul16(moveX, s_deltaTime) + mul16(s_externalVelX, s_deltaTime);
-		s_playerLogic.move.z = mul16(moveZ, s_deltaTime) + mul16(s_externalVelZ, s_deltaTime);
+		if (s_disablePlayerMovement) // TFE scripting option
+		{
+			s_playerLogic.move.x = 0;
+			s_playerLogic.move.z = 0;
+		}
+		else // normal behaviour
+		{
+			s_playerLogic.move.x = mul16(moveX, s_deltaTime) + mul16(s_externalVelX, s_deltaTime);
+			s_playerLogic.move.z = mul16(moveZ, s_deltaTime) + mul16(s_externalVelZ, s_deltaTime);
+		}
 		s_playerLogic.stepHeight = s_limitStepHeight ? PLAYER_STEP : PLAYER_INF_STEP;
 		fixed16_16 width = (s_smallModeEnabled) ? PLAYER_SIZE_SMALL : PLAYER_WIDTH;
 		player->worldWidth = width;
@@ -3328,6 +3355,10 @@ namespace TFE_DarkForces
 		{
 			setProjectileGravityAccel(projectileGravity);
 		}
+
+		SERIALIZE(ObjState_DisablePlayerMovement, s_disablePlayerMovement, JFALSE);
+		SERIALIZE(ObjState_DisablePlayerMovement, s_disablePlayerRotation, JFALSE);
+		SERIALIZE(ObjState_DisablePlayerMovement, s_disablePlayerFire, JFALSE);
 
 		s32 invSavedSize = 0;
 		if (serialization_getMode() == SMODE_WRITE && s_playerInvSaved)

--- a/TheForceEngine/TFE_DarkForces/player.h
+++ b/TheForceEngine/TFE_DarkForces/player.h
@@ -170,6 +170,11 @@ namespace TFE_DarkForces
 	extern s32 s_weaponSuperchargeDuration;
 	extern s32 s_shieldSuperchargeDuration;
 
+	// Scripting
+	extern JBool s_disablePlayerMovement;
+	extern JBool s_disablePlayerRotation;
+	extern JBool s_disablePlayerFire;
+
 	void player_init();
 	void player_readInfo(u8* inv, s32* ammo);
 	void player_writeInfo(u8* inv, s32* ammo);

--- a/TheForceEngine/TFE_Jedi/Level/robjData.h
+++ b/TheForceEngine/TFE_Jedi/Level/robjData.h
@@ -64,7 +64,8 @@ enum ObjStateVersion : u32
 	ObjState_CrouchToggle = 5,
 	ObjState_CustomLogics = 6,
 	ObjState_ConstOverrides = 7,
-	ObjState_CurVersion = ObjState_ConstOverrides,
+	ObjState_DisablePlayerMovement = 8,
+	ObjState_CurVersion = ObjState_DisablePlayerMovement,
 };
 
 #define SPRITE_SCALE_FIXED FIXED(10)


### PR DESCRIPTION
The motive of this is to support the feature I am creating which allows the camera (eye) to be switched between the player object and other objects.
I want to be able to stop the player from moving while (for example) a cinematic sequence is playing and the eye is elsewhere.

I've allowed separate control over movement, rotation and firing so that modders can have fine-tuned control. Someone might want to suppress firing while still allowing movement, and so on.