### PR TITLE
Scripting get sector by name

### DIFF
--- a/TheForceEngine/TFE_DarkForces/Scripting/gs_level.cpp
+++ b/TheForceEngine/TFE_DarkForces/Scripting/gs_level.cpp
@@ -48,6 +48,30 @@ namespace TFE_DarkForces
 		return sector;
 	}
 
+	ScriptSector GS_Level::getSectorByName(std::string name)
+	{
+		const char* sectorName = name.c_str();
+		
+		MessageAddress* msgAddr = message_getAddress(sectorName);
+		if (msgAddr)
+		{
+			u32 sectorCount = s_levelState.sectorCount;
+			for (u32 s = 0; s < sectorCount; s++)
+			{
+				RSector* sec = &s_levelState.sectors[s];
+				if (sec == msgAddr->sector)
+				{
+					ScriptSector sector(s);
+					return sector;
+				}
+			}
+		}
+
+		// Could not find the sector
+		ScriptSector sector(-1);
+		return sector;
+	}
+
 	ScriptElev GS_Level::getElevator(s32 id)
 	{
 		if (id < 0 || id >= allocator_getCount(s_infSerState.infElevators))
@@ -227,6 +251,7 @@ namespace TFE_DarkForces
 
 			// Functions
 			ScriptObjMethod("Sector getSector(int)", getSectorById);
+			ScriptObjMethod("Sector getSector(string)", getSectorByName);
 			ScriptObjMethod("Elevator getElevator(int)", getElevator);
 			ScriptObjMethod("void findConnectedSectors(Sector initSector, uint, array<Sector>&)", findConnectedSectors);
 

--- a/TheForceEngine/TFE_DarkForces/Scripting/gs_level.h
+++ b/TheForceEngine/TFE_DarkForces/Scripting/gs_level.h
@@ -25,6 +25,7 @@ namespace TFE_DarkForces
 		bool scriptRegister(ScriptAPI api) override;
 
 		ScriptSector getSectorById(s32 id);
+		ScriptSector getSectorByName(std::string name);
 		ScriptElev   getElevator(s32 id);
 		void findConnectedSectors(ScriptSector initSector, u32 matchProp, CScriptArray& results);
 		void setGravity(s32 grav);

--- a/TheForceEngine/TFE_Jedi/InfSystem/message.h
+++ b/TheForceEngine/TFE_Jedi/InfSystem/message.h
@@ -60,6 +60,9 @@ namespace TFE_Jedi
 	void message_sendToObj(SecObject* obj, MessageType msgType, MessageFunc func);
 	void message_sendToSector(RSector* sector, SecObject* entity, u32 evt, MessageType msgType);
 
+	// Serialisation
+	void level_serializeMessageAddresses(Stream* stream);
+
 	// Optional message values - set these before calling message_XXX() and read inside the message function.
 	extern void* s_msgEntity;
 	extern void* s_msgTarget;

--- a/TheForceEngine/TFE_Jedi/Level/levelData.cpp
+++ b/TheForceEngine/TFE_Jedi/Level/levelData.cpp
@@ -22,11 +22,6 @@ namespace TFE_DarkForces
 
 namespace TFE_Jedi
 {
-	enum LevelStateVersion : u32
-	{
-		LevelState_InitVersion = 1,
-		LevelState_CurVersion = LevelState_InitVersion,
-	};
 	enum LevelTextureType : u32
 	{
 		LEVTEX_TYPE_TEX = 1,
@@ -220,6 +215,9 @@ namespace TFE_Jedi
 
 			level_serializeFixupMirrors();
 		}
+
+		// Serialise sector names - so the scripting system can access sectors by their names after save & load
+		level_serializeMessageAddresses(stream);
 
 		// Serialize objects.
 		objData_serialize(stream);

--- a/TheForceEngine/TFE_Jedi/Level/levelData.h
+++ b/TheForceEngine/TFE_Jedi/Level/levelData.h
@@ -32,6 +32,13 @@ struct Task;
 
 namespace TFE_Jedi
 {
+	enum LevelStateVersion : u32
+	{
+		LevelState_InitVersion = 1,
+		LevelState_SaveSectorNames = 2,
+		LevelState_CurVersion = LevelState_SaveSectorNames,
+	};
+
 	enum GoalConstants
 	{
 		COMPL_TRIG = 0,


### PR DESCRIPTION
- Add method to gs_level API to get a sector by its name 
- serialise the MessageAddresses (sector names) so they will persist after save/load
