### PR TITLE
Texture Flag Fix

### DIFF
--- a/TheForceEngine/TFE_Jedi/Level/levelData.h
+++ b/TheForceEngine/TFE_Jedi/Level/levelData.h
@@ -37,7 +37,8 @@ namespace TFE_Jedi
 		LevelState_InitVersion = 1,
 		LevelState_SaveSectorNames = 2,
 		LevelState_SecretUpdate = 3,
-		LevelState_CurVersion = LevelState_SecretUpdate,
+		LevelState_TextureFlags = 4,
+		LevelState_CurVersion = LevelState_TextureFlags,
 	};
 
 	enum GoalConstants

--- a/TheForceEngine/TFE_Jedi/Level/rtexture.cpp
+++ b/TheForceEngine/TFE_Jedi/Level/rtexture.cpp
@@ -12,6 +12,7 @@
 #include <TFE_Jedi/Serialization/serialization.h>
 #include <TFE_System/math.h>
 #include <TFE_Settings/settings.h>
+#include <TFE_Jedi/Level/levelData.h>
 #include <unordered_map>
 
 using namespace TFE_DarkForces;
@@ -189,7 +190,16 @@ namespace TFE_Jedi
 			{
 				list->name.resize(length);
 			}
-			SERIALIZE_BUF(SaveVersionInit, &list->name[0], length);
+			SERIALIZE_BUF(SaveVersionInit, &list->name[0], length);			
+
+			// Serialize the runtime flags so they survive save/load 
+			u8 flags = 0;
+			if (serialization_getMode() == SMODE_WRITE && list->texture)
+			{
+				flags = list->texture->flags;
+			}
+
+			SERIALIZE(LevelState_TextureFlags, flags, 0);			
 
 			// If reading, we need to load the texture now.
 			if (serialization_getMode() == SMODE_READ)
@@ -197,6 +207,12 @@ namespace TFE_Jedi
 				const char* name = list->name.c_str();
 				list->texture = bitmap_load(name, 1, POOL_LEVEL, false);
 				s_textureTable[POOL_LEVEL][name] = i;
+
+				// Restore the runtime flags that bitmap_load() masked away
+				if (list->texture && LevelState_TextureFlags >= serialization_getVersion())
+				{
+					list->texture->flags = flags;
+				}
 			}
 		}
 	}

--- a/TheForceEngine/TFE_Jedi/Level/rtexture.cpp
+++ b/TheForceEngine/TFE_Jedi/Level/rtexture.cpp
@@ -209,7 +209,7 @@ namespace TFE_Jedi
 				s_textureTable[POOL_LEVEL][name] = i;
 
 				// Restore the runtime flags that bitmap_load() masked away
-				if (list->texture && LevelState_TextureFlags >= serialization_getVersion())
+				if (list->texture && serialization_getVersion() >= LevelState_TextureFlags)
 				{
 					list->texture->flags = flags;
 				}


### PR DESCRIPTION
Fix for texture flags not being preserved between saves as seen as Dark Tide 3 INVSPACE.BM bug. Adds compatibility for older  save files.