### PR TITLE
Enable moving the camera to a different object

### DIFF
--- a/TheForceEngine/TFE_Asset/dfKeywords.cpp
+++ b/TheForceEngine/TFE_Asset/dfKeywords.cpp
@@ -227,7 +227,8 @@ static const char* c_keywords[] =
 	"M_TRIGGER",
 	// TFE
 	"SCRIPTCALL:",
-	"NAME:"
+	"NAME:",
+	"CAMERA",
 };
 
 #define KEYWORD_COUNT TFE_ARRAYSIZE(c_keywords)

--- a/TheForceEngine/TFE_Asset/dfKeywords.h
+++ b/TheForceEngine/TFE_Asset/dfKeywords.h
@@ -235,6 +235,7 @@ enum KEYWORD
 	// TFE ADDED
 	KW_SCRIPTCALL,
 	KW_NAME,
+	KW_CAMERA,				// TFE - camera feature
 	KW_COUNT
 };
 

--- a/TheForceEngine/TFE_DarkForces/Scripting/gs_player.cpp
+++ b/TheForceEngine/TFE_DarkForces/Scripting/gs_player.cpp
@@ -603,6 +603,12 @@ namespace TFE_DarkForces
 		return result;
 	}
 
+	void setCamera()
+	{
+		player_setupEyeObject(s_playerObject);
+		s_externalCameraMode = JFALSE;
+	}
+
 	bool GS_Player::scriptRegister(ScriptAPI api)
 	{
 		ScriptClassBegin("Player", "player", api);
@@ -644,6 +650,7 @@ namespace TFE_DarkForces
 			ScriptObjFunc("void disableActions(uint)", disableActions);
 			ScriptObjFunc("void enableActions(uint)", enableActions);
 			ScriptPropertyGetFunc("uint get_disabledActions()", getDisabledActions);
+			ScriptObjFunc("void setCamera()", setCamera);
 
 			// Position and velocity
 			ScriptPropertyGetFunc("float3 get_position()", getPlayerPosition);

--- a/TheForceEngine/TFE_DarkForces/Scripting/scriptObject.cpp
+++ b/TheForceEngine/TFE_DarkForces/Scripting/scriptObject.cpp
@@ -7,6 +7,8 @@
 #include <TFE_DarkForces/logic.h>
 #include <TFE_DarkForces/animLogic.h>
 #include <TFE_DarkForces/pickup.h>
+#include <TFE_DarkForces/player.h>
+#include <TFE_DarkForces/mission.h>
 #include <TFE_ForceScript/forceScript.h>
 #include <TFE_ForceScript/scriptAPI.h>
 #include <TFE_Jedi/Level/levelData.h>
@@ -265,6 +267,16 @@ namespace TFE_DarkForces
 		// TODO enable adding custom logic
 	}
 
+	void setCamera(ScriptObject* sObject)
+	{
+		if (!doesObjectExist(sObject)) { return; }
+
+		SecObject* obj = TFE_Jedi::s_objectRefList[sObject->m_id].object;
+		player_setupEyeObject(obj);
+		s_externalCameraMode = obj == s_playerObject ? JFALSE : JTRUE;
+		if (s_nightVisionActive) { disableNightVision(); }
+	}
+
 	void ScriptObject::registerType()
 	{
 		s32 res = 0;
@@ -301,5 +313,6 @@ namespace TFE_DarkForces
 		// Other functions
 		ScriptObjFunc("void delete()", deleteObject);
 		ScriptObjFunc("void addLogic(string)", addLogicToObject);
+		ScriptObjFunc("void setCamera()", setCamera);
 	}
 }

--- a/TheForceEngine/TFE_DarkForces/logic.cpp
+++ b/TheForceEngine/TFE_DarkForces/logic.cpp
@@ -102,6 +102,11 @@ namespace TFE_DarkForces
 		{
 			obj->worldWidth = floatToFixed16(strtof(s_objSeqArg1, &endPtr));
 		}
+		// New in TFE
+		else if (key == KW_CAMERA)
+		{
+			obj->flags |= OBJ_FLAG_CAMERA;
+		}
 		else if (key == KW_NAME)
 		{
 			// TFE - scripting

--- a/TheForceEngine/TFE_DarkForces/logic.cpp
+++ b/TheForceEngine/TFE_DarkForces/logic.cpp
@@ -102,15 +102,15 @@ namespace TFE_DarkForces
 		{
 			obj->worldWidth = floatToFixed16(strtof(s_objSeqArg1, &endPtr));
 		}
+		// TFE - scripting
+		else if (key == KW_NAME)
+		{
+			TFE_Jedi::obj_addName(s_objSeqArg1, obj);
+		}
 		// New in TFE
 		else if (key == KW_CAMERA)
 		{
 			obj->flags |= OBJ_FLAG_CAMERA;
-		}
-		else if (key == KW_NAME)
-		{
-			// TFE - scripting
-			TFE_Jedi::obj_addName(s_objSeqArg1, obj);
 		}
 		else  // Invalid key.
 		{

--- a/TheForceEngine/TFE_DarkForces/mission.cpp
+++ b/TheForceEngine/TFE_DarkForces/mission.cpp
@@ -986,7 +986,7 @@ namespace TFE_DarkForces
 
 	void enableNightVision()
 	{
-		if (!s_playerInfo.itemGoggles) { return; }
+		if (!s_playerInfo.itemGoggles || s_externalCameraMode) { return; }
 
 		if (!s_batteryPower)
 		{

--- a/TheForceEngine/TFE_DarkForces/player.cpp
+++ b/TheForceEngine/TFE_DarkForces/player.cpp
@@ -222,6 +222,7 @@ namespace TFE_DarkForces
 	SecObject* s_playerEye = nullptr;
 	vec3_fixed s_eyePos = { 0 };	// s_camX, s_camY, s_camZ in the DOS code.
 	angle14_32 s_eyePitch = 0, s_eyeYaw = 0, s_eyeRoll = 0;
+	JBool s_externalCameraMode = JFALSE;
 	u32 s_playerEyeFlags = OBJ_FLAG_NEEDS_TRANSFORM;
 	Tick s_playerTick;
 	Tick s_prevPlayerTick;
@@ -899,6 +900,8 @@ namespace TFE_DarkForces
 		s_disablePlayerRotation = JFALSE;
 		s_disablePlayerFire     = JFALSE;
 
+		s_externalCameraMode = JFALSE;
+
 		s_crushSoundId = 0;
 		s_kyleScreamSoundId = 0;
 
@@ -1415,7 +1418,7 @@ namespace TFE_DarkForces
 			{
 				renderer_computeCameraTransform(s_playerEye->sector, s_eyePitch, s_eyeYaw, s_eyePos.x, s_eyePos.y, s_eyePos.z);
 			}
-			renderer_setWorldAmbient(s_playerLight);
+			renderer_setWorldAmbient(s_externalCameraMode ? 0 : s_playerLight);		// don't apply headlamp attentuation when camera is away from player
 		}
 	}
 
@@ -1554,6 +1557,9 @@ namespace TFE_DarkForces
 		s_disablePlayerMovement = JFALSE;
 		s_disablePlayerRotation = JFALSE;
 		s_disablePlayerFire = JFALSE;
+
+		s_externalCameraMode = JFALSE;
+		player_setupEyeObject(s_playerObject);
 	}
 
 	void player_changeSector(RSector* newSector)

--- a/TheForceEngine/TFE_DarkForces/player.cpp
+++ b/TheForceEngine/TFE_DarkForces/player.cpp
@@ -3370,6 +3370,7 @@ namespace TFE_DarkForces
 		SERIALIZE(ObjState_DisablePlayerMovement, s_disablePlayerMovement, JFALSE);
 		SERIALIZE(ObjState_DisablePlayerMovement, s_disablePlayerRotation, JFALSE);
 		SERIALIZE(ObjState_DisablePlayerMovement, s_disablePlayerFire, JFALSE);
+		SERIALIZE(ObjState_ExternalCamera, s_externalCameraMode, JFALSE);
 
 		s32 invSavedSize = 0;
 		if (serialization_getMode() == SMODE_WRITE && s_playerInvSaved)

--- a/TheForceEngine/TFE_DarkForces/player.h
+++ b/TheForceEngine/TFE_DarkForces/player.h
@@ -106,6 +106,8 @@ namespace TFE_DarkForces
 	extern fixed16_16 s_playerYPos;
 	extern vec3_fixed s_eyePos;	// s_camX, s_camY, s_camZ in the DOS code.
 	extern angle14_32 s_eyePitch, s_eyeYaw, s_eyeRoll;
+	extern JBool s_externalCameraMode;	// TFE - camera feature
+
 	extern angle14_32 s_playerYaw;
 	extern Tick s_playerTick;
 	extern Tick s_prevPlayerTick;

--- a/TheForceEngine/TFE_DarkForces/weapon.cpp
+++ b/TheForceEngine/TFE_DarkForces/weapon.cpp
@@ -892,6 +892,7 @@ namespace TFE_DarkForces
 
 				if (!s_weaponOffAnim)
 				{
+					// Remove weapon from screen
 					weapon_setIdle();
 					
 					s_weaponAnimState =
@@ -906,6 +907,7 @@ namespace TFE_DarkForces
 				}
 				else
 				{
+					// Return weapon to screen
 					s_weaponOffAnim = JFALSE;
 					if (s_curWeapon == WPN_PISTOL || s_curWeapon == WPN_RIFLE || s_curWeapon == WPN_REPEATER || s_curWeapon == WPN_FUSION || s_curWeapon == WPN_MORTAR ||
 						s_curWeapon == WPN_CONCUSSION || s_curWeapon == WPN_CANNON)
@@ -986,6 +988,12 @@ namespace TFE_DarkForces
 	// for TFE I split it out to limit the amount of game code in the renderer.
 	void weapon_draw(u8* display, DrawRect* rect)
 	{
+		// TFE - don't draw weapon in external camera mode
+		if (s_externalCameraMode)
+		{
+			return;
+		}
+
 		const fixed16_16 weaponLightingZDist  = FIXED(6);
 		const fixed16_16 gasmaskLightingZDist = FIXED(2);
 
@@ -1009,7 +1017,7 @@ namespace TFE_DarkForces
 				x += weapon->xOffset;
 				y += weapon->yOffset;
 			}
-						
+			
 			const u8* atten = RClassic_Fixed::computeLighting(weaponLightingZDist, 0);
 			TextureData* tex = weapon->frames[weapon->frame];
 			if (weapon->ammo && *weapon->ammo == 0 && (weapon->ammo == &s_playerInfo.ammoDetonator || weapon->ammo == &s_playerInfo.ammoMine))

--- a/TheForceEngine/TFE_Jedi/InfSystem/infSystem.cpp
+++ b/TheForceEngine/TFE_Jedi/InfSystem/infSystem.cpp
@@ -11,6 +11,7 @@
 #include <TFE_DarkForces/agent.h>
 #include <TFE_DarkForces/sound.h>
 #include <TFE_DarkForces/automap.h>
+#include <TFE_DarkForces/mission.h>
 #include <TFE_FileSystem/paths.h>
 #include <TFE_Jedi/Memory/allocator.h>
 #include <TFE_Jedi/Level/level.h>
@@ -1921,6 +1922,10 @@ namespace TFE_Jedi
 			case KW_LIGHTS:
 				*type = MSG_LIGHTS;
 				break;
+			// TFE - camera feature
+			case KW_CAMERA:
+				*type = MSG_CAMERA;
+				break;
 			case KW_M_TRIGGER:
 			default:
 				if (elevator)
@@ -3231,6 +3236,42 @@ namespace TFE_Jedi
 						i++;
 					}
 				}
+			} break;
+			// TFE - camera feature
+			case MSG_CAMERA:
+			{
+				if (s_externalCameraMode == JFALSE)
+				{
+					// Change EYE to external camera if there is one
+					s32 objCount = sector->objectCount;
+					s32 objCapacity = sector->objectCapacity;
+					SecObject** objList = sector->objectList;
+
+					for (s32 i = 0; i < objCount && i < objCapacity; objList++)
+					{
+						SecObject* obj = *objList;
+						if (obj)
+						{
+							if (obj->flags & OBJ_FLAG_CAMERA)
+							{
+								// Disable night vision
+								if (s_nightVisionActive) { disableNightVision(); }
+
+								player_setupEyeObject(obj);
+								s_externalCameraMode = JTRUE;
+								break;
+							}
+							i++;
+						}
+					}
+				}
+				else
+				{
+					// Move EYE back to player
+					player_setupEyeObject(s_playerObject);
+					s_externalCameraMode = JFALSE;
+				}
+				
 			} break;
 			case MSG_SET_BITS:
 			{

--- a/TheForceEngine/TFE_Jedi/InfSystem/message.h
+++ b/TheForceEngine/TFE_Jedi/InfSystem/message.h
@@ -37,6 +37,7 @@ enum MessageType
 	MSG_CLEAR_BITS   = 32,
 	MSG_COMPLETE     = 33,
 	MSG_LIGHTS       = 34,
+	MSG_CAMERA		 = 35,		// TFE - camera feature
 	MSG_COUNT
 };
 

--- a/TheForceEngine/TFE_Jedi/Level/robjData.h
+++ b/TheForceEngine/TFE_Jedi/Level/robjData.h
@@ -31,6 +31,7 @@ enum ObjectFlags
 	OBJ_FLAG_MOVABLE         = FLAG_BIT(4),  // Object is movable.
 	OBJ_FLAG_BOSS            = FLAG_BIT(5),  // Boss enemy.
 	OBJ_FLAG_NO_REMOVE       = FLAG_BIT(6),  // Do not remove when crushed
+	OBJ_FLAG_CAMERA			 = FLAG_BIT(7),  // New in TFE
 };
 
 enum EntityTypeFlags

--- a/TheForceEngine/TFE_Jedi/Level/robjData.h
+++ b/TheForceEngine/TFE_Jedi/Level/robjData.h
@@ -67,7 +67,8 @@ enum ObjStateVersion : u32
 	ObjState_ConstOverrides = 7,
 	ObjState_DisablePlayerMovement = 8,
 	ObjState_RefList = 9,
-	ObjState_CurVersion = ObjState_RefList,
+	ObjState_ExternalCamera = 10,
+	ObjState_CurVersion = ObjState_ExternalCamera,
 };
 
 // TFE Scripting


### PR DESCRIPTION
Create a new keyword and message type (`CAMERA`)
Create and serialise a new player static variable `s_externalCameraMode`
Add ability to move the camera via INF or scripting

When camera is away from the player, weapon won't be drawn and nightvision will be disabled.