### PR TITLE
Send messages from ForceScript

### DIFF
--- a/TheForceEngine/TFE_DarkForces/Scripting/gs_game.cpp
+++ b/TheForceEngine/TFE_DarkForces/Scripting/gs_game.cpp
@@ -31,6 +31,18 @@ namespace TFE_DarkForces
 	{
 		ScriptClassBegin("Game", "game", api);
 		{
+			// Enums
+			ScriptEnumRegister("MessageType");
+			ScriptEnum("M_TRIGGER", MSG_TRIGGER);
+			ScriptEnum("NEXT_STOP", MSG_NEXT_STOP);
+			ScriptEnum("PREV_STOP", MSG_PREV_STOP);
+			// ScriptEnum("GOTO_STOP",   MSG_GOTO_STOP);	// GOTO_STOP requires a parameter, not yet implemented
+			ScriptEnum("DONE", MSG_DONE);
+			ScriptEnum("WAKEUP", MSG_WAKEUP);
+			ScriptEnum("MASTER_ON", MSG_MASTER_ON);
+			ScriptEnum("MASTER_OFF", MSG_MASTER_OFF);
+			ScriptEnum("CRUSH", MSG_CRUSH);
+
 			// Functions
 			ScriptObjMethod("float getGameTime()", getGameTime);
 			ScriptObjMethod("int random(int)", scriptRandom);

--- a/TheForceEngine/TFE_DarkForces/Scripting/gs_level.cpp
+++ b/TheForceEngine/TFE_DarkForces/Scripting/gs_level.cpp
@@ -312,17 +312,6 @@ namespace TFE_DarkForces
 			ScriptEnumStr(SECTORPROP_CEIL_TEX);
 			ScriptEnumStr(SECTORPROP_AMBIENT);
 
-			ScriptEnumRegister("MessageType");
-			ScriptEnum("M_TRIGGER",   MSG_TRIGGER);
-			ScriptEnum("NEXT_STOP",   MSG_NEXT_STOP);
-			ScriptEnum("PREV_STOP",   MSG_PREV_STOP);
-			// ScriptEnum("GOTO_STOP",   MSG_GOTO_STOP);	// requires a parameter, not yet implemented
-			ScriptEnum("DONE",        MSG_DONE);
-			ScriptEnum("WAKEUP",      MSG_WAKEUP);
-			ScriptEnum("MASTER_ON",   MSG_MASTER_ON);
-			ScriptEnum("MASTER_OFF",  MSG_MASTER_OFF);
-			ScriptEnum("CRUSH",       MSG_CRUSH);
-
 			// Functions
 			ScriptObjMethod("Sector getSector(int)", getSectorById);
 			ScriptObjMethod("Sector getSector(string)", getSectorByName);

--- a/TheForceEngine/TFE_DarkForces/Scripting/gs_level.cpp
+++ b/TheForceEngine/TFE_DarkForces/Scripting/gs_level.cpp
@@ -312,6 +312,16 @@ namespace TFE_DarkForces
 			ScriptEnumStr(SECTORPROP_CEIL_TEX);
 			ScriptEnumStr(SECTORPROP_AMBIENT);
 
+			ScriptEnumRegister("MessageType");
+			ScriptEnum("M_TRIGGER",   MSG_TRIGGER);
+			ScriptEnum("NEXT_STOP",   MSG_NEXT_STOP);
+			ScriptEnum("PREV_STOP",   MSG_PREV_STOP);
+			// ScriptEnum("GOTO_STOP",   MSG_GOTO_STOP);	// requires a parameter, not yet implemented
+			ScriptEnum("DONE",        MSG_DONE);
+			ScriptEnum("WAKEUP",      MSG_WAKEUP);
+			ScriptEnum("MASTER_ON",   MSG_MASTER_ON);
+			ScriptEnum("MASTER_OFF",  MSG_MASTER_OFF);
+
 			// Functions
 			ScriptObjMethod("Sector getSector(int)", getSectorById);
 			ScriptObjMethod("Sector getSector(string)", getSectorByName);

--- a/TheForceEngine/TFE_DarkForces/Scripting/gs_level.cpp
+++ b/TheForceEngine/TFE_DarkForces/Scripting/gs_level.cpp
@@ -321,6 +321,7 @@ namespace TFE_DarkForces
 			ScriptEnum("WAKEUP",      MSG_WAKEUP);
 			ScriptEnum("MASTER_ON",   MSG_MASTER_ON);
 			ScriptEnum("MASTER_OFF",  MSG_MASTER_OFF);
+			ScriptEnum("CRUSH",       MSG_CRUSH);
 
 			// Functions
 			ScriptObjMethod("Sector getSector(int)", getSectorById);

--- a/TheForceEngine/TFE_DarkForces/Scripting/scriptObject.cpp
+++ b/TheForceEngine/TFE_DarkForces/Scripting/scriptObject.cpp
@@ -9,6 +9,7 @@
 #include <TFE_DarkForces/pickup.h>
 #include <TFE_DarkForces/player.h>
 #include <TFE_DarkForces/mission.h>
+#include <TFE_DarkForces/Actor/actor.h>
 #include <TFE_ForceScript/forceScript.h>
 #include <TFE_ForceScript/scriptAPI.h>
 #include <TFE_Jedi/Level/levelData.h>
@@ -277,6 +278,14 @@ namespace TFE_DarkForces
 		if (s_nightVisionActive) { disableNightVision(); }
 	}
 
+	void sendMessageToObject(MessageType messageType, ScriptObject* sObject)
+	{
+		if (!doesObjectExist(sObject)) { return; }
+		
+		SecObject* obj = TFE_Jedi::s_objectRefList[sObject->m_id].object;
+		message_sendToObj(obj, messageType, actor_messageFunc);
+	}
+
 	void ScriptObject::registerType()
 	{
 		s32 res = 0;
@@ -314,5 +323,6 @@ namespace TFE_DarkForces
 		ScriptObjFunc("void delete()", deleteObject);
 		ScriptObjFunc("void addLogic(string)", addLogicToObject);
 		ScriptObjFunc("void setCamera()", setCamera);
+		ScriptObjFunc("void sendMessage(int)", sendMessageToObject)
 	}
 }

--- a/TheForceEngine/TFE_DarkForces/Scripting/scriptSector.cpp
+++ b/TheForceEngine/TFE_DarkForces/Scripting/scriptSector.cpp
@@ -5,6 +5,7 @@
 #include <TFE_Jedi/Level/levelData.h>
 #include <TFE_Jedi/Level/rwall.h>
 #include <TFE_Jedi/Level/rsector.h>
+#include <TFE_Jedi/InfSystem/message.h>
 #include <angelscript.h>
 
 using namespace TFE_Jedi;
@@ -169,6 +170,33 @@ namespace TFE_DarkForces
 		}
 	}
 
+	// Message with event and arg, eg. GOTO_STOP 131072 2
+	void sendMessageToSector(MessageType messageType, u32 evt, u32 msgArg1, ScriptSector* sSector)
+	{
+		if (!isScriptSectorValid(sSector))
+		{
+			return;
+		}
+
+		// TODO: investigate how to do this safely
+		// s_msgArg1 = msgArg1;
+
+		RSector* sector = &s_levelState.sectors[sSector->m_id];
+		message_sendToSector(sector, nullptr, evt, messageType);
+	}
+
+	// Message with no event and no arg, eg. NEXT_STOP
+	void sendMessageToSector1(MessageType messageType, ScriptSector* sSector)
+	{
+		sendMessageToSector(messageType, 0, 0, sSector);
+	}
+
+	// Message with event, eg. NEXT_STOP 131072
+	void sendMessageToSector2(MessageType messageType, u32 evt, ScriptSector* sSector)
+	{
+		sendMessageToSector(messageType, evt, 0, sSector);
+	}
+
 	void ScriptSector::registerType()
 	{
 		s32 res = 0;
@@ -185,6 +213,11 @@ namespace TFE_DarkForces
 		ScriptObjFunc("void setFlag(int, uint)", setSectorFlag);
 		ScriptObjFunc("float2 getCenterXZ()", getCenterXZ);
 		ScriptObjFunc("Wall getWall(int)", getWall);
+
+		ScriptObjFunc("void sendMessage(int)", sendMessageToSector1);
+		ScriptObjFunc("void sendMessage(int, uint)", sendMessageToSector2);
+		//ScriptObjFunc("void sendMessage(int, uint, uint)", sendMessageToSector);		// For now do not expose the ability to pass an arg
+
 		// Properties
 		ScriptPropertyGetFunc("float get_floorHeight()", getFloorHeight);
 		ScriptPropertyGetFunc("float get_ceilHeight()", getCeilHeight);


### PR DESCRIPTION
Add a MessageType enum, including
`MASTER_ON`, `MASTER_OFF`
`NEXT_STOP`, `PREV_STOP`
`WAKEUP`
`CRUSH`

Enable sending messages to sectors and objects
Scripts will be able to affect elevators
Scripts will be able to alert (WAKEUP) or instantly kill (CRUSH) enemies
