### PR TITLE
Enable burst-fire for NPC secondary fire

### DIFF
--- a/TheForceEngine/TFE_DarkForces/Actor/actor.cpp
+++ b/TheForceEngine/TFE_DarkForces/Actor/actor.cpp
@@ -982,6 +982,11 @@ namespace TFE_DarkForces
 								// Do ranged attack (secondary)
 								attackMod->anim.state = STATE_ATTACK2;
 								attackMod->timing.delay = attackMod->timing.rangedDelay;
+
+								if (attackMod->hasBurstFire)
+								{
+									attackMod->anim.flags &= ~AFLAG_PLAYONCE;	// if logic has burst fire, allow attack anim to loop
+								}
 							}
 						}
 						else  // Actor does not have melee attack

--- a/TheForceEngine/TFE_DarkForces/Actor/actor.cpp
+++ b/TheForceEngine/TFE_DarkForces/Actor/actor.cpp
@@ -1035,7 +1035,7 @@ namespace TFE_DarkForces
 			} break;
 			case STATE_ATTACK1:
 			{
-				if (!(attackMod->anim.flags & AFLAG_READY) && !attackMod->hasBurstFire)
+				if (!(attackMod->anim.flags & AFLAG_READY) && (!attackMod->hasBurstFire || attackMod->attackFlags & ATTFLAG_MELEE))
 				{
 					break;
 				}
@@ -1165,7 +1165,7 @@ namespace TFE_DarkForces
 			} break;
 			case STATE_ATTACK2:
 			{
-				if (!(attackMod->anim.flags & AFLAG_READY))
+				if (!(attackMod->anim.flags & AFLAG_READY) && !attackMod->hasBurstFire)
 				{
 					break;
 				}
@@ -1174,7 +1174,41 @@ namespace TFE_DarkForces
 					obj->flags |= OBJ_FLAG_FULLBRIGHT;
 				}
 
-				attackMod->anim.state = STATE_ANIMATE2;
+				// Burst fire option - set via custom logics
+				if (attackMod->hasBurstFire)
+				{
+					if (s_curTick < attackMod->burstFire.lastShot + attackMod->burstFire.interval)
+					{
+						break;
+					}
+
+					if (logic->flags & ACTOR_DYING) { break; }
+
+					if (attackMod->burstFire.shotCount <= 1)
+					{
+						// Burst is finished, end the looping & reset the shot count
+						attackMod->anim.state = STATE_ANIMATE2;
+						attackMod->anim.flags |= AFLAG_PLAYONCE;
+
+						s32 var = random(attackMod->burstFire.variation * 2);
+						s32 nextBurstNumber = attackMod->burstFire.burstNumber - attackMod->burstFire.variation + var;
+						attackMod->burstFire.shotCount = max(nextBurstNumber, 2);
+					}
+					else
+					{
+						// Reorient towards the player
+						attackMod->target.yaw = vec2ToAngle(s_playerObject->posWS.x - obj->posWS.x, s_playerObject->posWS.z - obj->posWS.z);
+
+						// Fire the next shot in the burst
+						attackMod->burstFire.lastShot = s_curTick;
+						attackMod->burstFire.shotCount--;
+					}
+				}
+				else
+				{
+					// No burst fire -- vanilla logic
+					attackMod->anim.state = STATE_ANIMATE2;
+				}
 
 				vec3_fixed fireOffset = {};
 				


### PR DESCRIPTION
This will enable NPCs with melee attacks to have burst-fire on their projectile (ranged) attack.
It copies what was done for https://github.com/TheForceEngine/TheForceEngine/pull/589 onto the secondary fire pathway.

When an NPC/actor has a melee attack, the melee attack uses the primary attack pathway, and projectile attack will use the secondary pathway