### PR TITLE
Harmonisation of InfEntityMask and EntityTypeFlags

### DIFF
--- a/TheForceEngine/TFE_DarkForces/logic.cpp
+++ b/TheForceEngine/TFE_DarkForces/logic.cpp
@@ -500,7 +500,15 @@ namespace TFE_DarkForces
 		obj->flags |= OBJ_FLAG_AIM;
 		obj->entityFlags = ETFLAG_AI_ACTOR;
 
-		if (customLogic->isFlying) { obj->entityFlags |= ETFLAG_FLYING; }
+		if (customLogic->isFlying)
+		{
+			obj->entityFlags |= ETFLAG_FLYING;
+		}
+		else
+		{
+			obj->entityFlags |= ETFLAG_HAS_GRAVITY;
+		}
+
 		if (customLogic->hasGravity) { obj->entityFlags |= ETFLAG_HAS_GRAVITY; }
 
 		LogicSetupFunc* setupFunc = nullptr;

--- a/TheForceEngine/TFE_Editor/LevelEditor/levelEditorInf.cpp
+++ b/TheForceEngine/TFE_Editor/LevelEditor/levelEditorInf.cpp
@@ -1600,16 +1600,16 @@ namespace LevelEditor
 
 	const char* c_infEntityMaskNames[] =
 	{
-		"Enemy",     // INF_ENTITY_ENEMY,
-		"Weapon",    // INF_ENTITY_WEAPON,
+		"Enemy",     // INF_ENTITY_AI_ACTOR,
+		"Weapon",    // INF_ENTITY_PROJECTILE,
 		"Smart Obj", // INF_ENTITY_SMART_OBJ,
 		"Player",    // INF_ENTITY_PLAYER,
 	};
 
 	const u32 c_infEntityMaskFlags[] =
 	{
-		u32(INF_ENTITY_ENEMY),
-		u32(INF_ENTITY_WEAPON),
+		u32(INF_ENTITY_AI_ACTOR),
+		u32(INF_ENTITY_PROJECTILE),
 		u32(INF_ENTITY_SMART_OBJ),
 		u32(INF_ENTITY_PLAYER),
 	};

--- a/TheForceEngine/TFE_Jedi/InfSystem/infTypesInternal.h
+++ b/TheForceEngine/TFE_Jedi/InfSystem/infTypesInternal.h
@@ -49,10 +49,11 @@ namespace TFE_Jedi
 		ITRIGGER_SINGLE
 	};
 		
+	// Note: These values correspond to object EntityTypeFlags
 	enum InfEntityMask
 	{
-		INF_ENTITY_ENEMY     = FLAG_BIT(0),
-		INF_ENTITY_WEAPON    = FLAG_BIT(3),
+		INF_ENTITY_AI_ACTOR   = FLAG_BIT(0),
+		INF_ENTITY_PROJECTILE = FLAG_BIT(3),
 		INF_ENTITY_SMART_OBJ = FLAG_BIT(11),
 		INF_ENTITY_PLAYER    = FLAG_BIT(31),
 		INF_ENTITY_ANY = 0xffffffffu

--- a/TheForceEngine/TFE_Jedi/Level/robjData.h
+++ b/TheForceEngine/TFE_Jedi/Level/robjData.h
@@ -34,11 +34,17 @@ enum ObjectFlags
 	OBJ_FLAG_CAMERA			 = FLAG_BIT(7),  // New in TFE
 };
 
+// Note: These values correspond to InfEntityMask
 enum EntityTypeFlags
 {
 	ETFLAG_AI_ACTOR       = FLAG_BIT(0),	// AI Actor - moves and acts on its own.
-	ETFLAG_HAS_GRAVITY    = FLAG_BIT(1),	// This entity is effected by gravity.
+
+	// NOTE: The following 2 flag bits are not actually used in the code to determine behaviour.
+	// Whether an NPC is affected by gravity or can move vertically is actually determined by the ActorCollisionFlags set in their MovementModule.
+	// These flags however can still be used with ENTITY_MASK to selectively trigger INF events.
+	ETFLAG_HAS_GRAVITY    = FLAG_BIT(1),	// This entity is ground-based (not flying).
 	ETFLAG_FLYING         = FLAG_BIT(2),	// This entity is flying (can change Y height).
+
 	ETFLAG_PROJECTILE     = FLAG_BIT(3),	// The entity is a projectile.
 	ETFLAG_CAN_WAKE       = FLAG_BIT(6),	// An inactive object or animation waiting to be "woken up" - such as Vues waiting to play.
 	ETFLAG_PICKUP         = FLAG_BIT(7),	// An item pickup.


### PR DESCRIPTION
`InfEntityMask` and `EntityTypeFlags` are equivalent to each other.
Therefore, it is less confusing if the enum names align in the code
eg. ENEMY --> AI_ACTOR
WEAPON --> PROJECTILE

I have added some comments to explain things.
Tiny behaviour change in custom logics -- the ETFLAG_HAS_GRAVITY flag should be set for all non-flying enemies. That way all ground-based custom logics will be guaranteed to align with the vanilla logics (stormtroopers, bossk, gamorrean, etc.) when modders are trying to do tricky INF stuff.