### PR TITLE
Bug fix - external data needs to be cleared out before loading a game

### DIFF
--- a/TheForceEngine/TFE_Game/saveSystem.cpp
+++ b/TheForceEngine/TFE_Game/saveSystem.cpp
@@ -4,6 +4,9 @@
 #include <TFE_FileSystem/fileutil.h>
 #include <TFE_Input/inputMapping.h>
 #include <TFE_RenderBackend/renderBackend.h>
+#include <TFE_ExternalData/dfLogics.h>
+#include <TFE_ExternalData/weaponExternal.h>
+#include <TFE_ExternalData/pickupExternal.h>
 #include <TFE_Settings/gameSourceData.h>
 #include <TFE_System/system.h>
 #include <cassert>
@@ -247,6 +250,14 @@ namespace TFE_SaveSystem
 		{
 			SaveHeader header;
 			loadHeader(&stream, &header, filename);
+			
+			// Clear out custom logics and external data before loading
+			TFE_ExternalData::getExternalLogics()->actorLogics.clear();
+			TFE_ExternalData::clearExternalWeapons();
+			TFE_ExternalData::clearExternalProjectiles();
+			TFE_ExternalData::clearExternalEffects();
+			TFE_ExternalData::clearExternalPickups();
+
 			ret = s_game->serializeGameState(&stream, filename, false);
 			stream.close();
 		}


### PR DESCRIPTION
The external data needs to be cleared when loading a save.

I had been relying on the user quitting back to the menu to clear the data.
But you can load a savegame without quitting to the menu!

The result is that if you load a savegame for a mod while a different mod is running (without first returning to the menu), the first mod's weapons/pickup data and custom logics will carry across into second other mod and the second mod's external data won't be loaded. 