### PR TITLE
Fix for camera pitch clamping (software renderer)

### DIFF
--- a/TheForceEngine/TFE_Jedi/Renderer/jediRenderer.cpp
+++ b/TheForceEngine/TFE_Jedi/Renderer/jediRenderer.cpp
@@ -460,6 +460,7 @@ namespace TFE_Jedi
 
 		// Clamp the pitch to 60 degrees (vanilla plus) for software renderer
 		// Higher values may be passed in if the camera is being moved by a VUE or is attached to a non-player object
+		if (pitch > 8192) { pitch -= ANGLE_MAX; }
 		angle14_32 clampedPitch = clamp(pitch, -2730, 2730);
 
 		// For now compute both fixed-point and floating-point camera transforms so that it is easier to swap between sub-renderers.


### PR DESCRIPTION
This fixes a bug associated with https://github.com/luciusDXL/TheForceEngine/pull/468
where I clamped the camera's pitch for the software renderer, but did not account for situations where pitch is expressed as a value between 180 and 360.

Angles between 180 and 360 need to first be converted to a value between -180 and 0, by subtracting 360
(This will not fix values that are > 540 and < 180 but I think it is fair to assume that such values won't be encountered in practice. This issue only occurred when transforming the camera object with a VUE, where all pitch values will be between 0 and 360)