### PR TITLE
Fix for remaster darkpilo.cfg which is not located in the game folder.

### DIFF
--- a/TheForceEngine/TFE_DarkForces/agent.cpp
+++ b/TheForceEngine/TFE_DarkForces/agent.cpp
@@ -541,10 +541,19 @@ namespace TFE_DarkForces
 				}
 				else
 				{
-					// Finally generate a new one.
-					TFE_System::logWrite(LOG_WARNING, "DarkForcesMain", "Cannot find 'DARKPILO.CFG' at '%s'. Creating a new file for save data.", sourcePath);
-newpilo:
-					createDarkPilotConfig(documentsPath);
+					// Also check the remaster documents path.
+					TFE_Paths::appendPath(PATH_REMASTER_DOCS, "DARKPILO.CFG", sourcePath);
+					if (FileUtil::exists(sourcePath))
+					{
+						FileUtil::copyFile(sourcePath, documentsPath);
+					}
+					else
+					{
+						// Finally generate a new one.
+						TFE_System::logWrite(LOG_WARNING, "DarkForcesMain", "Cannot find 'DARKPILO.CFG' at '%s'. Creating a new file for save data.", sourcePath);
+					newpilo:
+						createDarkPilotConfig(documentsPath);
+					}
 				}
 			}
 		}

--- a/TheForceEngine/TFE_FileSystem/paths-posix.cpp
+++ b/TheForceEngine/TFE_FileSystem/paths-posix.cpp
@@ -140,15 +140,14 @@ namespace TFE_Paths
 			s_paths[PATH_REMASTER_DOCS] = s_paths[PATH_PROGRAM];
 			return true;
 		}
-		
-		string id = to_string(c_steamRemasterProductId[game]);
-		string append = "steamapps/compatdata/" + id + "/pfx/drive_c/users/steamuser/Saved Games/Nightdive Studios";
+		string strId = to_string((int)TFE_Settings::c_steamRemasterProductId[game]);
+		string append = "steamapps/compatdata/" + strId + "/pfx/drive_c/users/steamuser/Saved Games/Nightdive Studios";
 
-		if (id == Game_Dark_Forces)
+		if (game == Game_Dark_Forces)
 		{
 			append += "/Dark Forces Remaster/";
 		}
-		else if (id == Game_Outlaws)
+		else if (game == Game_Outlaws)
 		{
 			append += "/Outlaws Remaster/";
 		}

--- a/TheForceEngine/TFE_FileSystem/paths-posix.cpp
+++ b/TheForceEngine/TFE_FileSystem/paths-posix.cpp
@@ -130,6 +130,18 @@ namespace TFE_Paths
 		return true;
 	}
 
+	bool setRemasterDocsPath(GameID game)
+	{
+		if (isPortableInstall())
+		{
+			s_paths[PATH_REMASTER_DOCS] = s_paths[PATH_PROGRAM];
+			return true;
+		}
+
+		// TO DO - find out where (if?) the remaster docs are available on Linux
+		return false;
+	}
+
 	bool setProgramPath(void)
 	{
 		char p[TFE_MAX_PATH];

--- a/TheForceEngine/TFE_FileSystem/paths-posix.cpp
+++ b/TheForceEngine/TFE_FileSystem/paths-posix.cpp
@@ -141,7 +141,7 @@ namespace TFE_Paths
 			return true;
 		}
 		string strId = to_string((int)TFE_Settings::c_steamRemasterProductId[game]);
-		string append = "steamapps/compatdata/" + strId + "/pfx/drive_c/users/steamuser/Saved Games/Nightdive Studios";
+		string append = "~/.steam/steam/steamapps/compatdata/" + strId + "/pfx/drive_c/users/steamuser/Saved Games/Nightdive Studios";
 
 		if (game == Game_Dark_Forces)
 		{
@@ -151,6 +151,7 @@ namespace TFE_Paths
 		{
 			append += "/Outlaws Remaster/";
 		}
+		else
 		{
 			return false;
 		}

--- a/TheForceEngine/TFE_FileSystem/paths-posix.cpp
+++ b/TheForceEngine/TFE_FileSystem/paths-posix.cpp
@@ -3,6 +3,7 @@
 #include "paths.h"
 #include "fileutil.h"
 #include "filestream.h"
+#include <TFE_Settings/gameSourceData.h>
 #include <TFE_System/system.h>
 #include <TFE_Archive/archive.h>
 #include <algorithm>
@@ -130,6 +131,8 @@ namespace TFE_Paths
 		return true;
 	}
 
+	// There is no official remaster support on linux
+	// Lets approximate proton save locations. 
 	bool setRemasterDocsPath(GameID game)
 	{
 		if (isPortableInstall())
@@ -137,9 +140,23 @@ namespace TFE_Paths
 			s_paths[PATH_REMASTER_DOCS] = s_paths[PATH_PROGRAM];
 			return true;
 		}
+		
+		string id = to_string(c_steamRemasterProductId[game]);
+		string append = "steamapps/compatdata/" + id + "/pfx/drive_c/users/steamuser/Saved Games/Nightdive Studios";
 
-		// TO DO - find out where (if?) the remaster docs are available on Linux
-		return false;
+		if (id == Game_Dark_Forces)
+		{
+			append += "/Dark Forces Remaster/";
+		}
+		else if (id == Game_Outlaws)
+		{
+			append += "/Outlaws Remaster/";
+		}
+		{
+			return false;
+		}
+		s_paths[PATH_REMASTER_DOCS] = append;
+		return !s_paths[PATH_REMASTER_DOCS].empty();
 	}
 
 	bool setProgramPath(void)

--- a/TheForceEngine/TFE_FileSystem/paths.cpp
+++ b/TheForceEngine/TFE_FileSystem/paths.cpp
@@ -123,6 +123,35 @@ namespace TFE_Paths
 		return false;
 	}
 
+	// This is the path to the Remaster documents folder.
+	bool setRemasterDocsPath(GameID game)	
+	{
+	#ifdef _WIN32
+		char path[TFE_MAX_PATH];
+		
+		if (SUCCEEDED(SHGetFolderPath(NULL, CSIDL_PROFILE, NULL, 0, path)))
+		{
+			// Append product-specific path
+			if (game == Game_Dark_Forces)
+			{
+				PathAppend(path, "Saved Games\\Nightdive Studios\\Dark Forces Remaster");
+			}
+			else if (game == Game_Outlaws)
+			{
+				PathAppend(path, "Saved Games\\Nightdive Studios\\Outlaws Remaster");
+			}
+			else
+			{
+				return false;
+			}
+			s_paths[PATH_REMASTER_DOCS] = path;
+			s_paths[PATH_REMASTER_DOCS] += "\\";
+		}
+		return !s_paths[PATH_REMASTER_DOCS].empty();
+	#endif
+		return false;
+	}
+
 	bool setProgramPath()
 	{
 		char path[TFE_MAX_PATH];

--- a/TheForceEngine/TFE_FileSystem/paths.h
+++ b/TheForceEngine/TFE_FileSystem/paths.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "fileutil.h"
 #include <TFE_System/types.h>
+#include <TFE_Settings/gameSourceData.h>
 
 enum TFE_PathType
 {
@@ -10,6 +11,7 @@ enum TFE_PathType
 	PATH_SOURCE_DATA,		// This is the location of the source data, such as maps, textures, etc.
 	PATH_EMULATOR,			// Path to the dosbox exe (for the editor).
 	PATH_MOD,				// Use this to reference mods.
+	PATH_REMASTER_DOCS,     // Path for Remaster Document Folder. 
 	PATH_COUNT
 };
 
@@ -34,6 +36,7 @@ namespace TFE_Paths
 	bool setProgramDataPath(const char* append);
 	bool setUserDocumentsPath(const char* append);
 	// Platform specific executable path.
+	bool setRemasterDocsPath(GameID game);
 	bool setProgramPath();
 	// find a relative path in a TFE system directory. true if mapping was done.
 	bool mapSystemPath(char *path);

--- a/TheForceEngine/main.cpp
+++ b/TheForceEngine/main.cpp
@@ -547,6 +547,7 @@ int main(int argc, char* argv[])
 	const TFE_GameHeader* gameHeader = TFE_Settings::getGameHeader(game->game);
 	TFE_Paths::setPath(PATH_SOURCE_DATA, gameHeader->sourcePath);
 	TFE_Paths::setPath(PATH_EMULATOR, gameHeader->emulatorPath);
+	TFE_Paths::setRemasterDocsPath(game->id);
 
 	// Validate the current game path.
 	validatePath();


### PR DESCRIPTION
Night Dive stores their DARKPILO.cfg in %USERPROFILE%\Saved Games\Nightdive Studios\Dark Forces Remaster instead of the game folder. This is why when people switch to TFE they lose all their saves. 

Fix for #495