### PR TITLE
Animate actors while idle

### DIFF
--- a/TheForceEngine/TFE_DarkForces/Actor/actor.cpp
+++ b/TheForceEngine/TFE_DarkForces/Actor/actor.cpp
@@ -29,6 +29,7 @@
 #include <TFE_Jedi/Memory/list.h>
 #include <TFE_Jedi/Memory/allocator.h>
 #include <TFE_Jedi/Serialization/serialization.h>
+#include <TFE_Settings/settings.h>
 
 using namespace TFE_Jedi;
 
@@ -1351,6 +1352,21 @@ namespace TFE_DarkForces
 		SecObject* obj = logic->logic.obj;
 		obj->anim = actor_getAnimationIndex(ANIM_IDLE);
 		obj->frame = 0;
+
+		// TFE: Find the thinker module and set its animation to the idle animation
+		if (TFE_Settings::jsonAiLogics())
+		{
+			for (s32 i = 0; i < ACTOR_MAX_MODULES; i++)
+			{
+				ActorModule* module = logic->modules[ACTOR_MAX_MODULES - 1 - i];
+				if (module && module->type == ACTMOD_THINKER)
+				{
+					ThinkerModule* thinkerMod = (ThinkerModule*)module;
+					actor_setupAnimation(ANIM_IDLE, &thinkerMod->anim);
+					break;
+				}
+			}
+		}
 	}
 
 	void actor_addModule(ActorDispatch* dispatch, ActorModule* module)
@@ -2109,6 +2125,36 @@ namespace TFE_DarkForces
 								message_sendToObj(obj, MSG_WAKEUP, actor_messageFunc);
 								gameMusic_startFight();
 								collision_effectObjectsInRangeXZ(obj->sector, FIXED(150), obj->posWS, actor_sendWakeupMsg, obj, ETFLAG_AI_ACTOR);
+							}
+						}
+
+						// TFE: Animate in idle state
+						if (TFE_Settings::jsonAiLogics())
+						{
+							s_actorState.curAnimation = nullptr;
+							if (obj->type & OBJ_TYPE_SPRITE)
+							{
+								// Find the thinker module and set its animation as the current animation
+								for (s32 i = 0; i < ACTOR_MAX_MODULES; i++)
+								{
+									ActorModule* module = dispatch->modules[ACTOR_MAX_MODULES - 1 - i];
+									if (module && module->type == ACTMOD_THINKER)
+									{
+										ThinkerModule* thinkerMod = (ThinkerModule*)module;
+										actor_setCurAnimation(&thinkerMod->anim);
+										break;
+									}
+								}
+
+								if (s_actorState.curAnimation)
+								{
+									obj->anim = s_actorState.curAnimation->animId;
+									if (actor_advanceAnimation(s_actorState.curAnimation, obj))
+									{
+										// The animation has finished.
+										s_actorState.curAnimation->flags |= AFLAG_READY;
+									}
+								}
 							}
 						}
 					}

--- a/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
+++ b/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
@@ -1261,7 +1261,7 @@ namespace TFE_FrontEndUI
 		}
 
 		bool jsonAiLogics = gameSettings->df_jsonAiLogics;
-		if (ImGui::Checkbox("Enable custom AI logics from JSON files", &jsonAiLogics))
+		if (ImGui::Checkbox("Enhanced AI logics (requires restart)", &jsonAiLogics))
 		{
 			gameSettings->df_jsonAiLogics = jsonAiLogics;
 		}		


### PR DESCRIPTION
This is achieved by using the thinker module's animation, which is only used for walking/movement animation in the existing code. 
The thinker module's animation is set to looping, which makes it suitable for idle animations, which we would expect to loop indefinitely. (Unlike attack and damage animations which don't loop)

I am making this dependent on the same setting as custom logics. (This setting can eventually be used for an assortment of logic related TFE features)