### PR TITLE
TD & Mine animation fix (proposed)

### DIFF
--- a/TheForceEngine/TFE_DarkForces/weapon.cpp
+++ b/TheForceEngine/TFE_DarkForces/weapon.cpp
@@ -485,6 +485,10 @@ namespace TFE_DarkForces
 		{
 			weapon->frame = 2;
 		}
+		else
+		{
+			weapon->frame = 0;
+		}
 	}
 
 	void weapon_computeMatrix(fixed16_16* mtx, angle14_32 pitch, angle14_32 yaw)

--- a/TheForceEngine/TFE_DarkForces/weapon.cpp
+++ b/TheForceEngine/TFE_DarkForces/weapon.cpp
@@ -775,7 +775,7 @@ namespace TFE_DarkForces
 		// s_prevWeapon is the weapon we are switching away from.
 		s_weaponAnimState =
 		{
-			0,							// frame
+			s_curPlayerWeapon->frame,	// frame
 			30, 40,						// startOffsetX, startOffsetY: was 14, 40
 			-3, -4,						// xSpeed, ySpeed
 			10, s_superCharge ? 1u : 2u	// frameCount, ticksPerFrame
@@ -1020,10 +1020,6 @@ namespace TFE_DarkForces
 			
 			const u8* atten = RClassic_Fixed::computeLighting(weaponLightingZDist, 0);
 			TextureData* tex = weapon->frames[weapon->frame];
-			if (weapon->ammo && *weapon->ammo == 0 && (weapon->ammo == &s_playerInfo.ammoDetonator || weapon->ammo == &s_playerInfo.ammoMine))
-			{
-				tex = s_playerWeaponList[WPN_FIST].frames[0];
-			}
 			
 			u32 dispWidth, dispHeight;
 			vfb_getResolution(&dispWidth, &dispHeight);


### PR DESCRIPTION
This is a subtle bug that has been present since the early days - it is seen when you use your final TD or mine.

@luciusDXL could you please compare with your original RE code?
I have reasoned out a fix which seems to give correct behaviour (cf. DOS), but I don't have access to the original code to check it. - thanks
It would be ideal if we can match the original code.