### PR TITLE
Fix build warnings

### DIFF
--- a/TheForceEngine/TFE_DarkForces/Scripting/gs_system.cpp
+++ b/TheForceEngine/TFE_DarkForces/Scripting/gs_system.cpp
@@ -8,6 +8,7 @@
 #include <TFE_ForceScript/float3.h>
 #include <TFE_ForceScript/Angelscript/add_on/scriptarray/scriptarray.h>
 #include <angelscript.h>
+#include <cinttypes>
 
 namespace TFE_DarkForces
 {
@@ -92,7 +93,7 @@ namespace TFE_DarkForces
 						case 5:
 						{
 							s64 local = *(s64*)(data);
-							sprintf(tmp, "%lld", local);
+							sprintf(tmp, "%" PRIi64, local);
 							value = tmp;
 							break;
 						}
@@ -120,7 +121,7 @@ namespace TFE_DarkForces
 						case 9:
 						{
 							u64 local = *(u64*)(data);
-							sprintf(tmp, "%llu", local);
+							sprintf(tmp, "%" PRIu64, local);
 							value = tmp;
 							break;
 						}
@@ -238,7 +239,7 @@ namespace TFE_DarkForces
 					case 5:
 					{
 						s64 local = *(s64*)(ref);
-						sprintf(tmp, "%lld", local);
+						sprintf(tmp, "%" PRIi64, local);
 						value = tmp;
 						break;
 					}
@@ -266,7 +267,7 @@ namespace TFE_DarkForces
 					case 9:
 					{
 						u64 local = *(u64*)(ref);
-						sprintf(tmp, "%llu", local);
+						sprintf(tmp, "%" PRIu64, local);
 						value = tmp;
 						break;
 					}

--- a/TheForceEngine/TFE_Editor/LevelEditor/Scripting/ls_system.cpp
+++ b/TheForceEngine/TFE_Editor/LevelEditor/Scripting/ls_system.cpp
@@ -7,6 +7,7 @@
 #include <TFE_ForceScript/float3.h>
 #include <TFE_ForceScript/Angelscript/add_on/scriptarray/scriptarray.h>
 #include <angelscript.h>
+#include <cinttypes>
 
 namespace LevelEditor
 {
@@ -85,7 +86,7 @@ namespace LevelEditor
 						case 5:
 						{
 							s64 local = *(s64*)(data);
-							sprintf(tmp, "%lld", local);
+							sprintf(tmp, "%" PRIi64, local);
 							value = tmp;
 							break;
 						}
@@ -113,7 +114,7 @@ namespace LevelEditor
 						case 9:
 						{
 							u64 local = *(u64*)(data);
-							sprintf(tmp, "%llu", local);
+							sprintf(tmp, "%" PRIu64, local);
 							value = tmp;
 							break;
 						}
@@ -221,7 +222,7 @@ namespace LevelEditor
 					case 5:
 					{
 						s64 local = *(s64*)(ref);
-						sprintf(tmp, "%lld", local);
+						sprintf(tmp, "%" PRIi64, local);
 						value = tmp;
 						break;
 					}
@@ -249,7 +250,7 @@ namespace LevelEditor
 					case 9:
 					{
 						u64 local = *(u64*)(ref);
-						sprintf(tmp, "%llu", local);
+						sprintf(tmp, "%" PRIu64, local);
 						value = tmp;
 						break;
 					}

--- a/TheForceEngine/TFE_Editor/LevelEditor/levelEditorData.cpp
+++ b/TheForceEngine/TFE_Editor/LevelEditor/levelEditorData.cpp
@@ -1391,7 +1391,6 @@ namespace LevelEditor
 		const LevelTextureAsset* tex = s_level.textures.data();
 		for (s32 i = 0; i < textureCount; i++, tex++)
 		{
-			tex->name.c_str();
 			WRITE_LINE("  TEXTURE: %s\t\t#  %d\r\n", tex->name.c_str(), i);
 		}
 		NEW_LINE();

--- a/TheForceEngine/TFE_Editor/LevelEditor/levelEditorInf.cpp
+++ b/TheForceEngine/TFE_Editor/LevelEditor/levelEditorInf.cpp
@@ -3099,7 +3099,7 @@ namespace LevelEditor
 	void selectableClassName(const char* className, ImVec2 itemStart, s32 classIndex)
 	{
 		ImVec2 itemEnd = ImGui::GetCursorPos();
-		ImGui::TextColored(colorKeywordInner, className);
+		ImGui::TextColored(colorKeywordInner, "%s", className);
 		itemEnd.x += ImGui::CalcTextSize(className).x;
 		ImVec2 itemNext = ImGui::GetCursorPos();
 

--- a/TheForceEngine/TFE_ForceScript/ScriptAPI-Shared/scriptTest.cpp
+++ b/TheForceEngine/TFE_ForceScript/ScriptAPI-Shared/scriptTest.cpp
@@ -5,6 +5,7 @@
 #include <TFE_Jedi/Level/rwall.h>
 #include <TFE_Jedi/Level/rsector.h>
 #include <angelscript.h>
+#include <cinttypes>
 
 using namespace TFE_Jedi;
 
@@ -186,8 +187,8 @@ namespace TFE_ForceScript
 					s64 v1 = *(s64*)(ref1);
 					if ((equal && v0 != v1) || (!equal && v0 == v1))
 					{
-						if (equal) { sprintf(errMsg, "%lld != %lld", v0, v1); }
-						else { sprintf(errMsg, "%lld == %lld", v0, v1); }
+						if (equal) { sprintf(errMsg, "%" PRIi64 " != %" PRIi64, v0, v1); }
+						else { sprintf(errMsg, "%" PRIi64 " ==  %" PRIi64, v0, v1); }
 						errorMsg = errMsg;
 						return false;
 					}
@@ -242,8 +243,8 @@ namespace TFE_ForceScript
 					u64 v1 = *(u64*)(ref1);
 					if ((equal && v0 != v1) || (!equal && v0 == v1))
 					{
-						if (equal) { sprintf(errMsg, "%llu != %llu", v0, v1); }
-						else { sprintf(errMsg, "%llu == %llu", v0, v1); }
+						if (equal) { sprintf(errMsg, "%" PRIu64 " !=  %" PRIu64, v0, v1); }
+						else { sprintf(errMsg, "%" PRIu64 " ==  %" PRIu64, v0, v1); }
 						errorMsg = errMsg;
 						return false;
 					}
@@ -404,8 +405,8 @@ namespace TFE_ForceScript
 					s64 v = *(s64*)(ref);
 					if ((testForTrue && v == 0) || (!testForTrue && v != 0))
 					{
-						if (testForTrue) { sprintf(errMsg, "%lld is false, true expected", v); }
-						else { sprintf(errMsg, "%lld is true, false expected", v); }
+						if (testForTrue) { sprintf(errMsg, "%" PRIi64 " is false, true expected", v); }
+						else { sprintf(errMsg, "%" PRIi64 " is true, false expected", v); }
 						errorMsg = errMsg;
 						return false;
 					}
@@ -456,8 +457,8 @@ namespace TFE_ForceScript
 					u64 v = *(u64*)(ref);
 					if ((testForTrue && v == 0) || (!testForTrue && v != 0))
 					{
-						if (testForTrue) { sprintf(errMsg, "%llu is false, true expected", v); }
-						else { sprintf(errMsg, "%llu is true, false expected", v); }
+						if (testForTrue) { sprintf(errMsg, "%" PRIu64 " is false, true expected", v); }
+						else { sprintf(errMsg, "%" PRIu64 " is true, false expected", v); }
 						errorMsg = errMsg;
 						return false;
 					}

--- a/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
+++ b/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
@@ -3777,7 +3777,7 @@ namespace TFE_FrontEndUI
 		string tag2 = "##LB" + to_string(index);
 		string tag3 = "##LVS" + to_string(index);
 		string tag4 = "##LWS" + to_string(index);
-		ImGui::LabelText("##ConfigLabel3", label1.c_str());
+		ImGui::LabelText("##ConfigLabel3", "%s", label1.c_str());
 		DrawLabelledFloatSlider(labelW, valueW * 0.5f - 2, "  Brightness", tag2.c_str(), &RClassic_Float::s_cameraLight[index].brightness, 0.0f, 8.0f);
 		Tooltip("Values above 1.0 only affect obliquely lit faces.");
 

--- a/TheForceEngine/TFE_FrontEndUI/modLoader.cpp
+++ b/TheForceEngine/TFE_FrontEndUI/modLoader.cpp
@@ -24,6 +24,7 @@
 #include <TFE_Jedi/Renderer/jediRenderer.h>
 #include <map>
 #include <algorithm>
+#include <cinttypes>
 
 using namespace TFE_Input;
 
@@ -420,11 +421,11 @@ namespace TFE_FrontEndUI
 	{
 		readFromQueue(c_itemsPerFrame);
 	}
-		
+
 	bool modLoader_selectionUI()
 	{
 		bool stayOpen = true;
-		f32 uiScale = (f32)TFE_Ui::getUiScale() * 0.01f;	
+		f32 uiScale = (f32)TFE_Ui::getUiScale() * 0.01f;
 
 		// Load in the mod data a few at a time so to limit waiting for loading.
 		readFromQueue(c_itemsPerFrame);
@@ -524,10 +525,10 @@ namespace TFE_FrontEndUI
 
 		ImVec4 infoColor = ImVec4(0.2f, 0.8f, 0.4f, 1.0f);  // RGBA
 
-		ImGui::TextColored(infoColor, "Showing %d out of %d mods.", s_filteredMods.size(), s_mods.size());
+		ImGui::TextColored(infoColor, "Showing %lu out of %lu mods.", s_filteredMods.size(), s_mods.size());
 
 		ImGui::Separator();
-					   
+
 		if (s_viewMode == VIEW_IMAGES)
 		{
 			modLoader_imageListUI(uiScale);

--- a/TheForceEngine/TFE_Input/replay.cpp
+++ b/TheForceEngine/TFE_Input/replay.cpp
@@ -66,8 +66,8 @@ namespace TFE_Input
 	bool showReplayMsgFrame = false;
 	bool alwaysRecord = false;
 	
-	extern f64 gameFrameLimit = 0;	
-	extern f64 replayFrameLimit = 0;
+	f64 gameFrameLimit = 0;
+	f64 replayFrameLimit = 0;
 
 	// Notification for replay system initialization. 
 	bool demoStartNotified = false;

--- a/TheForceEngine/TFE_RenderBackend/Win32OpenGL/screenCapture.cpp
+++ b/TheForceEngine/TFE_RenderBackend/Win32OpenGL/screenCapture.cpp
@@ -345,7 +345,7 @@ void ScreenCapture::drawGui()
 		ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1, 1, 0, 1));
 		if (TFE_Settings::getSystemSettings()->showGifPathConfirmation)
 		{
-			ImGui::TextWrapped(m_confirmationMessage.c_str());
+			ImGui::TextWrapped("%s", m_confirmationMessage.c_str());
 		}
 		else
 		{

--- a/TheForceEngine/TFE_System/log.cpp
+++ b/TheForceEngine/TFE_System/log.cpp
@@ -1,4 +1,5 @@
 #include <cstdarg>
+#include <cinttypes>
 #include <cstring>
 
 #include <TFE_System/system.h>
@@ -100,7 +101,7 @@ namespace TFE_System
 			strftime(timeStr, sizeof(timeStr) - 4, "%Y-%b-%d %H:%M:%S", &now_tm); // Leave space for milliseconds
 
 			// Add milliseconds to the formatted time
-			snprintf(timeStr + strlen(timeStr), 8, ".%03lld - ", milliseconds.count());
+			snprintf(timeStr + strlen(timeStr), 8, ".%03" PRIu64 " - ", milliseconds.count());
 		}
 		else
 		{

--- a/TheForceEngine/TFE_System/system.cpp
+++ b/TheForceEngine/TFE_System/system.cpp
@@ -234,7 +234,7 @@ namespace TFE_System
 	{
 		time_t _tm = time(NULL);
 		struct tm* curtime = localtime(&_tm);
-		sprintf(output, "%0.2d-%0.2d-%0.4d-%0.2d-%0.2d", curtime->tm_mon + 1, curtime->tm_mday, curtime->tm_year + 1900, curtime->tm_hour + 1, curtime->tm_min);
+		strftime(output, 16, "%m-%d-%Y-%H-%M", curtime);
 	}
 
 	bool osShellExecute(const char* pathToExe, const char* exeDir, const char* param, bool waitForCompletion)


### PR DESCRIPTION
Fix all the build warnings emitted by gcc:
- drop 2 "externs" on file-scope variables,
- replace %d/%l/.. with PRI* equivalents. gcc is espcially noisy wrt. printf format mismatches.
- use strftime() instead of the home-made equivalent. Again, printf() format specifier warnings.

With this the build is now warning-free with gcc-15+.
