### PR TITLE
MINGW: Fix error of use of deleted function

### DIFF
--- a/TheForceEngine/TFE_FileSystem/CMakeLists.txt
+++ b/TheForceEngine/TFE_FileSystem/CMakeLists.txt
@@ -12,7 +12,6 @@ elseif(UNIX)
 	)
 endif()
 target_sources(tfe PRIVATE
-		"${CMAKE_CURRENT_SOURCE_DIR}/filewriterAsync.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/memorystream.cpp"
 		)
 

--- a/TheForceEngine/TFE_FileSystem/filewriterAsync.cpp
+++ b/TheForceEngine/TFE_FileSystem/filewriterAsync.cpp
@@ -6,6 +6,7 @@
 
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN 1
+#define NOGDI 1
 #include <Windows.h>
 #endif
 
@@ -26,9 +27,9 @@ namespace FileWriterAsync
 	s32 s_freeRequests[MAX_REQUEST_COUNT];
 	s32 s_processRequest[MAX_REQUEST_COUNT];
 
-	std::atomic<s32> s_requestCount = 0;
-	std::atomic<s32> s_freeRequestCount = 0;
-	std::atomic<s32> s_processRequestCount = 0;
+	std::atomic<s32> s_requestCount{0};
+	std::atomic<s32> s_freeRequestCount{0};
+	std::atomic<s32> s_processRequestCount{0};
 
 	void CALLBACK fileWrittenCallback(DWORD dwErrorCode, DWORD dwBytesTransferred, LPOVERLAPPED lpOverlapped)
 	{


### PR DESCRIPTION
I tried to build the engine with MinGW and I got several errors like this one:
```
TheForceEngine/TFE_FileSystem/filewriterAsync.cpp:29:43: error: use of deleted function ‘std::atomic<int>::atomic(const std::atomic<int>&)’
   29 |         std::atomic<s32> s_requestCount = 0;
      |                                           ^
In file included from TheForceEngine/TFE_System/types.h:6,
                 from TheForceEngine/TFE_System/system.h:8,
                 from TheForceEngine/TFE_FileSystem/filewriterAsync.h:2,
                 from TheForceEngine/TFE_FileSystem/filewriterAsync.cpp:1:
/usr/lib/gcc/x86_64-w64-mingw32/14/include/c++/atomic:834:7: note: declared here
  834 |       atomic(const atomic&) = delete;
      |       ^~~~~~
TheForceEngine/TFE_FileSystem/filewriterAsync.cpp:29:43: note: use ‘-fdiagnostics-all-candidates’ to display considered candidates
   29 |         std::atomic<s32> s_requestCount = 0;
      |                                           ^
/usr/lib/gcc/x86_64-w64-mingw32/14/include/c++/atomic:838:17: note:   after user-defined conversion: ‘constexpr std::atomic<int>::atomic(__integral_type)’
  838 |       constexpr atomic(__integral_type __i) noexcept : __base_type(__i) { }
      |                 ^~~~~~
```
Attached patch fixes it.
Actually, this file doesn't seem to be compiled by the Visual Studio project file, so I could not test if this change works there too. However, I have been able to build the engine also with MSVC even after this fix.