### PR TITLE
Fix guidelines persisting between levels

### DIFF
--- a/TheForceEngine/TFE_Editor/LevelEditor/levelEditorData.cpp
+++ b/TheForceEngine/TFE_Editor/LevelEditor/levelEditorData.cpp
@@ -540,8 +540,9 @@ namespace LevelEditor
 		selection_clearHovered();
 		s_featureTex = {};
 
-		// Clear notes.
+		// Clear notes and guidelines
 		s_level.notes.clear();
+		s_level.guidelines.clear();
 		levelSetClean();
 
 		// First check to see if there is a "tfl" version of the level.


### PR DESCRIPTION
s_level.guidelines wasn't being cleared when loading a GOB, only when loading a TFL. Adding this line next to a cluster of existing initialisation steps.