### PR TITLE
Level bounds / layers fixes

### DIFF
--- a/TheForceEngine/TFE_Editor/LevelEditor/levelEditorData.cpp
+++ b/TheForceEngine/TFE_Editor/LevelEditor/levelEditorData.cpp
@@ -915,20 +915,28 @@ namespace LevelEditor
 	{
 		if (!sector)
 		{
-			s_level.bounds[0] = { FLT_MAX,  FLT_MAX,  FLT_MAX };
-			s_level.bounds[1] = { -FLT_MAX, -FLT_MAX, -FLT_MAX };
-			s_level.layerRange[0] = INT_MAX;
-			s_level.layerRange[1] = -INT_MAX;
 			const size_t count = s_level.sectors.size();
 			sector = s_level.sectors.data();
-			for (size_t i = 0; i < count; i++, sector++)
+
+			if (count == 0)
 			{
-				updateBoundsWithSector(sector);
+				s_level.bounds[0] = { 0 };
+				s_level.bounds[1] = { 0 };
+				s_level.layerRange[0] = 0;
+				s_level.layerRange[1] = 0;
 			}
-		}
-		else
-		{
-			updateBoundsWithSector(sector);
+			else
+			{
+				s_level.bounds[0] = { FLT_MAX,  FLT_MAX,  FLT_MAX };
+				s_level.bounds[1] = { -FLT_MAX, -FLT_MAX, -FLT_MAX };
+				s_level.layerRange[0] = INT_MAX;
+				s_level.layerRange[1] = -INT_MAX;
+
+				for (size_t i = 0; i < count; i++, sector++)
+				{
+					updateBoundsWithSector(sector);
+				}
+			}
 		}
 	}
 
@@ -5487,6 +5495,30 @@ namespace LevelEditor
 			{
 				levHistory_createSnapshot("Clean Zero-Sectors");
 			}
+		}
+	}
+
+	// Update visible layer when history replay changes the overall layer bounds.
+	void updateCurrentLayer(s32* oldLayers)
+	{
+		bool inRange = s_curLayer >= s_level.layerRange[0] && s_curLayer <= s_level.layerRange[1];
+		if (inRange)
+		{
+			// If layer bounds expands, follow it
+			if (oldLayers[0] > s_level.layerRange[0])
+			{
+				s_curLayer = s_level.layerRange[0];
+			}
+			else if (oldLayers[1] < s_level.layerRange[1])
+			{
+				s_curLayer = s_level.layerRange[1];
+			}
+		}
+		else
+		{
+			// Drifted out of range, find closest
+			s_curLayer = std::min(s_curLayer, s_level.layerRange[1]);
+			s_curLayer = std::max(s_curLayer, s_level.layerRange[0]);
 		}
 	}
 }

--- a/TheForceEngine/TFE_Editor/LevelEditor/levelEditorData.cpp
+++ b/TheForceEngine/TFE_Editor/LevelEditor/levelEditorData.cpp
@@ -938,6 +938,10 @@ namespace LevelEditor
 				}
 			}
 		}
+		else
+		{
+			updateBoundsWithSector(sector);
+		}
 	}
 
 	bool loadFromTFLWithPath(const char* filePath)
@@ -5499,17 +5503,17 @@ namespace LevelEditor
 	}
 
 	// Update visible layer when history replay changes the overall layer bounds.
-	void updateCurrentLayer(s32* oldLayers)
+	void updateCurrentLayer(s32* oldLayerRange)
 	{
 		bool inRange = s_curLayer >= s_level.layerRange[0] && s_curLayer <= s_level.layerRange[1];
 		if (inRange)
 		{
 			// If layer bounds expands, follow it
-			if (oldLayers[0] > s_level.layerRange[0])
+			if (oldLayerRange[0] > s_level.layerRange[0])
 			{
 				s_curLayer = s_level.layerRange[0];
 			}
-			else if (oldLayers[1] < s_level.layerRange[1])
+			else if (oldLayerRange[1] < s_level.layerRange[1])
 			{
 				s_curLayer = s_level.layerRange[1];
 			}

--- a/TheForceEngine/TFE_Editor/LevelEditor/levelEditorData.h
+++ b/TheForceEngine/TFE_Editor/LevelEditor/levelEditorData.h
@@ -311,7 +311,7 @@ namespace LevelEditor
 	bool loadFromTFL(const char* name);
 	bool loadFromTFLWithPath(const char* filePath);
 	void updateLevelBounds(EditorSector* sector = nullptr);
-	void updateCurrentLayer(s32* oldLayers);
+	void updateCurrentLayer(s32* oldLayerRange);
 
 	bool exportLevel(const char* path, const char* name, const StartPoint* start);
 	bool exportSelectionToText(std::string& buffer);

--- a/TheForceEngine/TFE_Editor/LevelEditor/levelEditorData.h
+++ b/TheForceEngine/TFE_Editor/LevelEditor/levelEditorData.h
@@ -311,6 +311,7 @@ namespace LevelEditor
 	bool loadFromTFL(const char* name);
 	bool loadFromTFLWithPath(const char* filePath);
 	void updateLevelBounds(EditorSector* sector = nullptr);
+	void updateCurrentLayer(s32* oldLayers);
 
 	bool exportLevel(const char* path, const char* name, const StartPoint* start);
 	bool exportSelectionToText(std::string& buffer);

--- a/TheForceEngine/TFE_Editor/LevelEditor/levelEditorHistory.cpp
+++ b/TheForceEngine/TFE_Editor/LevelEditor/levelEditorHistory.cpp
@@ -119,21 +119,21 @@ namespace LevelEditor
 		
 	void levHistory_undo()
 	{
-		s32 oldLayers[2] = { s_level.layerRange[0], s_level.layerRange[1] };
+		s32 oldLayerRange[2] = { s_level.layerRange[0], s_level.layerRange[1] };
 		history_step(-1);
 		edit_clearSelections(false);
 		updateLevelBounds(nullptr);
-		updateCurrentLayer(oldLayers);
+		updateCurrentLayer(oldLayerRange);
 
 	}
 
 	void levHistory_redo()
 	{
-		s32 oldLayers[2] = { s_level.layerRange[0], s_level.layerRange[1] };
+		s32 oldLayerRange[2] = { s_level.layerRange[0], s_level.layerRange[1] };
 		history_step(1);
 		edit_clearSelections(false);
 		updateLevelBounds(nullptr);
-		updateCurrentLayer(oldLayers);
+		updateCurrentLayer(oldLayerRange);
 	}
 		
 	////////////////////////////////

--- a/TheForceEngine/TFE_Editor/LevelEditor/levelEditorHistory.cpp
+++ b/TheForceEngine/TFE_Editor/LevelEditor/levelEditorHistory.cpp
@@ -119,14 +119,21 @@ namespace LevelEditor
 		
 	void levHistory_undo()
 	{
+		s32 oldLayers[2] = { s_level.layerRange[0], s_level.layerRange[1] };
 		history_step(-1);
 		edit_clearSelections(false);
+		updateLevelBounds(nullptr);
+		updateCurrentLayer(oldLayers);
+
 	}
 
 	void levHistory_redo()
 	{
+		s32 oldLayers[2] = { s_level.layerRange[0], s_level.layerRange[1] };
 		history_step(1);
 		edit_clearSelections(false);
+		updateLevelBounds(nullptr);
+		updateCurrentLayer(oldLayers);
 	}
 		
 	////////////////////////////////

--- a/TheForceEngine/TFE_Editor/historyView.cpp
+++ b/TheForceEngine/TFE_Editor/historyView.cpp
@@ -47,6 +47,7 @@ namespace TFE_Editor
 					if (ImGui::Selectable(editor_getUniqueLabel(name), pos == i))
 					{
 						history_setPos(i);
+						LevelEditor::updateLevelBounds(nullptr);
 						history_showBranch(i);
 						// TODO: This should clear the selections for the current editor.
 						LevelEditor::edit_clearSelections(false);

--- a/TheForceEngine/TFE_Editor/historyView.cpp
+++ b/TheForceEngine/TFE_Editor/historyView.cpp
@@ -1,6 +1,7 @@
 #include "historyView.h"
 #include "editor.h"
 #include "history.h"
+#include <TFE_Editor/LevelEditor/sharedState.h>
 #include <TFE_Editor/LevelEditor/levelEditor.h>
 #include <TFE_Ui/ui.h>
 
@@ -46,8 +47,10 @@ namespace TFE_Editor
 					if (isHidden) { ImGui::PushStyleColor(ImGuiCol_Text, hiddenColor); }
 					if (ImGui::Selectable(editor_getUniqueLabel(name), pos == i))
 					{
+						s32 oldLayerRange[2] = { LevelEditor::s_level.layerRange[0], LevelEditor::s_level.layerRange[1] };
 						history_setPos(i);
 						LevelEditor::updateLevelBounds(nullptr);
+						LevelEditor::updateCurrentLayer(oldLayerRange);
 						history_showBranch(i);
 						// TODO: This should clear the selections for the current editor.
 						LevelEditor::edit_clearSelections(false);


### PR DESCRIPTION
1. updateLevelBounds(): Updated to handle empty level case avoiding a crash.

2. Update undo, redo & history popup to refresh level bounds after replaying history.

3. updateCurrentLayer(): new function to make useful changes to active layer after undo / redo actions, effectively "Following" layer changes as it expands or shrinks.