### PR TITLE
RFC: CMake improvements for windows builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
-cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 include(CheckCXXCompilerFlag)
+include(FetchContent)
 
 set(CMAKE_DISABLE_SOURCE_CHANGES ON)
 set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
@@ -66,25 +67,93 @@ if(ENABLE_TFE)
 		set_target_properties(tfe PROPERTIES OUTPUT_NAME "theforceengine")
 	endif()
 
-	if(UNIX)
-		set(THREADS_PREFER_PTHREAD_FLAG ON)
-		find_package(Threads REQUIRED)
+	set(THREADS_PREFER_PTHREAD_FLAG ON)
+	find_package(Threads REQUIRED)
+	FetchContent_Declare(
+		SDL2
+		GIT_REPOSITORY https://github.com/libsdl-org/SDL.git
+		GIT_TAG        release-2.32.10
+		FIND_PACKAGE_ARGS NAMES SDL2
+	)
+
+	FetchContent_Declare(
+		SDL2Image
+		GIT_REPOSITORY https://github.com/libsdl-org/SDL_image.git
+		GIT_TAG        release-2.8.12
+		FIND_PACKAGE_ARGS NAMES SDL2_image
+	)
+	# omit further unneded dependencies
+	set(SDL2IMAGE_WEBP OFF CACHE BOOL "" FORCE)
+	set(SDL2IMAGE_AVIF OFF CACHE BOOL "" FORCE)
+
+	FetchContent_MakeAvailable(SDL2)
+	FetchContent_MakeAvailable(SDL2Image)
+
+	target_include_directories(tfe PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+	target_link_libraries(tfe PRIVATE SDL2::SDL2main SDL2::SDL2 SDL2_image::SDL2_image Threads::Threads)
+
+	if(ENABLE_SYSMIDI)
 		find_package(PkgConfig REQUIRED)
-		pkg_check_modules(SDL2 REQUIRED sdl2)
-		pkg_check_modules(SDL2_IMAGE REQUIRED SDL2_image)
+		pkg_check_modules(RTMIDI rtmidi>=5.0.0)
+		if(RTMIDI_FOUND)
+			add_definitions("-DBUILD_SYSMIDI")
+			target_link_libraries(tfe PRIVATE ${RTMIDI_LIBRARIES})
+		else()
+			set(ENABLE_SYSMIDI 0)
+			message(STATUS "System MIDI Disabled")
+		endif()
+	endif()
 
-		target_include_directories(tfe PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+	if(COMPILER_ENABLE_AUTOZERO)
+		message(STATUS "enabled -ftrivial-auto-var-init=zero")
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ftrivial-auto-var-init=zero")
+	endif()
 
-		target_include_directories(tfe PRIVATE ${SDL2_INCLUDE_DIRS})
-		target_include_directories(tfe PRIVATE ${SDL2_IMAGE_INCLUDE_DIRS})
-		target_link_libraries(tfe PRIVATE ${SDL2_LIBRARIES}
-					${SDL2_IMAGE_LIBRARIES}
-					${CMAKE_DL_LIBS}
-					Threads::Threads
+	if(ENABLE_EDITOR)
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBUILD_EDITOR")
+	endif()
+
+	if(ENABLE_OGV_CUTSCENES)
+		FetchContent_Declare(
+			Ogg
+			GIT_REPOSITORY https://github.com/xiph/ogg
+			GIT_TAG        master
+			FIND_PACKAGE_ARGS NAMES ogg
 		)
-		
-		target_link_directories(tfe PRIVATE ${SDL2_LIBRARY_DIRS} ${SDL2_IMAGE_LIBRARY_DIRS})		
+		FetchContent_Declare(
+			Vorbis
+			GIT_REPOSITORY https://github.com/xiph/vorbis
+			GIT_TAG        master
+			FIND_PACKAGE_ARGS NAMES vorbis
+		)
 
+		FetchContent_MakeAvailable(Ogg)
+		FetchContent_MakeAvailable(Vorbis)
+		target_link_libraries(tfe PRIVATE Ogg::ogg Vorbis::vorbis ${THEORA_LIBRARIES})
+		target_link_directories(tfe PRIVATE ${THEORA_LIBRARY_DIRS})
+		# unlike Ogg/Vorbis, theora does **NOT** have CMake support.
+		# On windows, use vcpkg to fetch and build the lib.
+		if (WIN32)
+			find_package(unofficial-libtheora CONFIG REQUIRED)
+			target_link_libraries(tfe PRIVATE unofficial::libtheora::theoradec)
+		else()
+			# FIXME: needs host libtheora. Find a way to build it
+			# on Linux/OSX.
+			find_package(PkgConfig REQUIRED)
+			pkg_check_modules(THEORA REQUIRED theoradec)
+			target_link_directories(tfe PRIVATE ${THEORA_LIBRARY_DIRS})
+			target_link_libraries(tfe PRIVATE ${THEORA_LIBRARIES})
+		endif()
+
+		add_definitions("-DENABLE_OGV_CUTSCENES")
+	endif()
+
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBUILD_FORCE_SCRIPT")
+	target_include_directories(tfe PRIVATE "TheForceEngine/TFE_ForceScript/Angelscript/angelscript/include")
+	target_include_directories(tfe PRIVATE "TheForceEngine/TFE_ForceScript/Angelscript/add_on")
+	target_include_directories(tfe PRIVATE TheForceEngine)
+
+	if(UNIX)
 		# set up build directory to be able to run TFE immediately: symlink
 		# the necessary support file directories into the build env.
 		execute_process(COMMAND ln -sf ${CMAKE_SOURCE_DIR}/TheForceEngine/Captions)
@@ -101,42 +170,6 @@ if(ENABLE_TFE)
 		include(CreateGitVersionH.cmake)
 		create_git_version_h()
 	endif()
-
-	if(COMPILER_ENABLE_AUTOZERO)
-		message(STATUS "enabled -ftrivial-auto-var-init=zero")
-		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ftrivial-auto-var-init=zero")
-	endif()
-
-	if(ENABLE_SYSMIDI)
-		pkg_check_modules(RTMIDI rtmidi>=5.0.0)
-		if(RTMIDI_FOUND)
-			add_definitions("-DBUILD_SYSMIDI")
-			target_link_libraries(tfe PRIVATE ${RTMIDI_LIBRARIES})
-		else()
-			set(ENABLE_SYSMIDI 0)
-			message(STATUS "System MIDI Disabled")
-		endif()
-	endif()
-	if(ENABLE_EDITOR)
-		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBUILD_EDITOR")
-	endif()
-	if(ENABLE_OGV_CUTSCENES)
-		if(UNIX)
-			pkg_check_modules(THEORA REQUIRED theoradec)
-			pkg_check_modules(OGG REQUIRED ogg)
-			pkg_check_modules(VORBIS REQUIRED vorbis vorbisfile)
-			target_include_directories(tfe PRIVATE ${THEORA_INCLUDE_DIRS} ${OGG_INCLUDE_DIRS} ${VORBIS_INCLUDE_DIRS})
-			target_link_libraries(tfe PRIVATE ${THEORA_LIBRARIES} ${OGG_LIBRARIES} ${VORBIS_LIBRARIES})
-			target_link_directories(tfe PRIVATE ${THEORA_LIBRARY_DIRS} ${OGG_LIBRARY_DIRS} ${VORBIS_LIBRARY_DIRS})
-		endif()
-		add_definitions("-DENABLE_OGV_CUTSCENES")
-	endif()
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBUILD_FORCE_SCRIPT")
-
-
-	target_include_directories(tfe PRIVATE "TheForceEngine/TFE_ForceScript/Angelscript/angelscript/include")
-	target_include_directories(tfe PRIVATE "TheForceEngine/TFE_ForceScript/Angelscript/add_on")
-	target_include_directories(tfe PRIVATE TheForceEngine)
 
 	add_subdirectory(TheForceEngine/)
 endif()

--- a/TheForceEngine/TFE_ForceScript/CMakeLists.txt
+++ b/TheForceEngine/TFE_ForceScript/CMakeLists.txt
@@ -3,36 +3,44 @@ file(GLOB_RECURSE SOURCES "*.cpp" "*.c")
 set(ARCHFLAGS "${CMAKE_SYSTEM_PROCESSOR}")
 
 if (APPLE AND NOT IOS)
-    # TODO: Would this break building on armv7 Linux?
-    if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm")
-        set(ARCHFLAGS "aarch64")
-    endif ()
+	# TODO: Would this break building on armv7 Linux?
+	if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm")
+		set(ARCHFLAGS "aarch64")
+	endif ()
 endif ()
 
 if(${ARCHFLAGS} MATCHES "^arm")
-   if(CMAKE_ASM_COMPILER_WORKS)
-       list(APPEND SOURCES
-           TheForceEngine/TFE_ForceScript/Angelscript/angelscript/source/as_callfunc_arm_gcc.S)
-       set_property(SOURCE
-           TheForceEngine/TFE_ForceScript/Angelscript/angelscript/source/as_callfunc_arm_gcc.S
-           APPEND PROPERTY COMPILE_FLAGS " -Wa,-mimplicit-it=always")
-   else()
-       message(FATAL ERROR "ARM target requires a working assembler")
-   endif()
+	if(CMAKE_ASM_COMPILER_WORKS)
+		if(WIN32)
+			list(APPEND SOURCES
+			     TheForceEngine/TFE_ForceScript/Angelscript/angelscript/source/as_callfunc_arm_msvc.asm)
+		else()
+			list(APPEND SOURCES
+			     TheForceEngine/TFE_ForceScript/Angelscript/angelscript/source/as_callfunc_arm_gcc.S)
+			set_property(SOURCE
+				     TheForceEngine/TFE_ForceScript/Angelscript/angelscript/source/as_callfunc_arm_gcc.S
+				     APPEND PROPERTY COMPILE_FLAGS " -Wa,-mimplicit-it=always")
+		endif()
+	   else()
+		message(FATAL ERROR "ARM target requires a working assembler")
+	endif()
 endif()
 
 if(${ARCHFLAGS} MATCHES "^aarch64")
-   if(CMAKE_ASM_COMPILER_WORKS)
-       if(NOT APPLE)
-           list(APPEND SOURCES
-               TheForceEngine/TFE_ForceScript/Angelscript/angelscript/source/as_callfunc_arm64_gcc.S)
-       else()
-           list(APPEND SOURCES
-               TheForceEngine/TFE_ForceScript/Angelscript/angelscript/source/as_callfunc_arm64_xcode.S)
-       endif()
-   else()
-       message(FATAL ERROR "ARM target requires a working assembler")
-   endif()
+	if(CMAKE_ASM_COMPILER_WORKS)
+		if(WIN32)
+			list(APPEND SOURCES
+			     TheForceEngine/TFE_ForceScript/Angelscript/angelscript/source/as_callfunc_arm64_msvc.asm)
+		elseif(NOT APPLE)
+			list(APPEND SOURCES
+			     TheForceEngine/TFE_ForceScript/Angelscript/angelscript/source/as_callfunc_arm64_gcc.S)
+		else()
+			list(APPEND SOURCES
+			     TheForceEngine/TFE_ForceScript/Angelscript/angelscript/source/as_callfunc_arm64_xcode.S)
+		endif()
+	else()
+		message(FATAL ERROR "ARM target requires a working assembler")
+	endif()
 endif()
 
 target_sources(tfe PRIVATE ${SOURCES})

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "TheForceEngine",
+  "version": "1.24.0",
+  "dependencies": [
+    "libtheora"
+  ]
+}


### PR DESCRIPTION
To make cmake build possible on windows:

- use cmake to fetch and build SDL2, SDL2_image if necessary
- use cmake to fetch and build ogg, vorbis if necessary.
  - for theora, because it does not support cmake, use vcpkg on visual studio to fetch it, or rely on availability of the host library on linux/osx.

I've tested this on linux and works pretty well:  If SDL2/SDL2 image are available on the host, they are dynamically linked, otherwise as part of the build step, they are built and statically linked into the executable.  Same for Ogg and Vorbis.
Theora however is difficult. It does not support cmake, just Makefiles and an old visual studio .dsp file.
vcpkg could be used to have it fetched and built before the main application link step.  That is what I opted for here.

Lacking a windows machine atm, I haven't tried to build this with visual studio though.