### PR TITLE
Fix for external pickups 

### DIFF
--- a/TheForceEngine/TFE_ExternalData/pickupExternal.h
+++ b/TheForceEngine/TFE_ExternalData/pickupExternal.h
@@ -24,7 +24,7 @@ namespace TFE_ExternalData
 	
 	struct ExternalPickup
 	{
-		const char* name = "";
+		const char* name = nullptr;
 		s32 type;
 		s32 weaponIndex = -1;
 		JBool* playerItem = nullptr;


### PR DESCRIPTION
`name` should start off as nullptr
