### PR TITLE
INF parsing fixes for split seq blocks.

### DIFF
--- a/TheForceEngine/TFE_Editor/LevelEditor/levelEditorData.cpp
+++ b/TheForceEngine/TFE_Editor/LevelEditor/levelEditorData.cpp
@@ -508,6 +508,7 @@ namespace LevelEditor
 	void levelClear()
 	{
 		// Clear the INF data.
+		s_levelInf.item.clear();
 		s_levelInf.elevator.clear();
 		s_levelInf.teleport.clear();
 		s_levelInf.trigger.clear();
@@ -529,6 +530,7 @@ namespace LevelEditor
 		FileUtil::stripExtension(asset->name.c_str(), slotName);
 
 		// Clear the INF data.
+		s_levelInf.item.clear();
 		s_levelInf.elevator.clear();
 		s_levelInf.teleport.clear();
 		s_levelInf.trigger.clear();

--- a/TheForceEngine/TFE_Editor/LevelEditor/levelEditorInf.cpp
+++ b/TheForceEngine/TFE_Editor/LevelEditor/levelEditorInf.cpp
@@ -1231,6 +1231,26 @@ namespace LevelEditor
 		return true;
 	}
 
+	void mergeExistingInfItem()
+	{
+		Editor_InfItem* last = &s_levelInf.item.back();
+		Editor_InfItem* item = s_levelInf.item.data();
+		for (s32 i = 0; i < (s32)s_levelInf.item.size() - 1; i++, item++) // -1: dont match self
+		{
+			if (item->name == last->name && item->wallNum == last->wallNum)
+			{
+				LE_WARNING("Merging INF item - Name: %s - Wall number: %d", last->name.c_str(), last->wallNum);
+				for (size_t j = 0; j < last->classData.size(); j++)
+				{
+					s_levelInf.item[i].classData.push_back(s_levelInf.item.back().classData[j]);
+				}
+
+				s_levelInf.item.pop_back();
+				return;
+			}
+		}
+	}
+
 	bool loadLevelInfFromAsset(const Asset* asset)
 	{
 		char infFile[TFE_MAX_PATH];
@@ -1454,6 +1474,9 @@ namespace LevelEditor
 					}  // while (!seqEnd) - outer (Line Classes).
 				} break;
 			}
+			
+			// Fix up sibling classes split over multiple seq blocks if we can
+			mergeExistingInfItem();
 		}
 
 		return true;


### PR DESCRIPTION
1. Add function mergeExistingInfItem() to scan for existing INF items with matching name and wallnum, then merge the newly added item's classData to the existing entry. This structures the data such that the INF editor UI can use these classes correctly.

2. Add s_levelInf.item.clear() to areas where it was needed. Item data was accumulating and ending up in strange places like exported TFL files.