### PR TITLE
Weapon start fix

### DIFF
--- a/TheForceEngine/TFE_DarkForces/player.cpp
+++ b/TheForceEngine/TFE_DarkForces/player.cpp
@@ -811,7 +811,7 @@ namespace TFE_DarkForces
 		}
 
 		// Don't start the game with a weapon you don't have after overrides.
-		if (!player_hasWeapon(s_playerInfo.curWeapon))
+		if (!player_hasWeapon(s_playerInfo.curWeapon + 1))
 		{
 			if (s_playerInfo.itemPistol)
 			{


### PR DESCRIPTION
Prevents you from starting the level by holding a weapon that is removed during MOD_CONF overrides. 