### PR TITLE
Custom projectiles & effects

### DIFF
--- a/TheForceEngine/ExternalData/DarkForces/weapons.json
+++ b/TheForceEngine/ExternalData/DarkForces/weapons.json
@@ -15,6 +15,7 @@
                 "ammo": "",
                 "wakeupRange": 0,
                 "variation": 0,
+                "primaryProjectile": "PUNCH",
                 "animFrames": [
                     {
                         "texture": 1,
@@ -54,6 +55,7 @@
                 "wakeupRange": 45,
                 "variation": 22,
                 "primaryFireConsumption": 1,
+                "primaryProjectile": "PISTOL_BOLT",
                 "animFrames": [
                     {
                         "texture": 1,
@@ -87,6 +89,7 @@
                 "wakeupRange": 50,
                 "variation": 86,
                 "primaryFireConsumption": 2,
+                "primaryProjectile": "RIFLE_BOLT",
                 "animFrames": [
                     {
                         "texture": 1,
@@ -114,6 +117,7 @@
                 "wakeupRange": 0,
                 "variation": 2949165,
                 "primaryFireConsumption": 1,
+                "primaryProjectile": "THERMAL_DET",
                 "animFrames": [
                     {
                         "texture": 1,
@@ -160,6 +164,8 @@
                 "variation": 2949165,
                 "primaryFireConsumption": 1,
                 "secondaryFireConsumption": 3,
+                "primaryProjectile": "REPEATER",
+                "secondaryProjectile": "REPEATER",
                 "animFrames": [
                     {
                         "texture": 1,
@@ -208,6 +214,8 @@
                 "variation": 45,
                 "primaryFireConsumption": 1,
                 "secondaryFireConsumption": 8,
+                "primaryProjectile": "PLASMA",
+                "secondaryProjectile": "PLASMA",
                 "animFrames": [
                     {
                         "texture": 0,
@@ -267,6 +275,7 @@
                 "wakeupRange": 60,
                 "variation": 45,
                 "primaryFireConsumption": 1,
+                "primaryProjectile": "MORTAR",
                 "animFrames": [
                     {
                         "texture": 1,
@@ -305,7 +314,9 @@
                 "ammo": "ammoMine",
                 "wakeupRange": 0,
                 "variation": 0,
-                "primaryFireConsumption": 1
+                "primaryFireConsumption": 1,
+                "primaryProjectile": "LAND_MINE",
+                "secondaryProjectile": "LAND_MINE_PROX"
             }
         },
         {
@@ -319,6 +330,7 @@
                 "wakeupRange": 70,
                 "variation": 0,
                 "primaryFireConsumption": 4,
+                "primaryProjectile": "CONCUSSION",
                 "animFrames":[
                     {
                         "texture": 1,
@@ -354,6 +366,8 @@
                 "variation": 2949165,
                 "primaryFireConsumption": 1,
                 "secondaryFireConsumption": 1,
+                "primaryProjectile": "CANNON",
+                "secondaryProjectile": "MISSILE",
                 "animFrames": [
                     {
                         "texture": 1,

--- a/TheForceEngine/ExternalData/DarkForces/weapons.json
+++ b/TheForceEngine/ExternalData/DarkForces/weapons.json
@@ -16,6 +16,11 @@
                 "wakeupRange": 0,
                 "variation": 0,
                 "primaryProjectile": "PUNCH",
+                "pitchOffsets": [35],
+                "yawOffsets": [-20],
+                "xOffsets": [-1.75],
+                "yOffsets": [-1.5],
+                "zOffsets": [6.0],
                 "animFrames": [
                     {
                         "texture": 1,
@@ -56,6 +61,11 @@
                 "variation": 22,
                 "primaryFireConsumption": 1,
                 "primaryProjectile": "PISTOL_BOLT",
+                "pitchOffsets": [0],
+                "yawOffsets": [0],
+                "xOffsets": [0.4],
+                "yOffsets": [-0.6],
+                "zOffsets": [3.2],
                 "animFrames": [
                     {
                         "texture": 1,
@@ -90,6 +100,11 @@
                 "variation": 86,
                 "primaryFireConsumption": 2,
                 "primaryProjectile": "RIFLE_BOLT",
+                "pitchOffsets": [0],
+                "yawOffsets": [0],
+                "xOffsets": [0.4],
+                "yOffsets": [-0.75],
+                "zOffsets": [4.0],
                 "animFrames": [
                     {
                         "texture": 1,
@@ -118,6 +133,11 @@
                 "variation": 2949165,
                 "primaryFireConsumption": 1,
                 "primaryProjectile": "THERMAL_DET",
+                "pitchOffsets": [35],
+                "yawOffsets": [0],
+                "xOffsets": [2.0],
+                "yOffsets": [-2.0],
+                "zOffsets": [2.0],
                 "animFrames": [
                     {
                         "texture": 1,
@@ -166,6 +186,16 @@
                 "secondaryFireConsumption": 3,
                 "primaryProjectile": "REPEATER",
                 "secondaryProjectile": "REPEATER",
+                "pitchOffsets": [0],
+                "yawOffsets": [0],
+                "xOffsets": [0.8],
+                "yOffsets": [-0.98],
+                "zOffsets": [5.0],
+                "pitchOffsetsSecondary": [3.0, -3.0, -3.0],
+                "yawOffsetsSecondary": [0, 3.0, -3.0],
+                "xOffsetsSecondary": [0.9, 0.5, 1.5],
+                "yOffsetsSecondary": [-0.98, -1.5, -1.5],
+                "zOffsetsSecondary": [5.0, 5.0, 5.0],
                 "animFrames": [
                     {
                         "texture": 1,
@@ -216,6 +246,16 @@
                 "secondaryFireConsumption": 8,
                 "primaryProjectile": "PLASMA",
                 "secondaryProjectile": "PLASMA",
+                "pitchOffsets": [0, 0, 0, 0],
+                "yawOffsets": [0, 0, 0, 0],
+                "xOffsets": [-1, -0.3, 0.3, 0.8],
+                "yOffsets": [-0.5, -0.8, -1.1, -1.3],
+                "zOffsets": [3.0, 3.0, 3.0, 3.0],
+                "pitchOffsetsSecondary": [0, 0, 0, 0],
+                "yawOffsetsSecondary": [-8.24, -2.75, 2.75, 8.24],
+                "xOffsetsSecondary": [-1, -0.3, 0.3, 0.8],
+                "yOffsetsSecondary": [-0.5, -0.8, -1.1, -1.3],
+                "zOffsetsSecondary": [3.0, 3.0, 3.0, 3.0],
                 "animFrames": [
                     {
                         "texture": 0,
@@ -276,6 +316,11 @@
                 "variation": 45,
                 "primaryFireConsumption": 1,
                 "primaryProjectile": "MORTAR",
+                "pitchOffsets": [18],
+                "yawOffsets": [0],
+                "xOffsets": [0.7],
+                "yOffsets": [-1.7],
+                "zOffsets": [2.0],
                 "animFrames": [
                     {
                         "texture": 1,
@@ -331,6 +376,11 @@
                 "variation": 0,
                 "primaryFireConsumption": 4,
                 "primaryProjectile": "CONCUSSION",
+                "pitchOffsets": [0],
+                "yawOffsets": [0],
+                "xOffsets": [1.0],
+                "yOffsets": [-0.5],
+                "zOffsets": [3.0],
                 "animFrames":[
                     {
                         "texture": 1,
@@ -368,6 +418,16 @@
                 "secondaryFireConsumption": 1,
                 "primaryProjectile": "CANNON",
                 "secondaryProjectile": "MISSILE",
+                "pitchOffsets": [0],
+                "yawOffsets": [0],
+                "xOffsets": [1.0],
+                "yOffsets": [-0.6],
+                "zOffsets": [3.0],
+                "pitchOffsetsSecondary": [0],
+                "yawOffsetsSecondary": [0],
+                "xOffsetsSecondary": [2.0],
+                "yOffsetsSecondary": [-0.25],
+                "zOffsetsSecondary": [4.0],
                 "animFrames": [
                     {
                         "texture": 1,

--- a/TheForceEngine/ExternalData/DarkForces/weapons.json
+++ b/TheForceEngine/ExternalData/DarkForces/weapons.json
@@ -17,8 +17,8 @@
                 "variation": 0,
                 "primaryProjectile": "PUNCH",
                 "pitchOffsets": [35],
-                "yawOffsets": [-20],
-                "xOffsets": [-1.75],
+                "yawOffsets": [20],
+                "xOffsets": [1.75],
                 "yOffsets": [-1.5],
                 "zOffsets": [6.0],
                 "animFrames": [

--- a/TheForceEngine/TFE_DarkForces/Actor/actor.cpp
+++ b/TheForceEngine/TFE_DarkForces/Actor/actor.cpp
@@ -1121,7 +1121,7 @@ namespace TFE_DarkForces
 				projObj->yaw = obj->yaw;
 				
 				// Vanilla DF did not handle arcing projectiles with STATE_ATTACK1; this has been added
-				if (attackMod->projType == PROJ_THERMAL_DET || attackMod->projType == PROJ_MORTAR)
+				if (proj->updateFunc == arcingProjectileUpdateFunc)
 				{
 					// TDs are lobbed at an angle that depends on distance from target
 					proj->bounceCnt = 0;
@@ -1227,7 +1227,9 @@ namespace TFE_DarkForces
 
 				SecObject* projObj = proj->logic.obj;
 				projObj->yaw = obj->yaw;
-				if (attackMod->projType == PROJ_THERMAL_DET || attackMod->projType == PROJ_MORTAR)
+				
+				// The original test here was projType == PROJ_THERMAL_DET. In TFE we want to generalise it to all arcing projectiles.
+				if (proj->updateFunc == arcingProjectileUpdateFunc)
 				{
 					proj->bounceCnt = 0;
 					proj->duration = 0xffffffff;

--- a/TheForceEngine/TFE_DarkForces/darkForcesMain.cpp
+++ b/TheForceEngine/TFE_DarkForces/darkForcesMain.cpp
@@ -1468,8 +1468,6 @@ namespace TFE_DarkForces
 		loadCutsceneList();
 		loadLangHotkeys();
 
-		TFE_ExternalData::loadCustomLogics();
-
 		TFE_ExternalData::loadExternalPickups();
 		if (!TFE_ExternalData::validateExternalPickups())
 		{
@@ -1493,6 +1491,8 @@ namespace TFE_DarkForces
 		{
 			TFE_System::logWrite(LOG_ERROR, "EXTERNAL_DATA", "Warning: Weapon data is incomplete. WEAPONS.JSON may have been altered. Weapons may not behave as expected.");
 		}
+
+		TFE_ExternalData::loadCustomLogics();
 
 		projectile_startup();
 		hitEffect_startup();

--- a/TheForceEngine/TFE_DarkForces/hitEffect.cpp
+++ b/TheForceEngine/TFE_DarkForces/hitEffect.cpp
@@ -11,6 +11,7 @@
 #include <TFE_Jedi/Memory/allocator.h>
 #include <TFE_Jedi/Task/task.h>
 #include <TFE_ExternalData/weaponExternal.h>
+#include <TFE_ExternalData/customEffect.h>
 
 using namespace TFE_Jedi;
 
@@ -37,6 +38,8 @@ namespace TFE_DarkForces
 	static EffectData s_effectData[HEFFECT_COUNT];
 	static Allocator* s_hitEffects;
 
+	std::vector<EffectData> s_customEffectData;	// TFE - custom effects
+
 	Task* s_hitEffectTask = nullptr;
 	vec3_fixed s_explodePos;
 	EffectData* s_curEffectData = nullptr;
@@ -58,38 +61,48 @@ namespace TFE_DarkForces
 		// TFE: Effect data is now defined externally. These were hardcoded in vanilla DF.
 		TFE_ExternalData::ExternalEffect* externalEffects = TFE_ExternalData::getExternalEffects();
 
-		s_effectData[HEFFECT_SMALL_EXP] = setEffectData(HEFFECT_SMALL_EXP, externalEffects);
-		s_effectData[HEFFECT_THERMDET_EXP] = setEffectData(HEFFECT_THERMDET_EXP, externalEffects);
-		s_effectData[HEFFECT_PLASMA_EXP] = setEffectData(HEFFECT_PLASMA_EXP, externalEffects);
-		s_effectData[HEFFECT_MORTAR_EXP] = setEffectData(HEFFECT_MORTAR_EXP, externalEffects);
-		s_effectData[HEFFECT_CONCUSSION] = setEffectData(HEFFECT_CONCUSSION, externalEffects);
-		s_effectData[HEFFECT_CONCUSSION2] = setEffectData(HEFFECT_CONCUSSION2, externalEffects);
-		s_effectData[HEFFECT_MISSILE_EXP] = setEffectData(HEFFECT_MISSILE_EXP, externalEffects);
-		s_effectData[HEFFECT_MISSILE_WEAK] = setEffectData(HEFFECT_MISSILE_WEAK, externalEffects);
-		s_effectData[HEFFECT_PUNCH] = setEffectData(HEFFECT_PUNCH, externalEffects);
-		s_effectData[HEFFECT_CANNON_EXP] = setEffectData(HEFFECT_CANNON_EXP, externalEffects);
-		s_effectData[HEFFECT_REPEATER_EXP] = setEffectData(HEFFECT_REPEATER_EXP, externalEffects);
-		s_effectData[HEFFECT_LARGE_EXP] = setEffectData(HEFFECT_LARGE_EXP, externalEffects);
-		s_effectData[HEFFECT_EXP_BARREL] = setEffectData(HEFFECT_EXP_BARREL, externalEffects);
-		s_effectData[HEFFECT_EXP_INVIS] = setEffectData(HEFFECT_EXP_INVIS, externalEffects);
-		s_effectData[HEFFECT_SPLASH] = setEffectData(HEFFECT_SPLASH, externalEffects);
-		s_effectData[HEFFECT_EXP_35] = setEffectData(HEFFECT_EXP_35, externalEffects);
-		s_effectData[HEFFECT_EXP_NO_DMG] = setEffectData(HEFFECT_EXP_NO_DMG, externalEffects);
-		s_effectData[HEFFECT_EXP_25] = setEffectData(HEFFECT_EXP_25, externalEffects);
+		s_effectData[HEFFECT_SMALL_EXP] = setEffectData(HEFFECT_SMALL_EXP, &externalEffects[HEFFECT_SMALL_EXP]);
+		s_effectData[HEFFECT_THERMDET_EXP] = setEffectData(HEFFECT_THERMDET_EXP, &externalEffects[HEFFECT_THERMDET_EXP]);
+		s_effectData[HEFFECT_PLASMA_EXP] = setEffectData(HEFFECT_PLASMA_EXP, &externalEffects[HEFFECT_PLASMA_EXP]);
+		s_effectData[HEFFECT_MORTAR_EXP] = setEffectData(HEFFECT_MORTAR_EXP, &externalEffects[HEFFECT_MORTAR_EXP]);
+		s_effectData[HEFFECT_CONCUSSION] = setEffectData(HEFFECT_CONCUSSION, &externalEffects[HEFFECT_CONCUSSION]);
+		s_effectData[HEFFECT_CONCUSSION2] = setEffectData(HEFFECT_CONCUSSION2, &externalEffects[HEFFECT_CONCUSSION2]);
+		s_effectData[HEFFECT_MISSILE_EXP] = setEffectData(HEFFECT_MISSILE_EXP, &externalEffects[HEFFECT_MISSILE_EXP]);
+		s_effectData[HEFFECT_MISSILE_WEAK] = setEffectData(HEFFECT_MISSILE_WEAK, &externalEffects[HEFFECT_MISSILE_WEAK]);
+		s_effectData[HEFFECT_PUNCH] = setEffectData(HEFFECT_PUNCH, &externalEffects[HEFFECT_PUNCH]);
+		s_effectData[HEFFECT_CANNON_EXP] = setEffectData(HEFFECT_CANNON_EXP, &externalEffects[HEFFECT_CANNON_EXP]);
+		s_effectData[HEFFECT_REPEATER_EXP] = setEffectData(HEFFECT_REPEATER_EXP, &externalEffects[HEFFECT_REPEATER_EXP]);
+		s_effectData[HEFFECT_LARGE_EXP] = setEffectData(HEFFECT_LARGE_EXP, &externalEffects[HEFFECT_LARGE_EXP]);
+		s_effectData[HEFFECT_EXP_BARREL] = setEffectData(HEFFECT_EXP_BARREL, &externalEffects[HEFFECT_EXP_BARREL]);
+		s_effectData[HEFFECT_EXP_INVIS] = setEffectData(HEFFECT_EXP_INVIS, &externalEffects[HEFFECT_EXP_INVIS]);
+		s_effectData[HEFFECT_SPLASH] = setEffectData(HEFFECT_SPLASH, &externalEffects[HEFFECT_SPLASH]);
+		s_effectData[HEFFECT_EXP_35] = setEffectData(HEFFECT_EXP_35, &externalEffects[HEFFECT_EXP_35]);
+		s_effectData[HEFFECT_EXP_NO_DMG] = setEffectData(HEFFECT_EXP_NO_DMG, &externalEffects[HEFFECT_EXP_NO_DMG]);
+		s_effectData[HEFFECT_EXP_25] = setEffectData(HEFFECT_EXP_25, &externalEffects[HEFFECT_EXP_25]);
+
+		// Custom effects
+		s_customEffectData.clear();
+		std::vector<TFE_ExternalData::ExternalEffect>* customEffects = TFE_ExternalData::getCustomEffects();
+		for (u32 e = 0; e < customEffects->size(); e++)
+		{
+			TFE_ExternalData::ExternalEffect* custEffect = &customEffects->at(e);
+			EffectData data = setEffectData((HitEffectID)(e + TFE_ExternalData::CUSTOM_EFFECT_STARTNUM), custEffect);
+			s_customEffectData.push_back(data);
+		}
 	}
 	
 	// TFE: Set up effect from external data.
-	EffectData setEffectData(HitEffectID type, TFE_ExternalData::ExternalEffect* extEffects)
+	EffectData setEffectData(HitEffectID type, TFE_ExternalData::ExternalEffect* extEffect)
 	{
 		return
 		{
-			type,															// type
-			TFE_Sprite_Jedi::getWax(extEffects[type].wax, POOL_GAME),		// spriteData
-			FIXED(extEffects[type].force),									// force
-			FIXED(extEffects[type].damage),									// damage
-			FIXED(extEffects[type].explosiveRange),							// explosiveRange
-			FIXED(extEffects[type].wakeupRange),							// wakeupRange
-			sound_load(extEffects[type].soundEffect, SoundPriority(extEffects[type].soundPriority)),	// soundEffect & priority
+			type,														// type
+			TFE_Sprite_Jedi::getWax(extEffect->wax, POOL_GAME),			// spriteData
+			FIXED(extEffect->force),									// force
+			FIXED(extEffect->damage),									// damage
+			FIXED(extEffect->explosiveRange),							// explosiveRange
+			FIXED(extEffect->wakeupRange),							// wakeupRange
+			sound_load(extEffect->soundEffect, SoundPriority(extEffect->soundPriority)),	// soundEffect & priority
 		};
 	}
 
@@ -168,10 +181,24 @@ namespace TFE_DarkForces
 					fixed16_16 y = effect->y;
 					fixed16_16 z = effect->z;
 
-					EffectData* data = &s_effectData[effect->type];
+					// TFE - custom effects are numbered starting from 100
+					EffectData* data = nullptr;
+					if (effect->type < TFE_ExternalData::CUSTOM_EFFECT_STARTNUM)
+					{
+						data = &s_effectData[effect->type];
+					}
+					else
+					{
+						u32 index = effect->type - TFE_ExternalData::CUSTOM_EFFECT_STARTNUM;
+						if (index < s_customEffectData.size())
+						{
+							data = &s_customEffectData.at(index);
+						}
+					}
+					
 					s_curEffectData = data;
 
-					if (data->spriteData)
+					if (data && data->spriteData)
 					{
 						JBool createEffectObj = JTRUE;
 						if (effect->type == HEFFECT_PLASMA_EXP || effect->type == HEFFECT_CANNON_EXP)
@@ -218,13 +245,13 @@ namespace TFE_DarkForces
 							// obj_addToRefList(obj, ObjRefType_Effect);	// scripting
 						}
 					}
-					if (s_curEffectData->soundEffect)
+					if (s_curEffectData && s_curEffectData->soundEffect)
 					{
 						vec3_fixed soundPos = { x,y,z };
 						sound_playCued(s_curEffectData->soundEffect, soundPos);
 					}
 
-					if (s_curEffectData->explosiveRange)
+					if (s_curEffectData && s_curEffectData->explosiveRange)
 					{
 						s_explodePos.x = x;
 						s_explodePos.y = y;
@@ -238,7 +265,7 @@ namespace TFE_DarkForces
 							inf_handleExplosion(sector, x, z, range >> 3);
 						}
 					}
-					if (s_curEffectData->wakeupRange)
+					if (s_curEffectData && s_curEffectData->wakeupRange)
 					{
 						// Wakes up all objects with a valid collision path to (x,y,z) that are within s_curEffectData->wakeupRange units.
 						vec3_fixed hitPos = { x, y, z };

--- a/TheForceEngine/TFE_DarkForces/projectile.cpp
+++ b/TheForceEngine/TFE_DarkForces/projectile.cpp
@@ -4,6 +4,7 @@
 #include "player.h"
 #include "sound.h"
 #include <cstring>
+#include <map>
 #include <TFE_Asset/modelAsset_jedi.h>
 #include <TFE_Asset/spriteAsset_Jedi.h>
 #include <TFE_Jedi/Collision/collision.h>
@@ -15,6 +16,7 @@
 #include <TFE_Jedi/Memory/allocator.h>
 #include <TFE_Jedi/Serialization/serialization.h>
 #include <TFE_ExternalData/weaponExternal.h>
+#include <TFE_ExternalData/customProjectile.h>
 
 using namespace TFE_Jedi;
 
@@ -51,29 +53,16 @@ namespace TFE_DarkForces
 	static SoundSourceId s_projectileReflectSnd[PROJ_COUNT];
 	static SoundSourceId s_projectileFlightSnd[PROJ_COUNT];
 
-	static JediModel* s_boltModel;
-	static JediModel* s_greenBoltModel;
-	static Wax*       s_plasmaProj;
-	static WaxFrame*  s_repeaterProj;
-	static Wax*       s_mortarProj;
-	static Wax*       s_missileProj;
-	static Wax*       s_cannonProj;
-	static Wax*       s_probeProj;
-	static Wax*       s_homingMissileProj;
-	static Wax*       s_bobafetBall;
-	static WaxFrame*  s_landmineWpnFrame;
-	static WaxFrame*  s_landmineFrame;
-	static WaxFrame*  s_thermalDetProj;
+	// Assets for custom projectiles
+	static std::map<u32, JediModel*> s_customProjectileModels;
+	static std::map<u32, WaxFrame*> s_customProjectileFrames;
+	static std::map<u32, Wax*> s_customProjectileWaxes;
 
-	static SoundSourceId s_stdProjCameraSnd       = NULL_SOUND;
-	static SoundSourceId s_stdProjReflectSnd      = NULL_SOUND;
-	static SoundSourceId s_thermalDetReflectSnd   = NULL_SOUND;
-	static SoundSourceId s_plasmaCameraSnd        = NULL_SOUND;
-	static SoundSourceId s_plasmaReflectSnd       = NULL_SOUND;
-	static SoundSourceId s_missileLoopingSnd      = NULL_SOUND;
+	static std::vector<SoundSourceId> s_customProjectileCameraSnd;
+	static std::vector<SoundSourceId> s_customProjectileReflectSnd;
+	static std::vector<SoundSourceId> s_customProjectileFlightSnd;
+
 	static SoundSourceId s_landMineTriggerSnd     = NULL_SOUND;
-	static SoundSourceId s_bobaBallCameraSnd      = NULL_SOUND;
-	static SoundSourceId s_homingMissileFlightSnd = NULL_SOUND;
 
 	static RSector*   s_projPath[PROJ_PATH_MAX_SECTORS];
 	static RSector*   s_projSector;
@@ -181,6 +170,45 @@ namespace TFE_DarkForces
 		// s_homingMissileFlightSnd = sound_load("tracker.voc",  SOUND_PRIORITY_LOW3);
 		// s_bobaBallCameraSnd      = sound_load("fireball.voc", SOUND_PRIORITY_LOW3);
 		s_landMineTriggerSnd     = sound_load("beep-10.voc",  SOUND_PRIORITY_HIGH3);		// still used!
+
+		// Custom projectile assets
+		s_customProjectileModels.clear();
+		s_customProjectileFrames.clear();
+		s_customProjectileWaxes.clear();
+		s_customProjectileCameraSnd.clear();
+		s_customProjectileReflectSnd.clear();
+		s_customProjectileFlightSnd.clear();
+
+		std::vector<TFE_ExternalData::ExternalProjectile>* customProjectiles = TFE_ExternalData::getCustomProjectiles();
+		for (u32 p = 0; p < customProjectiles->size(); p++)
+		{
+			TFE_ExternalData::ExternalProjectile proj = customProjectiles->at(p);
+			
+			// Frame
+			if (strcasecmp(proj.assetType, "frame") == 0)
+			{
+				WaxFrame* frame = TFE_Sprite_Jedi::getFrame(proj.asset, POOL_GAME);
+				s_customProjectileFrames.insert({ p, frame });
+			}
+
+			// Wax
+			if (strcasecmp(proj.assetType, "sprite") == 0)
+			{
+				Wax* wax = TFE_Sprite_Jedi::getWax(proj.asset, POOL_GAME);
+				s_customProjectileWaxes.insert({p, wax});
+			}
+
+			// 3D model
+			if (strcasecmp(proj.assetType, "3d") == 0)
+			{
+				JediModel* model = TFE_Model_Jedi::get(proj.asset, POOL_GAME);
+				s_customProjectileModels.insert({ p, model });
+			}
+
+			s_customProjectileCameraSnd.push_back(sound_load(proj.cameraPassSound, SOUND_PRIORITY_LOW3));
+			s_customProjectileReflectSnd.push_back(sound_load(proj.reflectSound, SOUND_PRIORITY_LOW1));
+			s_customProjectileFlightSnd.push_back(sound_load(proj.flightSound, SOUND_PRIORITY_LOW3));
+		}
 	}
 
 	void projectile_clearState()
@@ -197,21 +225,21 @@ namespace TFE_DarkForces
 		s_projectileTask = createSubTask("projectiles", projectileTaskFunc);
 	}
 
-	// TFE: Set the Projectile object from external data. These were hardcoded in vanilla DF.
-	void setProjectileObject(SecObject*& projObj, ProjectileType type, TFE_ExternalData::ExternalProjectile* externalProjectiles)
+	// TFE: Set the Projectile object assets from external data. These were hardcoded in vanilla DF.
+	void setProjectileObjAssets(SecObject*& projObj, ProjectileType type, TFE_ExternalData::ExternalProjectile* externalProjectile)
 	{
-		if (strcasecmp(externalProjectiles[type].assetType, "spirit") == 0)
+		if (strcasecmp(externalProjectile->assetType, "spirit") == 0)
 		{
 			spirit_setData(projObj);
 		}
-		else if (strcasecmp(externalProjectiles[type].assetType, "frame") == 0)
+		else if (strcasecmp(externalProjectile->assetType, "frame") == 0)
 		{
 			if (s_projectileFrames[type])
 			{
 				frame_setData(projObj, s_projectileFrames[type]);
 			}
 		}
-		else if (strcasecmp(externalProjectiles[type].assetType, "sprite") == 0)
+		else if (strcasecmp(externalProjectile->assetType, "sprite") == 0)
 		{
 			if (s_projectileWaxes[type])
 			{
@@ -219,7 +247,7 @@ namespace TFE_DarkForces
 				obj_setSpriteAnim(projObj);		// Setup the looping wax animation.
 			}
 		}
-		else if (strcasecmp(externalProjectiles[type].assetType, "3d") == 0)
+		else if (strcasecmp(externalProjectile->assetType, "3d") == 0)
 		{
 			if (s_projectileModels[type])
 			{
@@ -230,58 +258,112 @@ namespace TFE_DarkForces
 		{
 			spirit_setData(projObj);	// default to spirit
 		}
+	}
+	
+	// Set custom projectile object assets
+	void setCustomProjectileObjAssets(SecObject*& projObj, u32 index, TFE_ExternalData::ExternalProjectile* customProjectile)
+	{
+		if (strcasecmp(customProjectile->assetType, "spirit") == 0)
+		{
+			spirit_setData(projObj);
+		}
+		else if (strcasecmp(customProjectile->assetType, "frame") == 0)
+		{
+			WaxFrame* frame = s_customProjectileFrames.at(index);
+			if (frame)
+			{
+				frame_setData(projObj, frame);
+			}
+		}
+		else if (strcasecmp(customProjectile->assetType, "sprite") == 0)
+		{
+			Wax* wax = s_customProjectileWaxes.at(index);
+			if (wax)
+			{
+				sprite_setData(projObj, wax);
+				obj_setSpriteAnim(projObj);		// Setup the looping wax animation.
+			}
+		}
+		else if (strcasecmp(customProjectile->assetType, "3d") == 0)
+		{
+			JediModel* model = s_customProjectileModels.at(index);
+			if (model)
+			{
+				obj3d_setData(projObj, model);
+			}
+		}
+		else
+		{
+			spirit_setData(projObj);	// default to spirit
+		}
+	}
 
-		if (externalProjectiles[type].fullBright)
+	// TFE: Set Projectile object data from external data
+	void setProjectileObjData(SecObject*& projObj, TFE_ExternalData::ExternalProjectile* externalProjectile)
+	{
+		if (externalProjectile->fullBright)
 		{
 			projObj->flags |= OBJ_FLAG_FULLBRIGHT;
 		}
 
-		if (externalProjectiles[type].autoAim)
+		if (externalProjectile->autoAim)
 		{
 			projObj->flags |= OBJ_FLAG_AIM;		// this is only meaningful for homing missiles, which can be shot down
 		}
 
-		if (externalProjectiles[type].movable)
+		if (externalProjectile->movable)
 		{
 			projObj->flags |= OBJ_FLAG_MOVABLE;		// thermal detonators & mines will be moved by elevators
 		}
 
-		if (externalProjectiles[type].zeroWidth)
+		if (externalProjectile->zeroWidth)
 		{
 			projObj->worldWidth = 0;
 		}
 	}
-	
+
 	// TFE: Set the Projectile logic from external data. These were hardcoded in vanilla DF.
-	void setProjectileLogic(ProjectileLogic*& projLogic, ProjectileType type, TFE_ExternalData::ExternalProjectile* externalProjectiles)
+	void setProjectileLogic(ProjectileLogic*& projLogic, ProjectileType type, TFE_ExternalData::ExternalProjectile* externalProjectile)
 	{
 		projLogic->type = type;
-		projLogic->updateFunc = getUpdateFunc(externalProjectiles[type].updateFunc);
-		projLogic->dmg = FIXED(externalProjectiles[type].damage);
-		projLogic->falloffAmt = externalProjectiles[type].falloffAmount;
-		projLogic->nextFalloffTick = s_curTick + externalProjectiles[type].nextFalloffTick;
-		projLogic->dmgFalloffDelta = externalProjectiles[type].damageFalloffDelta;
-		projLogic->minDmg = FIXED(externalProjectiles[type].minDamage);
+		projLogic->updateFunc = getUpdateFunc(externalProjectile->updateFunc);
+		projLogic->dmg = FIXED(externalProjectile->damage);
+		projLogic->falloffAmt = externalProjectile->falloffAmount;
+		projLogic->nextFalloffTick = s_curTick + externalProjectile->nextFalloffTick;
+		projLogic->dmgFalloffDelta = externalProjectile->damageFalloffDelta;
+		projLogic->minDmg = FIXED(externalProjectile->minDamage);
 
-		projLogic->projForce = externalProjectiles[type].force;
-		projLogic->speed = FIXED(externalProjectiles[type].speed);
-		projLogic->horzBounciness = externalProjectiles[type].horzBounciness;
-		projLogic->vertBounciness = externalProjectiles[type].vertBounciness;
-		projLogic->bounceCnt = externalProjectiles[type].bounceCount;
-		projLogic->reflVariation = externalProjectiles[type].reflectVariation;
-		projLogic->reflectEffectId = (HitEffectID)externalProjectiles[type].reflectEffectId;
-		projLogic->hitEffectId = (HitEffectID)externalProjectiles[type].hitEffectId;;
-		projLogic->duration = s_curTick + externalProjectiles[type].duration;
-		projLogic->homingAngleSpd = externalProjectiles[type].homingAngularSpeed;	// Starting homing rate
+		projLogic->projForce = externalProjectile->force;
+		projLogic->speed = FIXED(externalProjectile->speed);
+		projLogic->horzBounciness = externalProjectile->horzBounciness;
+		projLogic->vertBounciness = externalProjectile->vertBounciness;
+		projLogic->bounceCnt = externalProjectile->bounceCount;
+		projLogic->reflVariation = externalProjectile->reflectVariation;
+		projLogic->reflectEffectId = (HitEffectID)externalProjectile->reflectEffectId;
+		projLogic->hitEffectId = (HitEffectID)externalProjectile->hitEffectId;;
+		projLogic->duration = s_curTick + externalProjectile->duration;
+		projLogic->homingAngleSpd = externalProjectile->homingAngularSpeed;	// Starting homing rate
 
-		projLogic->cameraPassSnd = s_projectileCameraSnd[type];
-		projLogic->reflectSnd = s_projectileReflectSnd[type];
-		projLogic->flightSndSource = s_projectileFlightSnd[type];
-
-		if (externalProjectiles[type].explodeOnTimeout)
+		if (externalProjectile->explodeOnTimeout)
 		{
 			projLogic->flags |= PROJFLAG_EXPLODE;
 		}
+	}
+
+	// TFE: Set projectile sounds
+	void setProjectileSounds(ProjectileLogic*& projLogic, ProjectileType type)
+	{
+		projLogic->cameraPassSnd = s_projectileCameraSnd[type];
+		projLogic->reflectSnd = s_projectileReflectSnd[type];
+		projLogic->flightSndSource = s_projectileFlightSnd[type];
+	}
+
+	// Set custom projectile sounds
+	void setCustomProjectileSounds(ProjectileLogic*& projLogic, u32 index)
+	{
+		projLogic->cameraPassSnd = s_customProjectileCameraSnd.at(index);
+		projLogic->reflectSnd = s_customProjectileReflectSnd.at(index);
+		projLogic->flightSndSource = s_customProjectileFlightSnd.at(index);
 	}
 
 	// TFE
@@ -340,92 +422,126 @@ namespace TFE_DarkForces
 		{
 			case PROJ_PUNCH:
 			{
-				setProjectileObject(projObj, PROJ_PUNCH, externalProjectiles);
-				setProjectileLogic(projLogic, PROJ_PUNCH, externalProjectiles);
+				setProjectileObjAssets(projObj, PROJ_PUNCH, &externalProjectiles[type]);
+				setProjectileObjData(projObj, &externalProjectiles[type]);
+				setProjectileLogic(projLogic, PROJ_PUNCH, &externalProjectiles[type]);
+				setProjectileSounds(projLogic, PROJ_PUNCH);
 			} break;
 			case PROJ_PISTOL_BOLT:
 			{
-				setProjectileObject(projObj, PROJ_PISTOL_BOLT, externalProjectiles);
-				setProjectileLogic(projLogic, PROJ_PISTOL_BOLT, externalProjectiles);
+				setProjectileObjAssets(projObj, PROJ_PISTOL_BOLT, &externalProjectiles[type]);
+				setProjectileObjData(projObj, &externalProjectiles[type]);
+				setProjectileLogic(projLogic, PROJ_PISTOL_BOLT, &externalProjectiles[type]);
+				setProjectileSounds(projLogic, PROJ_PISTOL_BOLT);
 			} break;
 			case PROJ_RIFLE_BOLT:
 			{
-				setProjectileObject(projObj, PROJ_RIFLE_BOLT, externalProjectiles);
-				setProjectileLogic(projLogic, PROJ_RIFLE_BOLT, externalProjectiles);
+				setProjectileObjAssets(projObj, PROJ_RIFLE_BOLT, &externalProjectiles[type]);
+				setProjectileObjData(projObj, &externalProjectiles[type]);
+				setProjectileLogic(projLogic, PROJ_RIFLE_BOLT, &externalProjectiles[type]);
+				setProjectileSounds(projLogic, PROJ_RIFLE_BOLT);
 			} break;
 			case PROJ_THERMAL_DET:
 			{
-				setProjectileObject(projObj, PROJ_THERMAL_DET, externalProjectiles);
-				setProjectileLogic(projLogic, PROJ_THERMAL_DET, externalProjectiles);
+				setProjectileObjAssets(projObj, PROJ_THERMAL_DET, &externalProjectiles[type]);
+				setProjectileObjData(projObj, &externalProjectiles[type]);
+				setProjectileLogic(projLogic, PROJ_THERMAL_DET, &externalProjectiles[type]);
+				setProjectileSounds(projLogic, PROJ_THERMAL_DET);
 			} break;
 			case PROJ_REPEATER:
 			{
-				setProjectileObject(projObj, PROJ_REPEATER, externalProjectiles);
-				setProjectileLogic(projLogic, PROJ_REPEATER, externalProjectiles);
+				setProjectileObjAssets(projObj, PROJ_REPEATER, &externalProjectiles[type]);
+				setProjectileObjData(projObj, &externalProjectiles[type]);
+				setProjectileLogic(projLogic, PROJ_REPEATER, &externalProjectiles[type]);
+				setProjectileSounds(projLogic, PROJ_REPEATER);
 
 				// dmgFalloffDelta was 19660 in the code; this probably should have been 0.3 seconds, or 43 ticks
 			} break;
 			case PROJ_PLASMA:
 			{
-				setProjectileObject(projObj, PROJ_PLASMA, externalProjectiles);
-				setProjectileLogic(projLogic, PROJ_PLASMA, externalProjectiles);
+				setProjectileObjAssets(projObj, PROJ_PLASMA, &externalProjectiles[type]);
+				setProjectileObjData(projObj, &externalProjectiles[type]);
+				setProjectileLogic(projLogic, PROJ_PLASMA, &externalProjectiles[type]);
+				setProjectileSounds(projLogic, PROJ_PLASMA);
 			} break;
 			case PROJ_MORTAR:
 			{
-				setProjectileObject(projObj, PROJ_MORTAR, externalProjectiles);
-				setProjectileLogic(projLogic, PROJ_MORTAR, externalProjectiles);
+				setProjectileObjAssets(projObj, PROJ_MORTAR, &externalProjectiles[type]);
+				setProjectileObjData(projObj, &externalProjectiles[type]);
+				setProjectileLogic(projLogic, PROJ_MORTAR, &externalProjectiles[type]);
+				setProjectileSounds(projLogic, PROJ_MORTAR);
 			} break;
 			case PROJ_LAND_MINE:
 			{
-				setProjectileObject(projObj, PROJ_LAND_MINE, externalProjectiles);
+				setProjectileObjAssets(projObj, PROJ_LAND_MINE, &externalProjectiles[type]);
+				setProjectileObjData(projObj, &externalProjectiles[type]);
 				projObj->entityFlags |= ETFLAG_LANDMINE_WPN;
-				setProjectileLogic(projLogic, PROJ_LAND_MINE, externalProjectiles);
+				setProjectileLogic(projLogic, PROJ_LAND_MINE, &externalProjectiles[type]);
+				setProjectileSounds(projLogic, PROJ_LAND_MINE);
 			} break;
 			case PROJ_LAND_MINE_PROX:
 			{
-				setProjectileObject(projObj, PROJ_LAND_MINE_PROX, externalProjectiles);
+				setProjectileObjAssets(projObj, PROJ_LAND_MINE_PROX, &externalProjectiles[type]);
+				setProjectileObjData(projObj, &externalProjectiles[type]);
 				projObj->entityFlags |= ETFLAG_LANDMINE_WPN;
-				setProjectileLogic(projLogic, PROJ_LAND_MINE_PROX, externalProjectiles);
+				setProjectileLogic(projLogic, PROJ_LAND_MINE_PROX, &externalProjectiles[type]);
+				setProjectileSounds(projLogic, PROJ_LAND_MINE_PROX);
 			} break;
 			case PROJ_LAND_MINE_PLACED:
 			{
-				setProjectileObject(projObj, PROJ_LAND_MINE_PLACED, externalProjectiles);
-				setProjectileLogic(projLogic, PROJ_LAND_MINE_PLACED, externalProjectiles);
+				setProjectileObjAssets(projObj, PROJ_LAND_MINE_PLACED, &externalProjectiles[type]);
+				setProjectileObjData(projObj, &externalProjectiles[type]);
+				setProjectileLogic(projLogic, PROJ_LAND_MINE_PLACED, &externalProjectiles[type]);
+				setProjectileSounds(projLogic, PROJ_LAND_MINE_PLACED);
 			} break;
 			case PROJ_CONCUSSION:
 			{
-				setProjectileObject(projObj, PROJ_CONCUSSION, externalProjectiles);
-				setProjectileLogic(projLogic, PROJ_CONCUSSION, externalProjectiles);
+				setProjectileObjAssets(projObj, PROJ_CONCUSSION, &externalProjectiles[type]);
+				setProjectileObjData(projObj, &externalProjectiles[type]);
+				setProjectileLogic(projLogic, PROJ_CONCUSSION, &externalProjectiles[type]);
+				setProjectileSounds(projLogic, PROJ_CONCUSSION);
 			} break;
 			case PROJ_CANNON:
 			{
-				setProjectileObject(projObj, PROJ_CANNON, externalProjectiles);
-				setProjectileLogic(projLogic, PROJ_CANNON, externalProjectiles);
+				setProjectileObjAssets(projObj, PROJ_CANNON, &externalProjectiles[type]);
+				setProjectileObjData(projObj, &externalProjectiles[type]);
+				setProjectileLogic(projLogic, PROJ_CANNON, &externalProjectiles[type]);
+				setProjectileSounds(projLogic, PROJ_CANNON);
 			} break;
 			case PROJ_MISSILE:
 			{
-				setProjectileObject(projObj, PROJ_MISSILE, externalProjectiles);
-				setProjectileLogic(projLogic, PROJ_MISSILE, externalProjectiles);
+				setProjectileObjAssets(projObj, PROJ_MISSILE, &externalProjectiles[type]);
+				setProjectileObjData(projObj, &externalProjectiles[type]);
+				setProjectileLogic(projLogic, PROJ_MISSILE, &externalProjectiles[type]);
+				setProjectileSounds(projLogic, PROJ_MISSILE);
 			} break;
 			case PROJ_TURRET_BOLT:
 			{
-				setProjectileObject(projObj, PROJ_TURRET_BOLT, externalProjectiles);
-				setProjectileLogic(projLogic, PROJ_TURRET_BOLT, externalProjectiles);
+				setProjectileObjAssets(projObj, PROJ_TURRET_BOLT, &externalProjectiles[type]);
+				setProjectileObjData(projObj, &externalProjectiles[type]);
+				setProjectileLogic(projLogic, PROJ_TURRET_BOLT, &externalProjectiles[type]);
+				setProjectileSounds(projLogic, PROJ_TURRET_BOLT);
 			} break;
 			case PROJ_REMOTE_BOLT:
 			{
-				setProjectileObject(projObj, PROJ_REMOTE_BOLT, externalProjectiles);
-				setProjectileLogic(projLogic, PROJ_REMOTE_BOLT, externalProjectiles);
+				setProjectileObjAssets(projObj, PROJ_REMOTE_BOLT, &externalProjectiles[type]);
+				setProjectileObjData(projObj, &externalProjectiles[type]);
+				setProjectileLogic(projLogic, PROJ_REMOTE_BOLT, &externalProjectiles[type]);
+				setProjectileSounds(projLogic, PROJ_REMOTE_BOLT);
 			} break;
 			case PROJ_EXP_BARREL:
 			{
-				setProjectileObject(projObj, PROJ_EXP_BARREL, externalProjectiles);
-				setProjectileLogic(projLogic, PROJ_EXP_BARREL, externalProjectiles);
+				setProjectileObjAssets(projObj, PROJ_EXP_BARREL, &externalProjectiles[type]);
+				setProjectileObjData(projObj, &externalProjectiles[type]);
+				setProjectileLogic(projLogic, PROJ_EXP_BARREL, &externalProjectiles[type]);
+				setProjectileSounds(projLogic, PROJ_EXP_BARREL);
 			} break;
 			case PROJ_HOMING_MISSILE:
 			{
-				setProjectileObject(projObj, PROJ_HOMING_MISSILE, externalProjectiles);
-				setProjectileLogic(projLogic, PROJ_HOMING_MISSILE, externalProjectiles);
+				setProjectileObjAssets(projObj, PROJ_HOMING_MISSILE, &externalProjectiles[type]);
+				setProjectileObjData(projObj, &externalProjectiles[type]);
+				setProjectileLogic(projLogic, PROJ_HOMING_MISSILE, &externalProjectiles[type]);
+				setProjectileSounds(projLogic, PROJ_HOMING_MISSILE);
 
 				// projLogic->speed = FIXED(58) / 2;
 				// speed will be set to 29 externally; the value is correct according to the code, but they are slower in DOS.
@@ -433,15 +549,36 @@ namespace TFE_DarkForces
 			} break;
 			case PROJ_PROBE_PROJ:
 			{
-				setProjectileObject(projObj, PROJ_PROBE_PROJ, externalProjectiles);
-				setProjectileLogic(projLogic, PROJ_PROBE_PROJ, externalProjectiles);
+				setProjectileObjAssets(projObj, PROJ_PROBE_PROJ, &externalProjectiles[type]);
+				setProjectileObjData(projObj, &externalProjectiles[type]);
+				setProjectileLogic(projLogic, PROJ_PROBE_PROJ, &externalProjectiles[type]);
+				setProjectileSounds(projLogic, PROJ_PROBE_PROJ);
 			} break;
 			case PROJ_BOBAFET_BALL:
 			{
-				setProjectileObject(projObj, PROJ_BOBAFET_BALL, externalProjectiles);
-				setProjectileLogic(projLogic, PROJ_BOBAFET_BALL, externalProjectiles);
+				setProjectileObjAssets(projObj, PROJ_BOBAFET_BALL, &externalProjectiles[type]);
+				setProjectileObjData(projObj, &externalProjectiles[type]);
+				setProjectileLogic(projLogic, PROJ_BOBAFET_BALL, &externalProjectiles[type]);
+				setProjectileSounds(projLogic, PROJ_BOBAFET_BALL);
 			} break;
 		}
+
+		// Custom projectiles - these are numbered starting at 100
+		if (type >= TFE_ExternalData::CUSTOM_PROJ_STARTNUM)
+		{
+			u32 index = type - TFE_ExternalData::CUSTOM_PROJ_STARTNUM;
+			std::vector<TFE_ExternalData::ExternalProjectile>* customProjs = TFE_ExternalData::getCustomProjectiles();
+
+			if (index < customProjs->size())
+			{
+				TFE_ExternalData::ExternalProjectile* customProj = &customProjs->at(index);
+				setCustomProjectileObjAssets(projObj, index, customProj);
+				setProjectileObjData(projObj, customProj);
+				setProjectileLogic(projLogic, type, customProj);
+				setCustomProjectileSounds(projLogic, index);
+			}
+		}
+
 		projLogic->col_speed = projLogic->speed;
 
 		projObj->posWS.x = x;

--- a/TheForceEngine/TFE_DarkForces/projectile.cpp
+++ b/TheForceEngine/TFE_DarkForces/projectile.cpp
@@ -348,6 +348,11 @@ namespace TFE_DarkForces
 		{
 			projLogic->flags |= PROJFLAG_EXPLODE;
 		}
+
+		if (externalProjectile->doNotScale)
+		{
+			projLogic->flags |= PROJFLAG_DONOT_SCALE;
+		}
 	}
 
 	// TFE: Set projectile sounds
@@ -903,14 +908,16 @@ namespace TFE_DarkForces
 		return hitType;
 	}
 
-
-	void proj_computeTransform3D(SecObject* obj, fixed16_16 sinPitch, fixed16_16 cosPitch, fixed16_16 sinYaw, fixed16_16 cosYaw, fixed16_16 dt)
+	void proj_computeTransform3D(SecObject* obj, fixed16_16 sinPitch, fixed16_16 cosPitch, fixed16_16 sinYaw, fixed16_16 cosYaw, fixed16_16 dt, u32 projectileFlags)
 	{
 		// Projectile size is scaled by the delta-time.
 		// But this breaks down if the delta-time is too small.
 		// Given the original game had an average frame time of 2 ticks, then the minimum
 		// ~ 2 * ONE_SECOND / 145 = 2 * 65536 / 145 = 903. I use 900 because it is a nice round number.
 		if (dt < 900) { dt = 900; }
+
+		// Added to TFE - disable the scaling
+		if (projectileFlags & PROJFLAG_DONOT_SCALE) { dt = ONE_16; }
 
 		fixed16_16* transform = obj->transform;
 		transform[0] = cosYaw;
@@ -941,7 +948,7 @@ namespace TFE_DarkForces
 		SecObject* obj = projLogic->logic.obj;
 		if (obj->type == OBJ_TYPE_3D)
 		{
-			proj_computeTransform3D(obj, sinPitch, cosPitch, sinYaw, cosYaw, s_deltaTime);
+			proj_computeTransform3D(obj, sinPitch, cosPitch, sinYaw, cosYaw, s_deltaTime, projLogic->flags);
 		}
 	}
 

--- a/TheForceEngine/TFE_DarkForces/projectile.h
+++ b/TheForceEngine/TFE_DarkForces/projectile.h
@@ -120,6 +120,8 @@ namespace TFE_DarkForces
 	ProjectileHitType proj_handleMovement(ProjectileLogic* logic);
 	JBool handleProjectileHit(ProjectileLogic* logic, ProjectileHitType hitType);
 
+	ProjectileHitType arcingProjectileUpdateFunc(ProjectileLogic* logic);
+
 	void proj_aimAtTarget(ProjectileLogic* proj, vec3_fixed target);
 	void proj_aimArcing(ProjectileLogic* proj, vec3_fixed target, fixed16_16 speed);
 

--- a/TheForceEngine/TFE_DarkForces/projectile.h
+++ b/TheForceEngine/TFE_DarkForces/projectile.h
@@ -63,6 +63,9 @@ namespace TFE_DarkForces
 	{
 		PROJFLAG_CAMERA_PASS_SOUND = FLAG_BIT(0),
 		PROJFLAG_EXPLODE           = FLAG_BIT(1),		// Explodes when reaches end of life.
+		
+		// TFE
+		PROJFLAG_DONOT_SCALE       = FLAG_BIT(2),       // Disable framerate based scaling on 3DOs
 	};
 
 	struct ProjectileLogic;

--- a/TheForceEngine/TFE_DarkForces/weapon.cpp
+++ b/TheForceEngine/TFE_DarkForces/weapon.cpp
@@ -202,6 +202,8 @@ namespace TFE_DarkForces
 		s_playerWeaponList[id].variation = extWeapons[id].variation;
 		s_playerWeaponList[id].primaryFireConsumption = extWeapons[id].primaryFireConsumption;
 		s_playerWeaponList[id].secondaryFireConsumption = extWeapons[id].secondaryFireConsumption;
+		s_playerWeaponList[id].primaryProjectile = (ProjectileType)extWeapons[id].primaryProjectile;
+		s_playerWeaponList[id].secondaryProjectile = (ProjectileType)extWeapons[id].secondaryProjectile;
 
 		setupAnimationFrames(id, extWeapons[id].numAnimFrames, extWeapons[id].animFrames, extWeapons[id].numSecondaryAnimFrames, extWeapons[id].animFramesSecondary);
 	}

--- a/TheForceEngine/TFE_DarkForces/weapon.cpp
+++ b/TheForceEngine/TFE_DarkForces/weapon.cpp
@@ -206,6 +206,7 @@ namespace TFE_DarkForces
 		s_playerWeaponList[id].secondaryProjectile = (ProjectileType)extWeapons[id].secondaryProjectile;
 
 		setupAnimationFrames(id, extWeapons[id].numAnimFrames, extWeapons[id].animFrames, extWeapons[id].numSecondaryAnimFrames, extWeapons[id].animFramesSecondary);
+		setupWeaponOffsets(id, &extWeapons[id]);
 	}
 	
 	void weapon_startup()

--- a/TheForceEngine/TFE_DarkForces/weapon.h
+++ b/TheForceEngine/TFE_DarkForces/weapon.h
@@ -7,6 +7,7 @@
 #include <TFE_Jedi/Math/core_math.h>
 #include <TFE_Jedi/Task/task.h>
 #include "sound.h"
+#include "projectile.h"
 
 namespace TFE_Jedi
 {
@@ -44,6 +45,8 @@ namespace TFE_DarkForces
 		// TFE
 		s32 primaryFireConsumption;
 		s32 secondaryFireConsumption;
+		ProjectileType primaryProjectile;
+		ProjectileType secondaryProjectile;
 	};
 
 	struct WeaponAnimState

--- a/TheForceEngine/TFE_DarkForces/weaponFireFunc.cpp
+++ b/TheForceEngine/TFE_DarkForces/weaponFireFunc.cpp
@@ -117,27 +117,7 @@ namespace TFE_DarkForces
 	static WeaponProjOffsets s_cannonOffsets;
 	static WeaponProjOffsets s_cannonSecOffsets;
 
-	static const angle14_32 c_repeaterYawOffset[3] = { 0, 136, -136 };
-	static const angle14_32 c_repeaterPitchOffset[3] = { 136, -136, -136 };
-	// Deltas for repeater - note the order is ZXY
-	static fixed16_16 c_repeaterDelta[3 * 3] =
-	{
-		0x50000, 0xe666,  0xfae1,   // 5.0, 0.9, 0.98
-		0x50000, 0x8000,  0x18000,  // 5.0, 0.5, 1.5
-		0x50000, 0x18000, 0x18000,  // 5.0, 1.5, 1.5
-	};
 	static s32 s_fusionCylinder = 1;
-	static fixed16_16 s_fusionOffset[] =
-	{
-		FIXED(3), -ONE_16, 0x8000,	// 3.0, -1.0, 0.5
-		FIXED(3),  -19660, 0xcccc,	// 3.0, -0.3, 0.8
-		FIXED(3),  0x4ccc, 0x11999,	// 3.0,  0.3, 1.1
-		FIXED(3),  0xcccc, 0x14ccc, // 3.0,  0.8, 1.3
-	};
-	static angle14_32 s_fusionYawOffset[] =
-	{
-		-375, -125, 125, 375
-	};
 	static JBool s_fusionCycleForward = JTRUE;
 
 	extern void weapon_handleState(MessageType msg);
@@ -245,7 +225,7 @@ namespace TFE_DarkForces
 			projOffsets->pitchOffset[i] = floatToAngle(pitchOffsets[i]);
 			projOffsets->yawOffset[i] = floatToAngle(yawOffsets[i]);
 			projOffsets->xOffset[i] = floatToFixed16(xOffsets[i]);
-			projOffsets->yOffset[i] = floatToFixed16(yOffsets[i]);
+			projOffsets->yOffset[i] = -floatToFixed16(yOffsets[i]);
 			projOffsets->zOffset[i] = floatToFixed16(zOffsets[i]);
 		}
 	}
@@ -387,14 +367,14 @@ namespace TFE_DarkForces
 		fixed16_16 mtx[9];
 		weapon_computeMatrix(mtx, -s_playerObject->pitch, -s_playerObject->yaw);
 
-		fixed16_16 xOffset = -114688;	// -1.75
-		angle14_32 yawOffset = -910;
-		for (s32 i = 0; i < 3; i++, xOffset += 0x1c000, yawOffset += 910)
+		fixed16_16 xOffset = -s_punchOffsets.xOffset[0];	// -1.75
+		angle14_32 yawOffset = -s_punchOffsets.yawOffset[0];
+		for (s32 i = 0; i < 3; i++, xOffset += s_punchOffsets.xOffset[0], yawOffset += s_punchOffsets.yawOffset[0])
 		{
 			ProjectileLogic* proj = (ProjectileLogic*)createProjectile(s_curPlayerWeapon->primaryProjectile, s_playerObject->sector, s_playerObject->posWS.x, s_playerObject->posWS.y - s_playerObject->worldHeight + s_headwaveVerticalOffset, s_playerObject->posWS.z, s_playerObject);
 			if (s_oneHitKillEnabled) {	applyOneHitKillCheat(proj); }
 
-			s_weaponFirePitch = s_playerObject->pitch + 0x638;
+			s_weaponFirePitch = s_playerObject->pitch + s_punchOffsets.pitchOffset[0];
 			s_weaponFireYaw   = s_playerObject->yaw + yawOffset;
 			proj_setTransform(proj, s_weaponFirePitch, s_weaponFireYaw);
 
@@ -405,8 +385,8 @@ namespace TFE_DarkForces
 			vec3_fixed inVec =
 			{
 				xOffset, // -1.75, 0.0, +1.75
-				0x18000, // 1.5
-				0x60000  // 6.0
+				s_punchOffsets.yOffset[0], // 1.5
+				s_punchOffsets.zOffset[0]  // 6.0
 			};
 			rotateVectorM3x3(&inVec, &proj->delta, mtx);
 
@@ -470,9 +450,9 @@ namespace TFE_DarkForces
 
 			vec3_fixed inVec =
 			{
-				0x6666,	// 0.4
-				0x9999, // 0.6
-				0x33333 // 3.2
+				s_pistolOffsets.xOffset[0],	// 0.4
+				s_pistolOffsets.yOffset[0], // 0.6
+				s_pistolOffsets.zOffset[0]  // 3.2
 			};
 			vec3_fixed outVec;
 			rotateVectorM3x3(&inVec, &outVec, mtx);
@@ -486,11 +466,11 @@ namespace TFE_DarkForces
 			{
 				s32 variation = s_curPlayerWeapon->variation & 0xffff;
 				variation = random(variation * 2) - variation;
-				s_weaponFirePitch = s_playerObject->pitch + variation;
+				s_weaponFirePitch = s_playerObject->pitch + variation + s_pistolOffsets.pitchOffset[0];
 
 				variation = s_curPlayerWeapon->variation & 0xffff;
 				variation = random(variation * 2) - variation;
-				s_weaponFireYaw = s_playerObject->yaw + variation;
+				s_weaponFireYaw = s_playerObject->yaw + variation + s_pistolOffsets.yawOffset[0];
 			}
 
 			s32 canFire = s_canFireWeaponPrim;
@@ -661,9 +641,9 @@ namespace TFE_DarkForces
 
 			vec3_fixed inVec =
 			{
-				0x6666,	// 0.4
-				0xc000, // 0.75
-				0x40000 // 4.0
+				s_rifleOffsets.xOffset[0],	// 0.4
+				s_rifleOffsets.yOffset[0],  // 0.75
+				s_rifleOffsets.zOffset[0]   // 4.0
 			};
 			vec3_fixed outVec;
 			rotateVectorM3x3(&inVec, &outVec, mtx);
@@ -677,11 +657,11 @@ namespace TFE_DarkForces
 			{
 				s32 variation = s_curPlayerWeapon->variation & 0xffff;
 				variation = random(variation * 2) - variation;
-				s_weaponFirePitch = s_playerObject->pitch + variation;
+				s_weaponFirePitch = s_playerObject->pitch + variation + s_rifleOffsets.pitchOffset[0];
 
 				variation = s_curPlayerWeapon->variation & 0xffff;
 				variation = random(variation * 2) - variation;
-				s_weaponFireYaw = s_playerObject->yaw + variation;
+				s_weaponFireYaw = s_playerObject->yaw + variation + s_rifleOffsets.yawOffset[0];
 			}
 
 			s32 canFire = s_canFireWeaponPrim;
@@ -893,18 +873,18 @@ namespace TFE_DarkForces
 			// Calculate projectile transform.
 			s32 baseVariation = s_curPlayerWeapon->variation & 0xffff;
 			s32 pitchVariation = random(baseVariation * 2) - baseVariation;
-			s_weaponFirePitch = (s_playerObject->pitch >> 1) + 0x638 + pitchVariation;
+			s_weaponFirePitch = (s_playerObject->pitch >> 1) + s_thermalDetOffsets.pitchOffset[0] + pitchVariation;
 
 			s32 yawVariation = random(baseVariation * 2) - baseVariation;
-			s_weaponFireYaw = s_playerObject->yaw + yawVariation;
+			s_weaponFireYaw = s_playerObject->yaw + s_thermalDetOffsets.yawOffset[0] + yawVariation;
 
 			proj_setTransform(proj, s_weaponFirePitch, s_weaponFireYaw);
 
 			// Calculate initial projectile delta and handle up close collision.
 			fixed16_16 mtx[9];
-			weapon_computeMatrix(mtx, -(s_playerObject->pitch + 0x638), -s_playerObject->yaw);
+			weapon_computeMatrix(mtx, -(s_playerObject->pitch + s_thermalDetOffsets.pitchOffset[0]), -s_playerObject->yaw);
 
-			vec3_fixed inVec = { FIXED(2), FIXED(2), FIXED(2) };
+			vec3_fixed inVec = { s_thermalDetOffsets.xOffset[0], s_thermalDetOffsets.yOffset[0], s_thermalDetOffsets.zOffset[0] };
 			rotateVectorM3x3(&inVec, &proj->delta, mtx);
 			tfe_adjustWeaponCollisionSpeed(proj);
 
@@ -1063,14 +1043,14 @@ namespace TFE_DarkForces
 					{
 						proj[i] = (ProjectileLogic*)createProjectile(s_curPlayerWeapon->secondaryProjectile, s_playerObject->sector, s_playerObject->posWS.x, yPos, s_playerObject->posWS.z, s_playerObject);
 						proj[i]->flags &= ~PROJFLAG_CAMERA_PASS_SOUND;
-						proj_setTransform(proj[i], s_weaponFirePitch + c_repeaterPitchOffset[i], s_weaponFireYaw + c_repeaterYawOffset[i]);
+						proj_setTransform(proj[i], s_weaponFirePitch + s_repeaterSecOffsets.pitchOffset[i], s_weaponFireYaw + s_repeaterSecOffsets.yawOffset[i]);
 						proj[i]->prevColObj = s_playerObject;
 						if (s_oneHitKillEnabled) { applyOneHitKillCheat(proj[i]); }
 					}
 
 					for (s32 i = 0; i < 3; i++)
 					{
-						vec3_fixed inVec = { c_repeaterDelta[1 + i*3], c_repeaterDelta[2 + i*3], c_repeaterDelta[i*3] };
+						vec3_fixed inVec = { s_repeaterSecOffsets.xOffset[i], s_repeaterSecOffsets.yOffset[i], s_repeaterSecOffsets.zOffset[i] };
 						vec3_fixed outVec;
 						rotateVectorM3x3(&inVec, &outVec, mtx);
 
@@ -1176,9 +1156,9 @@ namespace TFE_DarkForces
 
 				vec3_fixed inVec =
 				{
-					0xcccc,	// 0.8
-					0xfae1, // 0.98
-					0x50000 // 5.0
+					s_repeaterOffsets.xOffset[0],	// 0.8
+					s_repeaterOffsets.yOffset[0],   // 0.98
+					s_repeaterOffsets.zOffset[0]    // 5.0
 				};
 				vec3_fixed outVec;
 				rotateVectorM3x3(&inVec, &outVec, mtx);
@@ -1192,10 +1172,10 @@ namespace TFE_DarkForces
 				if (!targetFound)
 				{
 					s32 variation = random(baseVariation * 2) - baseVariation;
-					s_weaponFirePitch = s_playerObject->pitch + variation;
+					s_weaponFirePitch = s_playerObject->pitch + variation + s_repeaterOffsets.pitchOffset[0];
 
 					variation = random(variation * 2) - variation;
-					s_weaponFireYaw = s_playerObject->yaw + variation;
+					s_weaponFireYaw = s_playerObject->yaw + variation + s_repeaterOffsets.yawOffset[0];
 				}
 
 				s32 canFire = s_canFireWeaponPrim;
@@ -1402,14 +1382,14 @@ namespace TFE_DarkForces
 					{
 						proj[i] = (ProjectileLogic*)createProjectile(s_curPlayerWeapon->secondaryProjectile, s_playerObject->sector, s_playerObject->posWS.x, yPos, s_playerObject->posWS.z, s_playerObject);
 						proj[i]->flags &= ~PROJFLAG_CAMERA_PASS_SOUND;
-						proj_setTransform(proj[i], s_weaponFirePitch, s_weaponFireYaw + s_fusionYawOffset[i]);
+						proj_setTransform(proj[i], s_weaponFirePitch + s_fusionSecOffsets.pitchOffset[i], s_weaponFireYaw + s_fusionSecOffsets.yawOffset[i]);
 						proj[i]->prevColObj = s_playerObject;
 						if (s_oneHitKillEnabled) { applyOneHitKillCheat(proj[i]); }
 					}
 
 					for (s32 i = 0; i < 4; i++)
 					{
-						vec3_fixed inVec = { s_fusionOffset[1 + i*3], s_fusionOffset[2 + i*3], s_fusionOffset[i*3] };
+						vec3_fixed inVec = { s_fusionSecOffsets.xOffset[i], s_fusionSecOffsets.yOffset[i], s_fusionSecOffsets.zOffset[i] };
 						vec3_fixed outVec;
 						rotateVectorM3x3(&inVec, &outVec, mtx);
 
@@ -1517,9 +1497,9 @@ namespace TFE_DarkForces
 
 					vec3_fixed inVec =
 					{
-						s_fusionOffset[(s_fusionCylinder-1)*3 + 1],
-						s_fusionOffset[(s_fusionCylinder-1)*3 + 2],
-						s_fusionOffset[(s_fusionCylinder-1)*3 + 0]
+						s_fusionOffsets.xOffset[(s_fusionCylinder - 1)],
+						s_fusionOffsets.yOffset[(s_fusionCylinder - 1)],
+						s_fusionOffsets.zOffset[(s_fusionCylinder - 1)],
 					};
 					vec3_fixed outVec;
 					rotateVectorM3x3(&inVec, &outVec, mtx);
@@ -1533,10 +1513,10 @@ namespace TFE_DarkForces
 					if (!targetFound)
 					{
 						s32 variation = random(baseVariation * 2) - baseVariation;
-						s_weaponFirePitch = s_playerObject->pitch + variation;
+						s_weaponFirePitch = s_playerObject->pitch + variation + s_fusionOffsets.pitchOffset[(s_fusionCylinder - 1)];
 
 						variation = random(baseVariation * 2) - baseVariation;
-						s_weaponFireYaw = s_playerObject->yaw + variation;
+						s_weaponFireYaw = s_playerObject->yaw + variation + s_fusionOffsets.yawOffset[(s_fusionCylinder - 1)];
 					}
 
 					s32 superChargeFrame = s_superCharge ? 0 : 1;
@@ -1694,23 +1674,23 @@ namespace TFE_DarkForces
 			s32 variation;
 			if (canFire > 1)
 			{
-				variation = random(wpnVariation * 2) - wpnVariation + 0x333;
+				variation = random(wpnVariation * 2) - wpnVariation + s_mortarOffsets.pitchOffset[0];
 				s_weaponFirePitch = s_playerObject->pitch + (variation >> 2);
 			}
 			else
 			{
-				variation = random(wpnVariation * 2) - wpnVariation + 0x333;
+				variation = random(wpnVariation * 2) - wpnVariation + s_mortarOffsets.pitchOffset[0];
 				s_weaponFirePitch = s_playerObject->pitch + variation;
 			}
 
-			variation = random(wpnVariation * 2) - wpnVariation;
+			variation = random(wpnVariation * 2) - wpnVariation + s_mortarOffsets.yawOffset[0];
 			s_weaponFireYaw = s_playerObject->yaw + variation;
 
 			vec3_fixed inVec =
 			{
-				0xb333,	 // 0.7
-				0x1b333, // 1.7
-				0x20000  // 2.0
+				s_mortarOffsets.xOffset[0],	 // 0.7
+				s_mortarOffsets.yOffset[0],  // 1.7
+				s_mortarOffsets.zOffset[0]   // 2.0
 			};
 			vec3_fixed outVec;
 			rotateVectorM3x3(&inVec, &outVec, mtx);
@@ -1955,9 +1935,9 @@ namespace TFE_DarkForces
 
 			vec3_fixed inVec =
 			{
-				0x10000, // 1.0
-				0x8000,  // 0.5
-				0x30000  // 3.0
+				s_concussionOffsets.xOffset[0],  // 1.0
+				s_concussionOffsets.yOffset[0],  // 0.5
+				s_concussionOffsets.zOffset[0]   // 3.0
 			};
 			vec3_fixed outVec;
 			rotateVectorM3x3(&inVec, &outVec, mtx);
@@ -1971,10 +1951,10 @@ namespace TFE_DarkForces
 			if (!targetFound)
 			{
 				s32 variation = random(baseVariation * 2) - baseVariation;
-				s_weaponFirePitch = s_playerObject->pitch + variation;
+				s_weaponFirePitch = s_playerObject->pitch + variation + s_concussionOffsets.pitchOffset[0];
 
 				variation = random(baseVariation * 2) - baseVariation;
-				s_weaponFireYaw = s_playerObject->yaw + variation;
+				s_weaponFireYaw = s_playerObject->yaw + variation + s_concussionOffsets.yawOffset[0];
 			}
 
 			s32 canFire = s_canFireWeaponPrim;
@@ -2138,9 +2118,9 @@ namespace TFE_DarkForces
 				vec3_fixed outVec;
 				vec3_fixed inVec =
 				{
-					0x20000,	// 2.0
-					0x4000,		// 0.25
-					0x40000,	// 4.0
+					s_cannonSecOffsets.xOffset[0],	 // 2.0
+					s_cannonSecOffsets.yOffset[0],	 // 0.25
+					s_cannonSecOffsets.zOffset[0],	 // 4.0
 				};
 				rotateVectorM3x3(&inVec, &outVec, mtx);
 
@@ -2153,10 +2133,10 @@ namespace TFE_DarkForces
 				if (!targetFound)
 				{
 					s32 variation = random(baseVariation * 2) - baseVariation;
-					s_weaponFirePitch = s_playerObject->pitch + variation;
+					s_weaponFirePitch = s_playerObject->pitch + variation + s_cannonSecOffsets.pitchOffset[0];
 
 					variation = random(baseVariation * 2) - baseVariation;
-					s_weaponFireYaw = s_playerObject->yaw + variation;
+					s_weaponFireYaw = s_playerObject->yaw + variation + s_cannonSecOffsets.yawOffset[0];
 				}
 
 				s32 canFire = s_canFireWeaponSec;
@@ -2273,9 +2253,9 @@ namespace TFE_DarkForces
 
 				vec3_fixed inVec =
 				{
-					0x10000,	// 1.0
-					0x9999,		// 0.6
-					0x30000		// 3.0
+					s_cannonOffsets.xOffset[0],  	// 1.0
+					s_cannonOffsets.yOffset[0],		// 0.6
+					s_cannonOffsets.zOffset[0]		// 3.0
 				};
 				vec3_fixed outVec;
 				rotateVectorM3x3(&inVec, &outVec, mtx);
@@ -2289,10 +2269,10 @@ namespace TFE_DarkForces
 				if (!targetFound)
 				{
 					s32 variation = random(baseVariation * 2) - baseVariation;
-					s_weaponFirePitch = s_playerObject->pitch + variation;
+					s_weaponFirePitch = s_playerObject->pitch + variation + s_cannonOffsets.pitchOffset[0];
 
 					variation = random(variation * 2) - variation;
-					s_weaponFireYaw = s_playerObject->yaw + variation;
+					s_weaponFireYaw = s_playerObject->yaw + variation + s_cannonOffsets.yawOffset[0];
 				}
 
 				s32 canFire = s_canFireWeaponPrim;

--- a/TheForceEngine/TFE_DarkForces/weaponFireFunc.cpp
+++ b/TheForceEngine/TFE_DarkForces/weaponFireFunc.cpp
@@ -317,7 +317,7 @@ namespace TFE_DarkForces
 		angle14_32 yawOffset = -910;
 		for (s32 i = 0; i < 3; i++, xOffset += 0x1c000, yawOffset += 910)
 		{
-			ProjectileLogic* proj = (ProjectileLogic*)createProjectile(ProjectileType::PROJ_PUNCH, s_playerObject->sector, s_playerObject->posWS.x, s_playerObject->posWS.y - s_playerObject->worldHeight + s_headwaveVerticalOffset, s_playerObject->posWS.z, s_playerObject);
+			ProjectileLogic* proj = (ProjectileLogic*)createProjectile(s_curPlayerWeapon->primaryProjectile, s_playerObject->sector, s_playerObject->posWS.x, s_playerObject->posWS.y - s_playerObject->worldHeight + s_headwaveVerticalOffset, s_playerObject->posWS.z, s_playerObject);
 			if (s_oneHitKillEnabled) {	applyOneHitKillCheat(proj); }
 
 			s_weaponFirePitch = s_playerObject->pitch + 0x638;
@@ -450,7 +450,7 @@ namespace TFE_DarkForces
 
 				ProjectileLogic* projLogic;
 				fixed16_16 yPos = s_playerObject->posWS.y - s_playerObject->worldHeight + s_headwaveVerticalOffset;
-				projLogic = (ProjectileLogic*)createProjectile(PROJ_PISTOL_BOLT, s_playerObject->sector, s_playerObject->posWS.x, yPos, s_playerObject->posWS.z, s_playerObject);
+				projLogic = (ProjectileLogic*)createProjectile(s_curPlayerWeapon->primaryProjectile, s_playerObject->sector, s_playerObject->posWS.x, yPos, s_playerObject->posWS.z, s_playerObject);
 				projLogic->flags &= ~PROJFLAG_CAMERA_PASS_SOUND;
 				projLogic->prevColObj = s_playerObject;
 				if (s_oneHitKillEnabled) { applyOneHitKillCheat(projLogic); }
@@ -641,7 +641,7 @@ namespace TFE_DarkForces
 
 				ProjectileLogic* projLogic;
 				fixed16_16 yPos = s_playerObject->posWS.y - s_playerObject->worldHeight + s_headwaveVerticalOffset;
-				projLogic = (ProjectileLogic*)createProjectile(PROJ_RIFLE_BOLT, s_playerObject->sector, s_playerObject->posWS.x, yPos, s_playerObject->posWS.z, s_playerObject);
+				projLogic = (ProjectileLogic*)createProjectile(s_curPlayerWeapon->primaryProjectile, s_playerObject->sector, s_playerObject->posWS.x, yPos, s_playerObject->posWS.z, s_playerObject);
 				projLogic->flags &= ~PROJFLAG_CAMERA_PASS_SOUND;
 				projLogic->prevColObj = s_playerObject;
 				if (s_oneHitKillEnabled) { applyOneHitKillCheat(projLogic); }
@@ -798,7 +798,7 @@ namespace TFE_DarkForces
 			}
 
 			fixed16_16 yPos = s_playerObject->posWS.y - s_playerObject->worldHeight + s_headwaveVerticalOffset;
-			ProjectileLogic* proj = (ProjectileLogic*)createProjectile(PROJ_THERMAL_DET, s_playerObject->sector, s_playerObject->posWS.x, yPos, s_playerObject->posWS.z, s_playerObject);
+			ProjectileLogic* proj = (ProjectileLogic*)createProjectile(s_curPlayerWeapon->primaryProjectile, s_playerObject->sector, s_playerObject->posWS.x, yPos, s_playerObject->posWS.z, s_playerObject);
 			proj->flags &= ~PROJFLAG_CAMERA_PASS_SOUND;
 			proj->prevColObj = s_playerObject;
 
@@ -987,7 +987,7 @@ namespace TFE_DarkForces
 					ProjectileLogic* proj[3];
 					for (s32 i = 0; i < 3; i++)
 					{
-						proj[i] = (ProjectileLogic*)createProjectile(PROJ_REPEATER, s_playerObject->sector, s_playerObject->posWS.x, yPos, s_playerObject->posWS.z, s_playerObject);
+						proj[i] = (ProjectileLogic*)createProjectile(s_curPlayerWeapon->secondaryProjectile, s_playerObject->sector, s_playerObject->posWS.x, yPos, s_playerObject->posWS.z, s_playerObject);
 						proj[i]->flags &= ~PROJFLAG_CAMERA_PASS_SOUND;
 						proj_setTransform(proj[i], s_weaponFirePitch + c_repeaterPitchOffset[i], s_weaponFireYaw + c_repeaterYawOffset[i]);
 						proj[i]->prevColObj = s_playerObject;
@@ -1154,7 +1154,7 @@ namespace TFE_DarkForces
 					}
 
 					fixed16_16 yPos = s_playerObject->posWS.y - s_playerObject->worldHeight + s_headwaveVerticalOffset;
-					ProjectileLogic* projLogic = (ProjectileLogic*)createProjectile(PROJ_REPEATER, s_playerObject->sector, s_playerObject->posWS.x, yPos, s_playerObject->posWS.z, s_playerObject);
+					ProjectileLogic* projLogic = (ProjectileLogic*)createProjectile(s_curPlayerWeapon->primaryProjectile, s_playerObject->sector, s_playerObject->posWS.x, yPos, s_playerObject->posWS.z, s_playerObject);
 					projLogic->flags &= ~PROJFLAG_CAMERA_PASS_SOUND;
 					projLogic->prevColObj = s_playerObject;
 					if (s_oneHitKillEnabled) { applyOneHitKillCheat(projLogic); }
@@ -1326,7 +1326,7 @@ namespace TFE_DarkForces
 					ProjectileLogic* proj[4];
 					for (s32 i = 0; i < 4; i++)
 					{
-						proj[i] = (ProjectileLogic*)createProjectile(PROJ_PLASMA, s_playerObject->sector, s_playerObject->posWS.x, yPos, s_playerObject->posWS.z, s_playerObject);
+						proj[i] = (ProjectileLogic*)createProjectile(s_curPlayerWeapon->secondaryProjectile, s_playerObject->sector, s_playerObject->posWS.x, yPos, s_playerObject->posWS.z, s_playerObject);
 						proj[i]->flags &= ~PROJFLAG_CAMERA_PASS_SOUND;
 						proj_setTransform(proj[i], s_weaponFirePitch, s_weaponFireYaw + s_fusionYawOffset[i]);
 						proj[i]->prevColObj = s_playerObject;
@@ -1477,7 +1477,7 @@ namespace TFE_DarkForces
 					}
 
 					fixed16_16 yPlayerPos = s_playerObject->posWS.y - s_playerObject->worldHeight + s_headwaveVerticalOffset;
-					ProjectileLogic* projLogic = (ProjectileLogic*)createProjectile(PROJ_PLASMA, s_playerObject->sector, s_playerObject->posWS.x, yPlayerPos, s_playerObject->posWS.z, s_playerObject);
+					ProjectileLogic* projLogic = (ProjectileLogic*)createProjectile(s_curPlayerWeapon->primaryProjectile, s_playerObject->sector, s_playerObject->posWS.x, yPlayerPos, s_playerObject->posWS.z, s_playerObject);
 					projLogic->flags &= ~PROJFLAG_CAMERA_PASS_SOUND;
 					projLogic->prevColObj = s_playerObject;
 					if (s_oneHitKillEnabled) { applyOneHitKillCheat(projLogic); }
@@ -1670,7 +1670,7 @@ namespace TFE_DarkForces
 
 				ProjectileLogic* projLogic;
 				fixed16_16 yPos = s_playerObject->posWS.y - s_playerObject->worldHeight + s_headwaveVerticalOffset;
-				projLogic = (ProjectileLogic*)createProjectile(PROJ_MORTAR, s_playerObject->sector, s_playerObject->posWS.x, yPos, s_playerObject->posWS.z, s_playerObject);
+				projLogic = (ProjectileLogic*)createProjectile(s_curPlayerWeapon->primaryProjectile, s_playerObject->sector, s_playerObject->posWS.x, yPos, s_playerObject->posWS.z, s_playerObject);
 				projLogic->flags &= ~PROJFLAG_CAMERA_PASS_SOUND;
 				projLogic->prevColObj = s_playerObject;
 				proj_setTransform(projLogic, s_weaponFirePitch, s_weaponFireYaw);
@@ -1803,7 +1803,7 @@ namespace TFE_DarkForces
 			fixed16_16 floorHeight, ceilHeight;
 			sector_getObjFloorAndCeilHeight(s_playerObject->sector, s_playerObject->posWS.y, &floorHeight, &ceilHeight);
 
-			ProjectileType type = (s_secondaryFire) ? PROJ_LAND_MINE_PROX : PROJ_LAND_MINE;
+			ProjectileType type = (s_secondaryFire) ? s_curPlayerWeapon->secondaryProjectile : s_curPlayerWeapon->primaryProjectile;
 			ProjectileLogic* mine = (ProjectileLogic*)createProjectile(type, s_playerObject->sector, s_playerObject->posWS.x, floorHeight, s_playerObject->posWS.z, s_playerObject);
 			mine->vel = { 0, 0, 0 };
 
@@ -1934,7 +1934,7 @@ namespace TFE_DarkForces
 
 				ProjectileLogic* projLogic;
 				fixed16_16 yPos = s_playerObject->posWS.y - s_playerObject->worldHeight + s_headwaveVerticalOffset;
-				projLogic = (ProjectileLogic*)createProjectile(PROJ_CONCUSSION, s_playerObject->sector, s_playerObject->posWS.x, yPos, s_playerObject->posWS.z, s_playerObject);
+				projLogic = (ProjectileLogic*)createProjectile(s_curPlayerWeapon->primaryProjectile, s_playerObject->sector, s_playerObject->posWS.x, yPos, s_playerObject->posWS.z, s_playerObject);
 				projLogic->flags &= ~PROJFLAG_CAMERA_PASS_SOUND;
 				projLogic->prevColObj = s_playerObject;
 
@@ -2111,7 +2111,7 @@ namespace TFE_DarkForces
 					}
 
 					fixed16_16 yPos = s_playerObject->posWS.y - s_playerObject->worldHeight + s_headwaveVerticalOffset;
-					ProjectileLogic* projLogic = (ProjectileLogic*)createProjectile(PROJ_MISSILE, s_playerObject->sector, s_playerObject->posWS.x, yPos, s_playerObject->posWS.z, s_playerObject);
+					ProjectileLogic* projLogic = (ProjectileLogic*)createProjectile(s_curPlayerWeapon->secondaryProjectile, s_playerObject->sector, s_playerObject->posWS.x, yPos, s_playerObject->posWS.z, s_playerObject);
 					projLogic->flags &= ~PROJFLAG_CAMERA_PASS_SOUND;
 					projLogic->prevColObj = s_playerObject;
 					if (targetFound)
@@ -2246,7 +2246,7 @@ namespace TFE_DarkForces
 					}
 
 					fixed16_16 yPos = s_playerObject->posWS.y - s_playerObject->worldHeight + s_headwaveVerticalOffset;
-					ProjectileLogic* projLogic = (ProjectileLogic*)createProjectile(PROJ_CANNON, s_playerObject->sector, s_playerObject->posWS.x, yPos, s_playerObject->posWS.z, s_playerObject);
+					ProjectileLogic* projLogic = (ProjectileLogic*)createProjectile(s_curPlayerWeapon->primaryProjectile, s_playerObject->sector, s_playerObject->posWS.x, yPos, s_playerObject->posWS.z, s_playerObject);
 					projLogic->flags &= ~PROJFLAG_CAMERA_PASS_SOUND;
 					projLogic->prevColObj = s_playerObject;
 					if (s_oneHitKillEnabled) { applyOneHitKillCheat(projLogic); }

--- a/TheForceEngine/TFE_DarkForces/weaponFireFunc.cpp
+++ b/TheForceEngine/TFE_DarkForces/weaponFireFunc.cpp
@@ -16,6 +16,7 @@ namespace TFE_DarkForces
 	{
 		MAX_AUTOAIM_DIST = COL_INFINITY,
 		WPN_NUM_ANIMFRAMES = 16,
+		WPN_MAX_PROJECTILES = 4,
 	};
 
 	static SoundEffectId s_punchSwingSndId = 0;
@@ -92,6 +93,29 @@ namespace TFE_DarkForces
 	static WeaponAnimFrame s_concussionAnim[WPN_NUM_ANIMFRAMES];
 	static WeaponAnimFrame s_cannonPrimaryAnim[WPN_NUM_ANIMFRAMES];
 	static WeaponAnimFrame s_cannonSecondaryAnim[WPN_NUM_ANIMFRAMES];
+
+	// TFE
+	struct WeaponProjOffsets
+	{
+		angle14_32 pitchOffset[WPN_MAX_PROJECTILES];
+		angle14_32 yawOffset[WPN_MAX_PROJECTILES];
+		angle14_32 xOffset[WPN_MAX_PROJECTILES];
+		angle14_32 yOffset[WPN_MAX_PROJECTILES];
+		angle14_32 zOffset[WPN_MAX_PROJECTILES];
+	};
+
+	static WeaponProjOffsets s_punchOffsets;
+	static WeaponProjOffsets s_pistolOffsets;
+	static WeaponProjOffsets s_rifleOffsets;
+	static WeaponProjOffsets s_thermalDetOffsets;
+	static WeaponProjOffsets s_repeaterOffsets;
+	static WeaponProjOffsets s_repeaterSecOffsets;
+	static WeaponProjOffsets s_fusionOffsets;
+	static WeaponProjOffsets s_fusionSecOffsets;
+	static WeaponProjOffsets s_mortarOffsets;
+	static WeaponProjOffsets s_concussionOffsets;
+	static WeaponProjOffsets s_cannonOffsets;
+	static WeaponProjOffsets s_cannonSecOffsets;
 
 	static const angle14_32 c_repeaterYawOffset[3] = { 0, 136, -136 };
 	static const angle14_32 c_repeaterPitchOffset[3] = { 136, -136, -136 };
@@ -210,6 +234,56 @@ namespace TFE_DarkForces
 				secondaryFrames[i].delaySupercharge = extSecFrames[i].durationSupercharge;
 				secondaryFrames[i].delayNormal = extSecFrames[i].durationNormal;
 			}
+		}
+	}
+
+	// TFE: Set up weapon offsets from external data (these were hardcoded in vanilla DF)
+	void setWeaponProjOffsets(WeaponProjOffsets* projOffsets, f32* pitchOffsets, f32* yawOffsets, f32* xOffsets, f32* yOffsets, f32* zOffsets)
+	{
+		for (u32 i = 0; i < WPN_MAX_PROJECTILES; i++)
+		{
+			projOffsets->pitchOffset[i] = floatToAngle(pitchOffsets[i]);
+			projOffsets->yawOffset[i] = floatToAngle(yawOffsets[i]);
+			projOffsets->xOffset[i] = floatToFixed16(xOffsets[i]);
+			projOffsets->yOffset[i] = floatToFixed16(yOffsets[i]);
+			projOffsets->zOffset[i] = floatToFixed16(zOffsets[i]);
+		}
+	}
+	
+	void setupWeaponOffsets(WeaponID weaponId, TFE_ExternalData::ExternalWeapon* extWeapon)
+	{
+		switch (weaponId)
+		{
+			case WPN_FIST:
+				setWeaponProjOffsets(&s_punchOffsets, extWeapon->pitchOffsets, extWeapon->yawOffsets, extWeapon->xOffsets, extWeapon->yOffsets, extWeapon->zOffsets);
+				break;
+			case WPN_PISTOL:
+				setWeaponProjOffsets(&s_pistolOffsets, extWeapon->pitchOffsets, extWeapon->yawOffsets, extWeapon->xOffsets, extWeapon->yOffsets, extWeapon->zOffsets);
+				break;
+			case WPN_RIFLE:
+				setWeaponProjOffsets(&s_rifleOffsets, extWeapon->pitchOffsets, extWeapon->yawOffsets, extWeapon->xOffsets, extWeapon->yOffsets, extWeapon->zOffsets);
+				break;
+			case WPN_THERMAL_DET:
+				setWeaponProjOffsets(&s_thermalDetOffsets, extWeapon->pitchOffsets, extWeapon->yawOffsets, extWeapon->xOffsets, extWeapon->yOffsets, extWeapon->zOffsets);
+				break;
+			case WPN_REPEATER:
+				setWeaponProjOffsets(&s_repeaterOffsets, extWeapon->pitchOffsets, extWeapon->yawOffsets, extWeapon->xOffsets, extWeapon->yOffsets, extWeapon->zOffsets);
+				setWeaponProjOffsets(&s_repeaterSecOffsets, extWeapon->pitchOffsetsSecondary, extWeapon->yawOffsetsSecondary, extWeapon->xOffsetsSecondary, extWeapon->yOffsetsSecondary, extWeapon->zOffsetsSecondary);
+				break;
+			case WPN_FUSION:
+				setWeaponProjOffsets(&s_fusionOffsets, extWeapon->pitchOffsets, extWeapon->yawOffsets, extWeapon->xOffsets, extWeapon->yOffsets, extWeapon->zOffsets);
+				setWeaponProjOffsets(&s_fusionSecOffsets, extWeapon->pitchOffsetsSecondary, extWeapon->yawOffsetsSecondary, extWeapon->xOffsetsSecondary, extWeapon->yOffsetsSecondary, extWeapon->zOffsetsSecondary);
+				break;
+			case WPN_MORTAR:
+				setWeaponProjOffsets(&s_mortarOffsets, extWeapon->pitchOffsets, extWeapon->yawOffsets, extWeapon->xOffsets, extWeapon->yOffsets, extWeapon->zOffsets);
+				break;
+			case WPN_CONCUSSION:
+				setWeaponProjOffsets(&s_concussionOffsets, extWeapon->pitchOffsets, extWeapon->yawOffsets, extWeapon->xOffsets, extWeapon->yOffsets, extWeapon->zOffsets);
+				break;
+			case WPN_CANNON:
+				setWeaponProjOffsets(&s_cannonOffsets, extWeapon->pitchOffsets, extWeapon->yawOffsets, extWeapon->xOffsets, extWeapon->yOffsets, extWeapon->zOffsets);
+				setWeaponProjOffsets(&s_cannonSecOffsets, extWeapon->pitchOffsetsSecondary, extWeapon->yawOffsetsSecondary, extWeapon->xOffsetsSecondary, extWeapon->yOffsetsSecondary, extWeapon->zOffsetsSecondary);
+				break;
 		}
 	}
 

--- a/TheForceEngine/TFE_DarkForces/weaponFireFunc.h
+++ b/TheForceEngine/TFE_DarkForces/weaponFireFunc.h
@@ -13,6 +13,7 @@ namespace TFE_DarkForces
 	typedef void(*WeaponFireFunc)(MessageType msg);
 
 	void setupAnimationFrames(WeaponID weaponId, s32 numPrimFrames, TFE_ExternalData::WeaponAnimFrame* extPrimFrames, s32 numSecondaryFrames, TFE_ExternalData::WeaponAnimFrame* extSecFrames);
+	void setupWeaponOffsets(WeaponID weaponId, TFE_ExternalData::ExternalWeapon* extWeapon);
 
 	void resetWeaponFunc();
 	void weaponFire_fist(MessageType msg);

--- a/TheForceEngine/TFE_ExternalData/customEffect.cpp
+++ b/TheForceEngine/TFE_ExternalData/customEffect.cpp
@@ -1,0 +1,63 @@
+#include "customEffect.h"
+
+
+namespace TFE_ExternalData
+{
+	std::vector<ExternalEffect> s_customEffects;
+
+	
+	std::vector<ExternalEffect>* getCustomEffects()
+	{
+		return &s_customEffects;
+	}
+
+	void clearCustomEffects()
+	{
+		s_customEffects.clear();
+	}
+
+	void parseCustomEffects(cJSON* data)
+	{
+		while (data)
+		{
+			cJSON* effectType = data->child;
+
+			// get the effect type
+			if (effectType && cJSON_IsString(effectType) && strcasecmp(effectType->string, "type") == 0)
+			{
+				ExternalEffect custEffect = {};
+				custEffect.type = effectType->valuestring;	// This will be the name/identifier of the custom effect
+
+				cJSON* effectData = effectType->next;
+				if (effectData && cJSON_IsObject(effectData))
+				{
+					cJSON* dataItem = effectData->child;
+
+					// iterate through the data and assign properties
+					while (dataItem)
+					{
+						tryAssignEffectProperty(dataItem, custEffect);
+						dataItem = dataItem->next;
+					}
+				}
+
+				s_customEffects.push_back(custEffect);
+			}
+
+			data = data->next;
+		}
+	}
+
+	s32 getCustomEffectIndex(const char* name)
+	{
+		for (u32 i = 0; i < s_customEffects.size(); i++)
+		{
+			if (strcasecmp(name, s_customEffects[i].type) == 0)
+			{
+				return i;
+			}
+		}
+
+		return -1;
+	}
+}

--- a/TheForceEngine/TFE_ExternalData/customEffect.cpp
+++ b/TheForceEngine/TFE_ExternalData/customEffect.cpp
@@ -1,4 +1,5 @@
 #include "customEffect.h"
+#include <cstring>
 
 
 namespace TFE_ExternalData

--- a/TheForceEngine/TFE_ExternalData/customEffect.h
+++ b/TheForceEngine/TFE_ExternalData/customEffect.h
@@ -1,0 +1,16 @@
+#pragma once
+#include "weaponExternal.h"
+#include <TFE_System/cJSON.h>
+
+namespace TFE_ExternalData
+{
+	enum
+	{
+		CUSTOM_EFFECT_STARTNUM = 100,
+	};
+
+	std::vector<ExternalEffect>* getCustomEffects();
+	void clearCustomEffects();
+	void parseCustomEffects(cJSON* data);
+	s32 getCustomEffectIndex(const char* name);
+}

--- a/TheForceEngine/TFE_ExternalData/customProjectile.cpp
+++ b/TheForceEngine/TFE_ExternalData/customProjectile.cpp
@@ -1,0 +1,63 @@
+#include "customProjectile.h"
+
+
+namespace TFE_ExternalData
+{
+	std::vector<ExternalProjectile> s_customProjectiles;
+
+
+	std::vector<ExternalProjectile>* getCustomProjectiles()
+	{
+		return &s_customProjectiles;
+	}
+	
+	void clearCustomProjectiles()
+	{
+		s_customProjectiles.clear();
+	}
+
+	void parseCustomProjectiles(cJSON* data)
+	{
+		while (data)
+		{
+			cJSON* projectileType = data->child;
+
+			// get the projectile type
+			if (projectileType && cJSON_IsString(projectileType) && strcasecmp(projectileType->string, "type") == 0)
+			{
+				ExternalProjectile custProjectile = {};
+				custProjectile.type = projectileType->valuestring;	// This will be the name/identifier of the custom projectile
+
+				cJSON* projectileData = projectileType->next;
+				if (projectileData && cJSON_IsObject(projectileData))
+				{
+					cJSON* dataItem = projectileData->child;
+
+					// iterate through the data and assign properties
+					while (dataItem)
+					{
+						tryAssignProjectileProperty(dataItem, custProjectile);
+						dataItem = dataItem->next;
+					}
+				}
+
+				s_customProjectiles.push_back(custProjectile);
+			}
+
+			data = data->next;
+		}
+	}
+
+	s32 getCustomProjectileIndex(const char* name)
+	{
+		for (u32 i = 0; i < s_customProjectiles.size(); i++)
+		{
+			if (strcasecmp(name, s_customProjectiles[i].type) == 0)
+			{
+				return i;
+			}
+		}
+
+		return -1;
+	}
+}

--- a/TheForceEngine/TFE_ExternalData/customProjectile.cpp
+++ b/TheForceEngine/TFE_ExternalData/customProjectile.cpp
@@ -1,4 +1,5 @@
 #include "customProjectile.h"
+#include <cstring>
 
 
 namespace TFE_ExternalData

--- a/TheForceEngine/TFE_ExternalData/customProjectile.h
+++ b/TheForceEngine/TFE_ExternalData/customProjectile.h
@@ -1,0 +1,16 @@
+#pragma once
+#include "weaponExternal.h"
+#include <TFE_System/cJSON.h>
+
+namespace TFE_ExternalData
+{
+	enum
+	{
+		CUSTOM_PROJ_STARTNUM = 100,
+	};
+	
+	std::vector<ExternalProjectile>* getCustomProjectiles();
+	void clearCustomProjectiles();
+	void parseCustomProjectiles(cJSON* data);
+	s32 getCustomProjectileIndex(const char* name);
+}

--- a/TheForceEngine/TFE_ExternalData/dfLogics.cpp
+++ b/TheForceEngine/TFE_ExternalData/dfLogics.cpp
@@ -5,9 +5,11 @@
 #include <TFE_FileSystem/filestream.h>
 #include <TFE_FileSystem/paths.h>
 #include <TFE_DarkForces/time.h>
+#include <TFE_DarkForces/projectile.h>
 #include "dfLogics.h"
 #include "logicTables.h"
 #include "customProjectile.h"
+#include "customEffect.h"
 
 namespace TFE_ExternalData
 {
@@ -17,6 +19,7 @@ namespace TFE_ExternalData
 	/// Forward declarations 
 	///////////////////////////
 	void parseLogicData(char* data, const char* filename, std::vector<CustomActorLogic>& actorLogics);
+	void assignCustomEffectsToProjectile(ExternalProjectile* proj);
 	bool tryAssignProperty(cJSON* data, CustomActorLogic& customLogic);
 
 
@@ -52,7 +55,7 @@ namespace TFE_ExternalData
 			free(data);
 		}
 
-		// All custom projectiles have now been loaded; go through the logics and assign them
+		// All custom projectiles & effects have now been loaded and can be assigned
 		for (u32 i = 0; i < s_externalLogics.actorLogics.size(); i++)
 		{
 			CustomActorLogic* logic = &s_externalLogics.actorLogics[i];
@@ -63,6 +66,50 @@ namespace TFE_ExternalData
 				{
 					logic->projectile = index + CUSTOM_PROJ_STARTNUM;	// start custom projectile numbering at 100
 				}
+			}
+
+			if (logic->dieEffectName && logic->dieEffectName[0])
+			{
+				s32 index = getCustomEffectIndex(logic->dieEffectName);
+				if (index >= 0)
+				{
+					logic->dieEffect = index + CUSTOM_EFFECT_STARTNUM;	// start custom effect numbering at 100
+				}
+			}
+		}
+
+		ExternalProjectile* projectiles = getExternalProjectiles();
+		for (u32 p = 0; p < TFE_DarkForces::PROJ_COUNT; p++)
+		{
+			ExternalProjectile* proj = &projectiles[p];
+			assignCustomEffectsToProjectile(proj);
+		}
+
+		std::vector<ExternalProjectile>* custProjectiles = getCustomProjectiles();
+		for (u32 p = 0; p < custProjectiles->size(); p++)
+		{
+			ExternalProjectile* proj = &custProjectiles->at(p);
+			assignCustomEffectsToProjectile(proj);
+		}
+	}
+
+	void assignCustomEffectsToProjectile(ExternalProjectile* proj)
+	{
+		if (proj->reflectEffectName && proj->reflectEffectName[0])
+		{
+			s32 index = getCustomEffectIndex(proj->reflectEffectName);
+			if (index >= 0)
+			{
+				proj->reflectEffectId = index + CUSTOM_EFFECT_STARTNUM;	// start custom effect numbering at 100
+			}
+		}
+
+		if (proj->hitEffectName && proj->hitEffectName[0])
+		{
+			s32 index = getCustomEffectIndex(proj->hitEffectName);
+			if (index >= 0)
+			{
+				proj->hitEffectId = index + CUSTOM_EFFECT_STARTNUM;	// start custom effect numbering at 100
 			}
 		}
 	}
@@ -112,6 +159,12 @@ namespace TFE_ExternalData
 				if (section && cJSON_IsArray(section) && strcasecmp(section->string, "projectiles") == 0)
 				{
 					parseCustomProjectiles(section->child);
+				}
+
+				// Custom effects
+				if (section && cJSON_IsArray(section) && strcasecmp(section->string, "effects") == 0)
+				{
+					parseCustomEffects(section->child);
 				}
 
 				section = section->next;
@@ -230,7 +283,7 @@ namespace TFE_ExternalData
 		// Die effect as a string
 		if (cJSON_IsString(data) && strcasecmp(data->string, "dieEffect") == 0)
 		{
-			for (int i = 0; i <= 17; i++)
+			for (int i = 0; i < HEFFECT_COUNT; i++)
 			{
 				if (strcasecmp(data->valuestring, df_effectTable[i]) == 0)
 				{
@@ -238,6 +291,9 @@ namespace TFE_ExternalData
 					return true;
 				}
 			}
+
+			// Save the effect name to check against custom effects
+			customLogic.dieEffectName = data->valuestring;
 
 			return false;
 		}
@@ -277,7 +333,7 @@ namespace TFE_ExternalData
 		if (cJSON_IsString(data) && strcasecmp(data->string, "projectile") == 0)
 		{
 			// First check the main list
-			for (int i = 0; i <= 18; i++)
+			for (int i = 0; i < TFE_DarkForces::PROJ_COUNT; i++)
 			{
 				if (strcasecmp(data->valuestring, df_projectileTable[i]) == 0)
 				{

--- a/TheForceEngine/TFE_ExternalData/dfLogics.cpp
+++ b/TheForceEngine/TFE_ExternalData/dfLogics.cpp
@@ -6,6 +6,7 @@
 #include <TFE_FileSystem/paths.h>
 #include <TFE_DarkForces/time.h>
 #include <TFE_DarkForces/projectile.h>
+#include <TFE_DarkForces/weapon.h>
 #include "dfLogics.h"
 #include "logicTables.h"
 #include "customProjectile.h"
@@ -74,6 +75,29 @@ namespace TFE_ExternalData
 				if (index >= 0)
 				{
 					logic->dieEffect = index + CUSTOM_EFFECT_STARTNUM;	// start custom effect numbering at 100
+				}
+			}
+		}
+
+		ExternalWeapon* weapons = getExternalWeapons();
+		for (u32 w = 0; w < TFE_DarkForces::WPN_COUNT; w++)
+		{
+			ExternalWeapon* weap = &weapons[w];
+			if (weap->primaryProjectileName && weap->primaryProjectileName[0])
+			{
+				s32 index = getCustomProjectileIndex(weap->primaryProjectileName);
+				if (index >= 0)
+				{
+					weap->primaryProjectile = index + CUSTOM_PROJ_STARTNUM;	// start custom projectile numbering at 100
+				}
+			}
+
+			if (weap->secondaryProjectileName && weap->secondaryProjectileName[0])
+			{
+				s32 index = getCustomProjectileIndex(weap->secondaryProjectileName);
+				if (index >= 0)
+				{
+					weap->secondaryProjectile = index + CUSTOM_PROJ_STARTNUM;	// start custom projectile numbering at 100
 				}
 			}
 		}

--- a/TheForceEngine/TFE_ExternalData/dfLogics.cpp
+++ b/TheForceEngine/TFE_ExternalData/dfLogics.cpp
@@ -7,6 +7,7 @@
 #include <TFE_DarkForces/time.h>
 #include "dfLogics.h"
 #include "logicTables.h"
+#include "customProjectile.h"
 
 namespace TFE_ExternalData
 {
@@ -50,6 +51,20 @@ namespace TFE_ExternalData
 			parseLogicData(data, fileName, s_externalLogics.actorLogics);
 			free(data);
 		}
+
+		// All custom projectiles have now been loaded; go through the logics and assign them
+		for (u32 i = 0; i < s_externalLogics.actorLogics.size(); i++)
+		{
+			CustomActorLogic* logic = &s_externalLogics.actorLogics[i];
+			if (logic->customProjectileName && logic->customProjectileName[0])
+			{
+				s32 index = getCustomProjectileIndex(logic->customProjectileName);
+				if (index >= 0)
+				{
+					logic->projectile = index + CUSTOM_PROJ_STARTNUM;	// start custom projectile numbering at 100
+				}
+			}
+		}
 	}
 
 	void parseLogicData(char* data, const char* filename, std::vector<CustomActorLogic>& actorLogics)
@@ -58,37 +73,48 @@ namespace TFE_ExternalData
 		if (root)
 		{
 			cJSON* section = root->child;
-			if (section && cJSON_IsArray(section) && strcasecmp(section->string, "logics") == 0)
+			while (section)
 			{
-				cJSON* logic = section->child;
-				while (logic)
+				if (cJSON_IsArray(section) && strcasecmp(section->string, "logics") == 0)
 				{
-					cJSON* logicName = logic->child;
-
-					// get the logic name
-					if (logicName && cJSON_IsString(logicName) && strcasecmp(logicName->string, "logicname") == 0)
+					cJSON* logic = section->child;
+					while (logic)
 					{
-						CustomActorLogic customLogic;
-						customLogic.logicName = logicName->valuestring;
+						cJSON* logicName = logic->child;
 
-						cJSON* logicData = logicName->next;
-						if (logicData && cJSON_IsObject(logicData))
+						// get the logic name
+						if (logicName && cJSON_IsString(logicName) && strcasecmp(logicName->string, "logicname") == 0)
 						{
-							cJSON* dataItem = logicData->child;
+							CustomActorLogic customLogic;
+							customLogic.logicName = logicName->valuestring;
 
-							// iterate through the data and assign properties
-							while (dataItem)
+							cJSON* logicData = logicName->next;
+							if (logicData && cJSON_IsObject(logicData))
 							{
-								tryAssignProperty(dataItem, customLogic);
-								dataItem = dataItem->next;
+								cJSON* dataItem = logicData->child;
+
+								// iterate through the data and assign properties
+								while (dataItem)
+								{
+									tryAssignProperty(dataItem, customLogic);
+									dataItem = dataItem->next;
+								}
 							}
+
+							actorLogics.push_back(customLogic);
 						}
 
-						actorLogics.push_back(customLogic);
+						logic = logic->next;
 					}
-
-					logic = logic->next;
 				}
+
+				// Custom projectiles
+				if (section && cJSON_IsArray(section) && strcasecmp(section->string, "projectiles") == 0)
+				{
+					parseCustomProjectiles(section->child);
+				}
+
+				section = section->next;
 			}
 		}
 		else
@@ -250,6 +276,7 @@ namespace TFE_ExternalData
 		// Projectile as string
 		if (cJSON_IsString(data) && strcasecmp(data->string, "projectile") == 0)
 		{
+			// First check the main list
 			for (int i = 0; i <= 18; i++)
 			{
 				if (strcasecmp(data->valuestring, df_projectileTable[i]) == 0)
@@ -258,6 +285,9 @@ namespace TFE_ExternalData
 					return true;
 				}
 			}
+
+			// Save the projectile name to check against custom projectiles
+			customLogic.customProjectileName = data->valuestring;
 
 			return false;
 		}

--- a/TheForceEngine/TFE_ExternalData/dfLogics.h
+++ b/TheForceEngine/TFE_ExternalData/dfLogics.h
@@ -30,6 +30,7 @@ namespace TFE_ExternalData
 		u32 hitPoints = 4;
 		s32 dropItem = -1;
 		s32 dieEffect = -1;
+		const char* dieEffectName = "";
 		bool stopOnDamage = true;
 
 		// Attack

--- a/TheForceEngine/TFE_ExternalData/dfLogics.h
+++ b/TheForceEngine/TFE_ExternalData/dfLogics.h
@@ -38,6 +38,7 @@ namespace TFE_ExternalData
 		bool litWithMeleeAttack = false;
 		bool litWithRangedAttack = true;
 		s32 projectile = 2;
+		const char* customProjectileName = "";
 		u32 rangedAttackDelay = 291;
 		u32 meleeAttackDelay = 0;
 		u32 losDelay = 43695;

--- a/TheForceEngine/TFE_ExternalData/weaponExternal.cpp
+++ b/TheForceEngine/TFE_ExternalData/weaponExternal.cpp
@@ -23,7 +23,6 @@ namespace TFE_ExternalData
 	//////////////////////////////
 	int getProjectileIndex(char* type);
 	int getEffectIndex(char* type);
-	bool tryAssignEffectProperty(cJSON* data, ExternalEffect& effect);
 	int getWeaponIndex(char* name);
 	bool tryAssignGasmaskProperty(cJSON* data);
 	bool tryAssignWeaponProperty(cJSON* data, ExternalWeapon& weapon);
@@ -617,6 +616,9 @@ namespace TFE_ExternalData
 				}
 			}
 
+			// Save the effect name to check against custom effects
+			projectile.reflectEffectName = data->valuestring;
+
 			return false;
 		}
 
@@ -630,6 +632,9 @@ namespace TFE_ExternalData
 					return true;
 				}
 			}
+
+			// Save the effect name to check against custom effects
+			projectile.hitEffectName = data->valuestring;
 
 			return false;
 		}

--- a/TheForceEngine/TFE_ExternalData/weaponExternal.cpp
+++ b/TheForceEngine/TFE_ExternalData/weaponExternal.cpp
@@ -1,6 +1,5 @@
 #include <cstring>
 #include <vector>
-#include <TFE_System/cJSON.h>
 #include <TFE_System/system.h>
 #include <TFE_FileSystem/filestream.h>
 #include <TFE_DarkForces/projectile.h>
@@ -23,7 +22,6 @@ namespace TFE_ExternalData
 	// Forward Declarations
 	//////////////////////////////
 	int getProjectileIndex(char* type);
-	bool tryAssignProjectileProperty(cJSON* data, ExternalProjectile& projectile);
 	int getEffectIndex(char* type);
 	bool tryAssignEffectProperty(cJSON* data, ExternalEffect& effect);
 	int getWeaponIndex(char* name);

--- a/TheForceEngine/TFE_ExternalData/weaponExternal.cpp
+++ b/TheForceEngine/TFE_ExternalData/weaponExternal.cpp
@@ -645,6 +645,12 @@ namespace TFE_ExternalData
 			return true;
 		}
 
+		if (cJSON_IsBool(data) && strcasecmp(data->string, "doNotScale") == 0)
+		{
+			projectile.doNotScale = cJSON_IsTrue(data);
+			return true;
+		}
+
 		return false;
 	}
 

--- a/TheForceEngine/TFE_ExternalData/weaponExternal.cpp
+++ b/TheForceEngine/TFE_ExternalData/weaponExternal.cpp
@@ -900,6 +900,42 @@ namespace TFE_ExternalData
 			return true;
 		}
 
+		if (cJSON_IsString(data) && strcasecmp(data->string, "primaryProjectile") == 0)
+		{
+			// First check the main list
+			for (int i = 0; i < TFE_DarkForces::PROJ_COUNT; i++)
+			{
+				if (strcasecmp(data->valuestring, df_projectileTable[i]) == 0)
+				{
+					weapon.primaryProjectile = i;
+					return true;
+				}
+			}
+
+			// Save the projectile name to check against custom projectiles
+			weapon.primaryProjectileName = data->valuestring;
+
+			return false;
+		}
+
+		if (cJSON_IsString(data) && strcasecmp(data->string, "secondaryProjectile") == 0)
+		{
+			// First check the main list
+			for (int i = 0; i < TFE_DarkForces::PROJ_COUNT; i++)
+			{
+				if (strcasecmp(data->valuestring, df_projectileTable[i]) == 0)
+				{
+					weapon.secondaryProjectile = i;
+					return true;
+				}
+			}
+
+			// Save the projectile name to check against custom projectiles
+			weapon.secondaryProjectileName = data->valuestring;
+
+			return false;
+		}
+
 		if (cJSON_IsArray(data) && strcasecmp(data->string, "animFrames") == 0)
 		{
 			cJSON* element;

--- a/TheForceEngine/TFE_ExternalData/weaponExternal.cpp
+++ b/TheForceEngine/TFE_ExternalData/weaponExternal.cpp
@@ -936,6 +936,176 @@ namespace TFE_ExternalData
 			return false;
 		}
 
+		if (cJSON_IsArray(data) && strcasecmp(data->string, "pitchOffsets") == 0)
+		{
+			cJSON* element;
+			s32 index = 0;
+			cJSON_ArrayForEach(element, data)
+			{
+				if (cJSON_IsNumber(element))
+				{
+					weapon.pitchOffsets[index] = element->valuedouble;
+					index++;
+				}
+				if (index >= WEAPON_MAX_PROJECTILES) { break; }
+			}
+
+			return true;
+		}
+
+		if (cJSON_IsArray(data) && strcasecmp(data->string, "yawOffsets") == 0)
+		{
+			cJSON* element;
+			s32 index = 0;
+			cJSON_ArrayForEach(element, data)
+			{
+				if (cJSON_IsNumber(element))
+				{
+					weapon.yawOffsets[index] = element->valuedouble;
+					index++;
+				}
+				if (index >= WEAPON_MAX_PROJECTILES) { break; }
+			}
+
+			return true;
+		}
+
+		if (cJSON_IsArray(data) && strcasecmp(data->string, "xOffsets") == 0)
+		{
+			cJSON* element;
+			s32 index = 0;
+			cJSON_ArrayForEach(element, data)
+			{
+				if (cJSON_IsNumber(element))
+				{
+					weapon.xOffsets[index] = element->valuedouble;
+					index++;
+				}
+				if (index >= WEAPON_MAX_PROJECTILES) { break; }
+			}
+
+			return true;
+		}
+
+		if (cJSON_IsArray(data) && strcasecmp(data->string, "yOffsets") == 0)
+		{
+			cJSON* element;
+			s32 index = 0;
+			cJSON_ArrayForEach(element, data)
+			{
+				if (cJSON_IsNumber(element))
+				{
+					weapon.yOffsets[index] = element->valuedouble;
+					index++;
+				}
+				if (index >= WEAPON_MAX_PROJECTILES) { break; }
+			}
+
+			return true;
+		}
+
+		if (cJSON_IsArray(data) && strcasecmp(data->string, "zOffsets") == 0)
+		{
+			cJSON* element;
+			s32 index = 0;
+			cJSON_ArrayForEach(element, data)
+			{
+				if (cJSON_IsNumber(element))
+				{
+					weapon.zOffsets[index] = element->valuedouble;
+					index++;
+				}
+				if (index >= WEAPON_MAX_PROJECTILES) { break; }
+			}
+
+			return true;
+		}
+
+		if (cJSON_IsArray(data) && strcasecmp(data->string, "pitchOffsetsSecondary") == 0)
+		{
+			cJSON* element;
+			s32 index = 0;
+			cJSON_ArrayForEach(element, data)
+			{
+				if (cJSON_IsNumber(element))
+				{
+					weapon.pitchOffsetsSecondary[index] = element->valuedouble;
+					index++;
+				}
+				if (index >= WEAPON_MAX_PROJECTILES) { break; }
+			}
+
+			return true;
+		}
+
+		if (cJSON_IsArray(data) && strcasecmp(data->string, "yawOffsetsSecondary") == 0)
+		{
+			cJSON* element;
+			s32 index = 0;
+			cJSON_ArrayForEach(element, data)
+			{
+				if (cJSON_IsNumber(element))
+				{
+					weapon.yawOffsetsSecondary[index] = element->valuedouble;
+					index++;
+				}
+				if (index >= WEAPON_MAX_PROJECTILES) { break; }
+			}
+
+			return true;
+		}
+
+		if (cJSON_IsArray(data) && strcasecmp(data->string, "xOffsetsSecondary") == 0)
+		{
+			cJSON* element;
+			s32 index = 0;
+			cJSON_ArrayForEach(element, data)
+			{
+				if (cJSON_IsNumber(element))
+				{
+					weapon.xOffsetsSecondary[index] = element->valuedouble;
+					index++;
+				}
+				if (index >= WEAPON_MAX_PROJECTILES) { break; }
+			}
+
+			return true;
+		}
+
+		if (cJSON_IsArray(data) && strcasecmp(data->string, "yOffsetsSecondary") == 0)
+		{
+			cJSON* element;
+			s32 index = 0;
+			cJSON_ArrayForEach(element, data)
+			{
+				if (cJSON_IsNumber(element))
+				{
+					weapon.yOffsetsSecondary[index] = element->valuedouble;
+					index++;
+				}
+				if (index >= WEAPON_MAX_PROJECTILES) { break; }
+			}
+
+			return true;
+		}
+
+		if (cJSON_IsArray(data) && strcasecmp(data->string, "zOffsetsSecondary") == 0)
+		{
+			cJSON* element;
+			s32 index = 0;
+			cJSON_ArrayForEach(element, data)
+			{
+				if (cJSON_IsNumber(element))
+				{
+					weapon.zOffsetsSecondary[index] = element->valuedouble;
+					index++;
+				}
+				if (index >= WEAPON_MAX_PROJECTILES) { break; }
+			}
+
+			return true;
+		}
+
 		if (cJSON_IsArray(data) && strcasecmp(data->string, "animFrames") == 0)
 		{
 			cJSON* element;

--- a/TheForceEngine/TFE_ExternalData/weaponExternal.h
+++ b/TheForceEngine/TFE_ExternalData/weaponExternal.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <TFE_System/types.h>
+#include <TFE_System/cJSON.h>
 #include <TFE_DarkForces/player.h>
 
 ///////////////////////////////////////////
@@ -108,6 +109,7 @@ namespace TFE_ExternalData
 	void loadExternalProjectiles();
 	void parseExternalProjectiles(char* data, bool fromMod);
 	bool validateExternalProjectiles();
+	bool tryAssignProjectileProperty(cJSON* data, ExternalProjectile& projectile);
 	void loadExternalEffects();
 	void parseExternalEffects(char* data, bool fromMod);
 	bool validateExternalEffects();

--- a/TheForceEngine/TFE_ExternalData/weaponExternal.h
+++ b/TheForceEngine/TFE_ExternalData/weaponExternal.h
@@ -47,6 +47,8 @@ namespace TFE_ExternalData
 		const char* cameraPassSound = "";
 		s32 reflectEffectId = -1;
 		s32 hitEffectId = -1;
+		const char* reflectEffectName = "";
+		const char* hitEffectName = "";
 		bool explodeOnTimeout = false;
 	};
 
@@ -116,4 +118,5 @@ namespace TFE_ExternalData
 	void loadExternalWeapons();
 	void parseExternalWeapons(char* data, bool fromMod);
 	bool validateExternalWeapons();
+	bool tryAssignEffectProperty(cJSON* data, ExternalEffect& effect);
 }

--- a/TheForceEngine/TFE_ExternalData/weaponExternal.h
+++ b/TheForceEngine/TFE_ExternalData/weaponExternal.h
@@ -51,6 +51,8 @@ namespace TFE_ExternalData
 		const char* reflectEffectName = "";
 		const char* hitEffectName = "";
 		bool explodeOnTimeout = false;
+
+		bool doNotScale = false;
 	};
 
 	struct ExternalEffect

--- a/TheForceEngine/TFE_ExternalData/weaponExternal.h
+++ b/TheForceEngine/TFE_ExternalData/weaponExternal.h
@@ -88,6 +88,11 @@ namespace TFE_ExternalData
 		s32 primaryFireConsumption = 1;
 		s32 secondaryFireConsumption = 1;
 
+		u32 primaryProjectile = 0;
+		u32 secondaryProjectile = 0;
+		const char* primaryProjectileName = "";
+		const char* secondaryProjectileName = "";
+
 		s32 numAnimFrames = 1;
 		WeaponAnimFrame animFrames[WEAPON_NUM_ANIMFRAMES];
 		s32 numSecondaryAnimFrames = 1;

--- a/TheForceEngine/TFE_ExternalData/weaponExternal.h
+++ b/TheForceEngine/TFE_ExternalData/weaponExternal.h
@@ -13,6 +13,7 @@ namespace TFE_ExternalData
 	{
 		WEAPON_NUM_TEXTURES = 16,
 		WEAPON_NUM_ANIMFRAMES = 16,
+		WEAPON_MAX_PROJECTILES = 4,
 	};
 
 	struct ExternalProjectile
@@ -92,6 +93,17 @@ namespace TFE_ExternalData
 		u32 secondaryProjectile = 0;
 		const char* primaryProjectileName = "";
 		const char* secondaryProjectileName = "";
+
+		f32 pitchOffsets[WEAPON_MAX_PROJECTILES] = { 0, 0, 0, 0 };
+		f32 yawOffsets[WEAPON_MAX_PROJECTILES] = { 0, 0, 0, 0 };
+		f32 xOffsets[WEAPON_MAX_PROJECTILES] = { 0, 0, 0, 0 };
+		f32 yOffsets[WEAPON_MAX_PROJECTILES] = { 0, 0, 0, 0 };
+		f32 zOffsets[WEAPON_MAX_PROJECTILES] = { 0, 0, 0, 0 };
+		f32 pitchOffsetsSecondary[WEAPON_MAX_PROJECTILES] = { 0, 0, 0, 0 };
+		f32 yawOffsetsSecondary[WEAPON_MAX_PROJECTILES] = { 0, 0, 0, 0 };
+		f32 xOffsetsSecondary[WEAPON_MAX_PROJECTILES] = { 0, 0, 0, 0 };
+		f32 yOffsetsSecondary[WEAPON_MAX_PROJECTILES] = { 0, 0, 0, 0 };
+		f32 zOffsetsSecondary[WEAPON_MAX_PROJECTILES] = { 0, 0, 0, 0 };
 
 		s32 numAnimFrames = 1;
 		WeaponAnimFrame animFrames[WEAPON_NUM_ANIMFRAMES];

--- a/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
+++ b/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
@@ -33,6 +33,7 @@
 #include <TFE_ExternalData/weaponExternal.h>
 #include <TFE_ExternalData/pickupExternal.h>
 #include <TFE_ExternalData/customProjectile.h>
+#include <TFE_ExternalData/customEffect.h>
 // Game
 #include <TFE_DarkForces/mission.h>
 #include <TFE_DarkForces/gameMusic.h>
@@ -528,6 +529,7 @@ namespace TFE_FrontEndUI
 		TFE_ExternalData::clearExternalEffects();						// clear effects
 		TFE_ExternalData::clearExternalPickups();						// clear pickups
 		TFE_ExternalData::clearCustomProjectiles();						// clear custom projectiles
+		TFE_ExternalData::clearCustomEffects();							// clear custom effects
 
 		// Restore the default messages if you are exiting a mod. 
 		if (TFE_System::modMessagesLoaded())

--- a/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
+++ b/TheForceEngine/TFE_FrontEndUI/frontEndUi.cpp
@@ -32,6 +32,7 @@
 #include <TFE_ExternalData/dfLogics.h>
 #include <TFE_ExternalData/weaponExternal.h>
 #include <TFE_ExternalData/pickupExternal.h>
+#include <TFE_ExternalData/customProjectile.h>
 // Game
 #include <TFE_DarkForces/mission.h>
 #include <TFE_DarkForces/gameMusic.h>
@@ -526,6 +527,7 @@ namespace TFE_FrontEndUI
 		TFE_ExternalData::clearExternalProjectiles();					// clear projectiles
 		TFE_ExternalData::clearExternalEffects();						// clear effects
 		TFE_ExternalData::clearExternalPickups();						// clear pickups
+		TFE_ExternalData::clearCustomProjectiles();						// clear custom projectiles
 
 		// Restore the default messages if you are exiting a mod. 
 		if (TFE_System::modMessagesLoaded())

--- a/TheForceEngine/TFE_Game/saveSystem.cpp
+++ b/TheForceEngine/TFE_Game/saveSystem.cpp
@@ -7,6 +7,7 @@
 #include <TFE_ExternalData/dfLogics.h>
 #include <TFE_ExternalData/weaponExternal.h>
 #include <TFE_ExternalData/pickupExternal.h>
+#include <TFE_ExternalData/customProjectile.h>
 #include <TFE_Settings/gameSourceData.h>
 #include <TFE_System/system.h>
 #include <cassert>
@@ -257,6 +258,7 @@ namespace TFE_SaveSystem
 			TFE_ExternalData::clearExternalProjectiles();
 			TFE_ExternalData::clearExternalEffects();
 			TFE_ExternalData::clearExternalPickups();
+			TFE_ExternalData::clearCustomProjectiles();
 
 			ret = s_game->serializeGameState(&stream, filename, false);
 			stream.close();

--- a/TheForceEngine/TFE_Game/saveSystem.cpp
+++ b/TheForceEngine/TFE_Game/saveSystem.cpp
@@ -8,6 +8,7 @@
 #include <TFE_ExternalData/weaponExternal.h>
 #include <TFE_ExternalData/pickupExternal.h>
 #include <TFE_ExternalData/customProjectile.h>
+#include <TFE_ExternalData/customEffect.h>
 #include <TFE_Settings/gameSourceData.h>
 #include <TFE_System/system.h>
 #include <cassert>
@@ -259,6 +260,7 @@ namespace TFE_SaveSystem
 			TFE_ExternalData::clearExternalEffects();
 			TFE_ExternalData::clearExternalPickups();
 			TFE_ExternalData::clearCustomProjectiles();
+			TFE_ExternalData::clearCustomEffects();
 
 			ret = s_game->serializeGameState(&stream, filename, false);
 			stream.close();

--- a/TheForceEngine/TheForceEngine.vcxproj
+++ b/TheForceEngine/TheForceEngine.vcxproj
@@ -527,6 +527,7 @@ echo ^)";
     <ClInclude Include="TFE_Editor\LevelEditor\testOptions.h" />
     <ClInclude Include="TFE_Editor\LevelEditor\userPreferences.h" />
     <ClInclude Include="TFE_Editor\snapshotReaderWriter.h" />
+    <ClInclude Include="TFE_ExternalData\customProjectile.h" />
     <ClInclude Include="TFE_ExternalData\pickupExternal.h" />
     <ClInclude Include="TFE_FileSystem\filestream.h" />
     <ClInclude Include="TFE_FileSystem\fileutil.h" />
@@ -946,6 +947,7 @@ echo ^)";
     <ClCompile Include="TFE_Editor\LevelEditor\testOptions.cpp" />
     <ClCompile Include="TFE_Editor\LevelEditor\userPreferences.cpp" />
     <ClCompile Include="TFE_Editor\snapshotReaderWriter.cpp" />
+    <ClCompile Include="TFE_ExternalData\customProjectile.cpp" />
     <ClCompile Include="TFE_ExternalData\pickupExternal.cpp" />
     <ClCompile Include="TFE_FileSystem\filestream.cpp" />
     <ClCompile Include="TFE_FileSystem\fileutil.cpp" />

--- a/TheForceEngine/TheForceEngine.vcxproj
+++ b/TheForceEngine/TheForceEngine.vcxproj
@@ -527,6 +527,7 @@ echo ^)";
     <ClInclude Include="TFE_Editor\LevelEditor\testOptions.h" />
     <ClInclude Include="TFE_Editor\LevelEditor\userPreferences.h" />
     <ClInclude Include="TFE_Editor\snapshotReaderWriter.h" />
+    <ClInclude Include="TFE_ExternalData\customEffect.h" />
     <ClInclude Include="TFE_ExternalData\customProjectile.h" />
     <ClInclude Include="TFE_ExternalData\pickupExternal.h" />
     <ClInclude Include="TFE_FileSystem\filestream.h" />
@@ -947,6 +948,7 @@ echo ^)";
     <ClCompile Include="TFE_Editor\LevelEditor\testOptions.cpp" />
     <ClCompile Include="TFE_Editor\LevelEditor\userPreferences.cpp" />
     <ClCompile Include="TFE_Editor\snapshotReaderWriter.cpp" />
+    <ClCompile Include="TFE_ExternalData\customEffect.cpp" />
     <ClCompile Include="TFE_ExternalData\customProjectile.cpp" />
     <ClCompile Include="TFE_ExternalData\pickupExternal.cpp" />
     <ClCompile Include="TFE_FileSystem\filestream.cpp" />

--- a/TheForceEngine/TheForceEngine.vcxproj.filters
+++ b/TheForceEngine/TheForceEngine.vcxproj.filters
@@ -1510,6 +1510,9 @@
     <ClInclude Include="TFE_Asset\srtParser.h">
       <Filter>Source\TFE_Asset</Filter>
     </ClInclude>
+    <ClInclude Include="TFE_ExternalData\customProjectile.h">
+      <Filter>Source\TFE_ExternalData</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp">
@@ -2648,6 +2651,9 @@
     </ClCompile>
     <ClCompile Include="TFE_Asset\srtParser.cpp">
       <Filter>Source\TFE_Asset</Filter>
+    </ClCompile>
+    <ClCompile Include="TFE_ExternalData\customProjectile.cpp">
+      <Filter>Source\TFE_ExternalData</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/TheForceEngine/TheForceEngine.vcxproj.filters
+++ b/TheForceEngine/TheForceEngine.vcxproj.filters
@@ -1513,6 +1513,9 @@
     <ClInclude Include="TFE_ExternalData\customProjectile.h">
       <Filter>Source\TFE_ExternalData</Filter>
     </ClInclude>
+    <ClInclude Include="TFE_ExternalData\customEffect.h">
+      <Filter>Source\TFE_ExternalData</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp">
@@ -2653,6 +2656,9 @@
       <Filter>Source\TFE_Asset</Filter>
     </ClCompile>
     <ClCompile Include="TFE_ExternalData\customProjectile.cpp">
+      <Filter>Source\TFE_ExternalData</Filter>
+    </ClCompile>
+    <ClCompile Include="TFE_ExternalData\customEffect.cpp">
       <Filter>Source\TFE_ExternalData</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
This PR allows modders to add projectiles and effects beyond DF's enumerated list.
Custom projectiles & effects are read from `json` files (same as custom logics).
Their data are stored in vectors, and they are distinguished from the original projectiles/effects by starting their numbering at 100.

Related changes
- player weapon projectiles are externalised to `weapons.json`
- player weapon projectile spawn offsets are externalised to `weapons.json` instead of being hardcoded
- NPCs will decide to use aimarcing if they have any kind of arcing projectile (not just TDs and mortars)
- 3DO projectiles can be given a flag which disables framerate based scaling

note- this feature has been quite thoroughly tested in the DF-21 community by ben