### PR TITLE
Don't validate the eye object when loading a savegame

### DIFF
--- a/TheForceEngine/TFE_DarkForces/player.cpp
+++ b/TheForceEngine/TFE_DarkForces/player.cpp
@@ -3362,7 +3362,7 @@ namespace TFE_DarkForces
 		if (serialization_getMode() == SMODE_READ)
 		{
 			s_playerObject = playerObjId < 0 ? nullptr : objData_getObjectBySerializationId(playerObjId);
-			s_playerEye    = playerEyeId < 0 ? nullptr : objData_getObjectBySerializationId(playerEyeId);
+			s_playerEye    = playerEyeId < 0 ? nullptr : objData_getObjectBySerializationId_NoValidation(playerEyeId);
 
 			if (s_nightVisionActive)
 			{


### PR DESCRIPTION
This prevents save/load crashes when the player and eye are different objects
A small number of existing mods (like Purple's recent "Enter the dragon" level) do this.

It isn't necessary to validate the eye object because it should never be deleted.  (If it has somehow been deleted, there are FAR bigger issues to worry about!!!)