### PR TITLE
Rotating logs

### DIFF
--- a/TheForceEngine/TFE_System/log.cpp
+++ b/TheForceEngine/TFE_System/log.cpp
@@ -162,7 +162,7 @@ namespace TFE_System
 		}
 	}
 
-	void logRotatingLogFile(const char* fileName, bool append)
+	void openRotatingLog(const char* fileName, bool append)
 	{
 		if (!fileName) { return; }
 

--- a/TheForceEngine/TFE_System/system.h
+++ b/TheForceEngine/TFE_System/system.h
@@ -59,7 +59,7 @@ namespace TFE_System
 	bool logOpen(const char* filename, bool append=false);
 	void logClose();
 	void logWrite(LogWriteType type, const char* tag, const char* str, ...);
-	void logRotatingLogFile(const char* fileName, bool append=false);
+	void openRotatingLog(const char* fileName, bool append=false);
 
 	// Lighter weight debug output (only useful when running in a terminal or debugger).
 	void debugWrite(const char* tag, const char* str, ...);

--- a/TheForceEngine/main.cpp
+++ b/TheForceEngine/main.cpp
@@ -509,7 +509,7 @@ int main(int argc, char* argv[])
 	pathsSet &= TFE_Paths::setProgramPath();
 	pathsSet &= TFE_Paths::setProgramDataPath("TheForceEngine");
 	pathsSet &= TFE_Paths::setUserDocumentsPath("TheForceEngine");
-	TFE_System::logRotatingLogFile("the_force_engine_log.txt");
+	TFE_System::openRotatingLog("the_force_engine_log.txt");
 	TFE_System::logWrite(LOG_MSG, "Main", "The Force Engine %s", c_gitVersion);
 	if (!pathsSet)
 	{


### PR DESCRIPTION
Adding log rotations. This is needed because often people after a crash would try to reopen the program wiping any useful logs. 