### PR TITLE
New functionality for mod cutscenes. Now controlled by file cutscene.json

### DIFF
--- a/TheForceEngine/TFE_DarkForces/Landru/modCutscene.cpp
+++ b/TheForceEngine/TFE_DarkForces/Landru/modCutscene.cpp
@@ -1,0 +1,178 @@
+#include "modCutscene.h"
+#include <TFE_DarkForces/darkForcesMain.h>
+#include <TFE_System/system.h>
+#include <TFE_System/cJSON.h>
+#include <TFE_FileSystem/paths.h>
+#include <TFE_FileSystem/filestream.h>
+#include <cstring>
+#include <vector>
+#include <string>
+
+namespace TFE_DarkForces
+{
+	struct ModCutsceneSlot
+	{
+		char intro[TFE_MAX_PATH] = "";
+		char outro[TFE_MAX_PATH] = "";
+		bool hasIntro = false;
+		bool hasOutro = false;
+	};
+
+	struct ModMissionSlot
+	{
+		std::string name;   
+		ModCutsceneSlot slot;
+	};
+
+	static bool s_active = false;
+	static ModCutsceneSlot s_gameSlot;
+	static std::vector<ModMissionSlot> s_missionSlots;
+
+	// Reads "intro"/"outro" string fields out of a JSON object into a slot.
+	// Missing, non-string, or empty-string fields just leave hasIntro/
+	// hasOutro false for that field - exactly "not defined", which is what
+	// tells the caller to play nothing for that slot.
+	static void parseSlot(const cJSON* obj, ModCutsceneSlot& out)
+	{
+		const cJSON* introItem = cJSON_GetObjectItem(obj, "intro");
+		if (introItem && cJSON_IsString(introItem) && introItem->valuestring && introItem->valuestring[0])
+		{
+			strncpy(out.intro, introItem->valuestring, sizeof(out.intro) - 1);
+			out.intro[sizeof(out.intro) - 1] = 0;
+			out.hasIntro = true;
+		}
+
+		const cJSON* outroItem = cJSON_GetObjectItem(obj, "outro");
+		if (outroItem && cJSON_IsString(outroItem) && outroItem->valuestring && outroItem->valuestring[0])
+		{
+			strncpy(out.outro, outroItem->valuestring, sizeof(out.outro) - 1);
+			out.outro[sizeof(out.outro) - 1] = 0;
+			out.hasOutro = true;
+		}
+	}
+
+	void modCutscene_clear()
+	{
+		s_active = false;
+		s_gameSlot = ModCutsceneSlot();
+		s_missionSlots.clear();
+	}
+
+	void modCutscene_init()
+	{
+		modCutscene_clear();
+
+		// Only ever read from an actual loaded mod - never from the base
+		// game data or a generic search path. See df_isCustomModLoaded()
+		// for why this is the right check (and not just probing whether
+		// the file happens to be findable).
+		if (!df_isCustomModLoaded()) { return; }
+
+		FilePath filePath;
+		if (!TFE_Paths::getFilePath("cutscene.txt", &filePath)) { return; }
+
+		FileStream file;
+		if (!file.open(&filePath, FileStream::MODE_READ)) { return; }
+
+		const size_t size = file.getSize();
+		if (size == 0)
+		{
+			file.close();
+			TFE_System::logWrite(LOG_WARNING, "ModCutscene", "cutscene.txt is empty, ignoring.");
+			return;
+		}
+
+		char* data = (char*)malloc(size + 1);
+		if (!data)
+		{
+			file.close();
+			return;
+		}
+		file.readBuffer(data, (u32)size);
+		data[size] = 0;
+		file.close();
+
+		cJSON* root = cJSON_Parse(data);
+		free(data);
+
+		if (!root)
+		{
+			const char* err = cJSON_GetErrorPtr();
+			TFE_System::logWrite(LOG_ERROR, "ModCutscene", "Failed to parse cutscene.txt%s%s. Is the JSON valid? Check on jsonlint.com",
+				err ? " near: " : "", err ? err : "");
+			return;
+		}
+
+		s32 missionCount = 0;
+		const cJSON* curElem = root->child;
+		for (; curElem; curElem = curElem->next)
+		{
+			if (!curElem->string || !cJSON_IsObject(curElem)) { continue; }
+
+			ModCutsceneSlot slot;
+			parseSlot(curElem, slot);
+
+			if (strcasecmp(curElem->string, "game") == 0)
+			{
+				s_gameSlot = slot;
+			}
+			else
+			{
+				ModMissionSlot m;
+				m.name = curElem->string;
+				m.slot = slot;
+				s_missionSlots.push_back(m);
+				missionCount++;
+			}
+		}
+		cJSON_Delete(root);
+
+		// Active even if every slot turned out empty - an intentionally
+		// sparse or "no cutscenes" cutscene.txt should still fully
+		// override the stock system, not silently fall back to it.
+		s_active = true;
+
+		TFE_System::logWrite(LOG_MSG, "ModCutscene", "Loaded cutscene.txt (%d mission entr%s).",
+			missionCount, missionCount == 1 ? "y" : "ies");
+	}
+
+	bool modCutscene_isActive()
+	{
+		return s_active;
+	}
+
+	const char* modCutscene_getGameIntro()
+	{
+ 		return s_gameSlot.hasIntro ? s_gameSlot.intro : nullptr;
+	}
+
+	const char* modCutscene_getGameOutro()
+	{
+		return s_gameSlot.hasOutro ? s_gameSlot.outro : nullptr;
+	}
+
+	static const ModCutsceneSlot* findMissionSlot(const char* levelName)
+	{
+		if (!levelName || !levelName[0]) { return nullptr; }
+		for (size_t i = 0; i < s_missionSlots.size(); i++)
+		{
+			if (strcasecmp(s_missionSlots[i].name.c_str(), levelName) == 0)
+			{
+				return &s_missionSlots[i].slot;
+			}
+		}
+		return nullptr;
+	}
+
+	const char* modCutscene_getMissionIntro(const char* levelName)
+	{
+		const ModCutsceneSlot* slot = findMissionSlot(levelName);
+		return (slot && slot->hasIntro) ? slot->intro : nullptr;
+	}
+
+	const char* modCutscene_getMissionOutro(const char* levelName)
+	{
+		const ModCutsceneSlot* slot = findMissionSlot(levelName);
+		return (slot && slot->hasOutro) ? slot->outro : nullptr;
+	}
+}  // TFE_DarkForces

--- a/TheForceEngine/TFE_DarkForces/Landru/modCutscene.cpp
+++ b/TheForceEngine/TFE_DarkForces/Landru/modCutscene.cpp
@@ -69,7 +69,7 @@ namespace TFE_DarkForces
 		if (!df_isCustomModLoaded()) { return; }
 
 		FilePath filePath;
-		if (!TFE_Paths::getFilePath("cutscene.txt", &filePath)) { return; }
+		if (!TFE_Paths::getFilePath("cutscene.json", &filePath)) { return; }
 
 		FileStream file;
 		if (!file.open(&filePath, FileStream::MODE_READ)) { return; }
@@ -78,7 +78,7 @@ namespace TFE_DarkForces
 		if (size == 0)
 		{
 			file.close();
-			TFE_System::logWrite(LOG_WARNING, "ModCutscene", "cutscene.txt is empty, ignoring.");
+			TFE_System::logWrite(LOG_WARNING, "ModCutscene", "cutscene.json is empty, ignoring.");
 			return;
 		}
 
@@ -98,7 +98,7 @@ namespace TFE_DarkForces
 		if (!root)
 		{
 			const char* err = cJSON_GetErrorPtr();
-			TFE_System::logWrite(LOG_ERROR, "ModCutscene", "Failed to parse cutscene.txt%s%s. Is the JSON valid? Check on jsonlint.com",
+			TFE_System::logWrite(LOG_ERROR, "ModCutscene", "Failed to parse cutscene.json %s%s. Is the JSON valid? Check on jsonlint.com",
 				err ? " near: " : "", err ? err : "");
 			return;
 		}
@@ -128,11 +128,11 @@ namespace TFE_DarkForces
 		cJSON_Delete(root);
 
 		// Active even if every slot turned out empty - an intentionally
-		// sparse or "no cutscenes" cutscene.txt should still fully
+		// sparse or "no cutscenes" cutscene.json should still fully
 		// override the stock system, not silently fall back to it.
 		s_active = true;
 
-		TFE_System::logWrite(LOG_MSG, "ModCutscene", "Loaded cutscene.txt (%d mission entr%s).",
+		TFE_System::logWrite(LOG_MSG, "ModCutscene", "Loaded cutscene.json (%d mission entr%s).",
 			missionCount, missionCount == 1 ? "y" : "ies");
 	}
 

--- a/TheForceEngine/TFE_DarkForces/Landru/modCutscene.h
+++ b/TheForceEngine/TFE_DarkForces/Landru/modCutscene.h
@@ -1,0 +1,64 @@
+#pragma once
+//////////////////////////////////////////////////////////////////////
+// Mod cutscene.txt override system
+//////////////////////////////////////////////////////////////////////
+//
+// A custom mod can ship a "cutscene.txt" file (JSON) at the root of its
+// zip to take full, explicit control of which OGV plays for the game's
+// intro/outro and for each mission's intro/outro - completely replacing
+// the stock cutscene.lst/scene-id driven system for those four slots.
+//
+// Format:
+//
+//   {
+//     "game":    { "intro": "logo",      "outro": "credits"   },
+//     "secbase": { "intro": "cutscene1", "outro": "cutscene2" },
+//     "talay":   { "intro": "cutscene3" },
+//     "arc":     { "outro": "cutscene4" }
+//   }
+//
+// - "game".intro plays once, before the agent menu is first shown.
+// - "game".outro plays once, after the last mission's own slots (if any)
+//   have finished, right before returning to the agent menu with no more
+//   missions to select (i.e. the game is "won").
+// - "<mission>".intro plays after the mission is selected from the agent
+//   menu, before the mission briefing screen.
+// - "<mission>".outro plays after that mission is completed.
+// - Mission keys are matched case-insensitively against the level name
+//   (e.g. "secbase", matching agent_getLevelName()).
+//
+// Every name is a base filename with no extension - "logo" means
+// "logo.ogv". Lookup order for each name: the mod zip first, then the
+// remaster's own movies/ directory as a fallback. If neither has it,
+// that slot plays nothing (it does NOT fall back to LFD/cutscene.lst -
+// once cutscene.txt is active, it's the sole source of truth for these
+// four slots). Likewise, a slot simply left out of the JSON (or the
+// whole "game" or mission object being absent) plays nothing.
+//
+#include <TFE_System/types.h>
+
+namespace TFE_DarkForces
+{
+	// Parses "cutscene.txt" from the currently loaded mod, if any. Safe to
+	// call unconditionally (e.g. right after a mod's files are known) -
+	// it's a no-op, and modCutscene_isActive() stays false, if no mod is
+	// loaded or the mod didn't ship the file.
+	void modCutscene_init();
+
+	// Drops any parsed data. Call when leaving a mod (returning to a
+	// vanilla session) so a stale config can't leak into the next game.
+	void modCutscene_clear();
+
+	// True only when a loaded mod shipped a valid cutscene.txt. While
+	// true, callers should use ONLY this system for the four slots below
+	// and must not fall back to cutscene.lst/scene ids for them.
+	bool modCutscene_isActive();
+
+	// Returns the configured base name (no extension) for each slot, or
+	// nullptr if that slot isn't defined. levelName is matched
+	// case-insensitively.
+	const char* modCutscene_getGameIntro();
+	const char* modCutscene_getGameOutro();
+	const char* modCutscene_getMissionIntro(const char* levelName);
+	const char* modCutscene_getMissionOutro(const char* levelName);
+}

--- a/TheForceEngine/TFE_DarkForces/Landru/modCutscene.h
+++ b/TheForceEngine/TFE_DarkForces/Landru/modCutscene.h
@@ -1,9 +1,9 @@
 #pragma once
 //////////////////////////////////////////////////////////////////////
-// Mod cutscene.txt override system
+// Mod cutscene.json override system
 //////////////////////////////////////////////////////////////////////
 //
-// A custom mod can ship a "cutscene.txt" file (JSON) at the root of its
+// A custom mod can ship a "cutscene.json" file at the root of its
 // zip to take full, explicit control of which OGV plays for the game's
 // intro/outro and for each mission's intro/outro - completely replacing
 // the stock cutscene.lst/scene-id driven system for those four slots.
@@ -31,7 +31,7 @@
 // "logo.ogv". Lookup order for each name: the mod zip first, then the
 // remaster's own movies/ directory as a fallback. If neither has it,
 // that slot plays nothing (it does NOT fall back to LFD/cutscene.lst -
-// once cutscene.txt is active, it's the sole source of truth for these
+// once cutscene.json is active, it's the sole source of truth for these
 // four slots). Likewise, a slot simply left out of the JSON (or the
 // whole "game" or mission object being absent) plays nothing.
 //
@@ -39,7 +39,7 @@
 
 namespace TFE_DarkForces
 {
-	// Parses "cutscene.txt" from the currently loaded mod, if any. Safe to
+	// Parses "cutscene.json" from the currently loaded mod, if any. Safe to
 	// call unconditionally (e.g. right after a mod's files are known) -
 	// it's a no-op, and modCutscene_isActive() stays false, if no mod is
 	// loaded or the mod didn't ship the file.
@@ -49,7 +49,7 @@ namespace TFE_DarkForces
 	// vanilla session) so a stale config can't leak into the next game.
 	void modCutscene_clear();
 
-	// True only when a loaded mod shipped a valid cutscene.txt. While
+	// True only when a loaded mod shipped a valid cutscene.json. While
 	// true, callers should use ONLY this system for the four slots below
 	// and must not fall back to cutscene.lst/scene ids for them.
 	bool modCutscene_isActive();

--- a/TheForceEngine/TFE_DarkForces/Remaster/remasterCutscenes.cpp
+++ b/TheForceEngine/TFE_DarkForces/Remaster/remasterCutscenes.cpp
@@ -377,22 +377,9 @@ namespace TFE_DarkForces
 		return s_available;
 	}
 
-	// ------------------------------------------------------------------
-	// Per-scene lookups
-	// ------------------------------------------------------------------
-	//
-	// Each returns a pointer to one of our static buffers, or nullptr on
-	// miss. These are called per-frame at the start of a cutscene (not
-	// inside the hot loop), so performance isn't critical; readability
-	// wins.
-
-	const char* remasterCutscenes_getVideoPath(const CutsceneState* scene)
+	// Load the cutscene path using the path string instead of scene
+	const char* remasterCutscenes_getVideoPathFromBasename(string baseName)
 	{
-		if (!s_available || !scene) { return nullptr; }
-
-		std::string baseName = sceneBaseName(scene);
-		if (baseName.empty()) { return nullptr; }
-
 		// Try the language-specific variant first. The remaster only
 		// localizes videos that have baked-in text (notably logo.ogv
 		// which shows opening credits in English / German / etc.). Most
@@ -413,6 +400,24 @@ namespace TFE_DarkForces
 		// No OGV for this scene. The caller will fall back to the LFD
 		// FILM path.
 		return nullptr;
+	}
+
+	// ------------------------------------------------------------------
+	// Per-scene lookups
+	// ------------------------------------------------------------------
+	//
+	// Each returns a pointer to one of our static buffers, or nullptr on
+	// miss. These are called per-frame at the start of a cutscene (not
+	// inside the hot loop), so performance isn't critical; readability
+	// wins.
+
+	const char* remasterCutscenes_getVideoPath(const CutsceneState* scene)
+	{
+		if (!s_available || !scene) { return nullptr; }
+
+		std::string baseName = sceneBaseName(scene);
+		if (baseName.empty()) { return nullptr; }
+		return remasterCutscenes_getVideoPathFromBasename(baseName);
 	}
 
 	const char* remasterCutscenes_getDcssPath(const CutsceneState* scene)

--- a/TheForceEngine/TFE_DarkForces/Remaster/remasterCutscenes.h
+++ b/TheForceEngine/TFE_DarkForces/Remaster/remasterCutscenes.h
@@ -26,6 +26,7 @@
 // multiple scenes, so scene name is the right key.
 //
 #include <TFE_System/types.h>
+#include <string>
 
 struct CutsceneState;
 
@@ -42,6 +43,7 @@ namespace TFE_DarkForces
 	// Returns a pointer to a static buffer containing the path, or nullptr
 	// if the file doesn't exist. The buffer is reused across calls, so
 	// don't hold the pointer past the next lookup.
+	const char* remasterCutscenes_getVideoPathFromBasename(std::string baseName);
 	const char* remasterCutscenes_getVideoPath(const CutsceneState* scene);
 	const char* remasterCutscenes_getDcssPath(const CutsceneState* scene);
 	const char* remasterCutscenes_getSubtitlePath(const CutsceneState* scene);

--- a/TheForceEngine/TFE_DarkForces/darkForcesMain.cpp
+++ b/TheForceEngine/TFE_DarkForces/darkForcesMain.cpp
@@ -583,7 +583,7 @@ namespace TFE_DarkForces
 
 			if (s_runGameState.cutscenesEnabled && !s_runGameState.startLevel)
 			{
-				// If running a mod from cutscene.txt don't load LFD scenes
+				// If running a mod from cutscene.json don't load LFD scenes
 				// Just play the mod's intro video instead.
 				if (modCutscene_isActive())
 				{

--- a/TheForceEngine/TFE_DarkForces/darkForcesMain.cpp
+++ b/TheForceEngine/TFE_DarkForces/darkForcesMain.cpp
@@ -25,6 +25,7 @@
 #include "Landru/lsystem.h"
 #include "Landru/lmusic.h"
 #include "Landru/cutscene_film.h"
+#include "Landru/modCutscene.h"
 #include <TFE_DarkForces/Landru/cutscene.h>
 #include <TFE_DarkForces/Landru/cutsceneList.h>
 #include <TFE_DarkForces/Actor/actor.h>
@@ -575,7 +576,6 @@ namespace TFE_DarkForces
 			s_runGameState.state = GSTATE_CUTSCENE;
 			s_invalidLevelIndex = JTRUE;
 
-			// Always force cutscenes off for demo playbac for cutscenes. 
 			if (isDemoPlayback())
 			{
 				s_runGameState.cutscenesEnabled = JFALSE;
@@ -583,7 +583,16 @@ namespace TFE_DarkForces
 
 			if (s_runGameState.cutscenesEnabled && !s_runGameState.startLevel)
 			{
-				cutscene_play(10);
+				// If running a mod from cutscene.txt don't load LFD scenes
+				// Just play the mod's intro video instead.
+				if (modCutscene_isActive())
+				{
+					cutscene_playVideoFile(modCutscene_getGameIntro());
+				}
+				else
+				{
+					cutscene_play(10);
+				}
 			}
 			else
 			{
@@ -767,7 +776,42 @@ namespace TFE_DarkForces
 		} break;
 		case GMODE_CUTSCENE:
 		{
-			if (s_runGameState.cutscenesEnabled && cutscene_play(s_cutsceneData[s_runGameState.cutsceneIndex].cutscene))
+			JBool started = JFALSE;
+			if (s_runGameState.cutscenesEnabled)
+			{
+				// Play a mod cutscene in OGV format
+				if (modCutscene_isActive())
+				{
+					inputMapping_removeState(IADF_MENU_TOGGLE);
+					GameMode nextMode = s_cutsceneData[s_runGameState.cutsceneIndex + 1].nextGameMode;
+					const char* levelName = agent_getLevelName();
+
+					const char* baseName;
+
+					// Figure out which cutscene to play, mission intro/outro or game outro					
+					if (nextMode == GMODE_END)
+					{
+						baseName = modCutscene_getGameOutro();
+					}
+					else if (nextMode == GMODE_BRIEFING)
+					{						
+						baseName = modCutscene_getMissionIntro(levelName);
+					}
+					else
+					{
+						baseName = modCutscene_getMissionOutro(levelName);
+					}
+
+					started = cutscene_playVideoFile(baseName);
+				}
+				else
+				{
+					// Fall back to LFD cutscenes
+					started = cutscene_play(s_cutsceneData[s_runGameState.cutsceneIndex].cutscene);
+				}
+			}
+
+			if (started)
 			{
 				s_runGameState.state = GSTATE_CUTSCENE;
 			}
@@ -863,6 +907,7 @@ namespace TFE_DarkForces
 	{
 		s_sharedState.customGobName[0] = 0;
 		TFE_Settings::clearModSettings();
+		modCutscene_clear();
 
 		for (s32 i = 0; i < argCount; i++)
 		{
@@ -930,6 +975,11 @@ namespace TFE_DarkForces
 	bool getCutscenesEnabled()
 	{
 		return s_runGameState.cutscenesEnabled;
+	}
+
+	bool df_isCustomModLoaded()
+	{
+		return s_sharedState.customGobName[0] != 0;
 	}
 
 	void setInitialLevel(const char* levelName)
@@ -1325,6 +1375,7 @@ namespace TFE_DarkForces
 		}
 
 		TFE_Settings::loadCustomModSettings();
+		modCutscene_init();
 	}
 
 	s32 loadLocalMessages()

--- a/TheForceEngine/TFE_DarkForces/darkForcesMain.h
+++ b/TheForceEngine/TFE_DarkForces/darkForcesMain.h
@@ -29,5 +29,6 @@ namespace TFE_DarkForces
 	extern void saveLevelStatus();
 	void enableCutscenes(JBool enable);
 	bool getCutscenesEnabled();
+	bool df_isCustomModLoaded();
 	void startMissionFromSave(s32 levelIndex);
 }

--- a/TheForceEngine/TFE_DarkForces/mission.cpp
+++ b/TheForceEngine/TFE_DarkForces/mission.cpp
@@ -556,7 +556,7 @@ namespace TFE_DarkForces
 			vfb_swap();
 		}
 	}
-				
+
 	void mission_mainTaskFunc(MessageType msg)
 	{
 		task_begin;
@@ -578,7 +578,7 @@ namespace TFE_DarkForces
 			// Grab the current framebuffer in case in changed.
 			s_framebuffer = vfb_getCpuBuffer();
 			TFE_Jedi::beginRender();
-						
+
 			// Handle delta time.
 			if (!TFE_Settings::getGraphicsSettings()->useSmoothDeltaTime)
 			{
@@ -595,7 +595,7 @@ namespace TFE_DarkForces
 			s_prevTick  = s_curTick;
 			s_prevTickFract = s_curTickFract;
 			s_playerTick = s_curTick;
-						
+
 			if (!escapeMenu_isOpen() && !pda_isOpen() && !cutscene_isPlaying())
 			{
 				player_setupCamera();
@@ -629,9 +629,16 @@ namespace TFE_DarkForces
 					// exactly where it left off.
 					mission_pause(JFALSE);
 					TFE_MidiPlayer::resume();
+
+					// TFE: If the cutscene was ended/skipped via the Escape key,
+					// the same key press was already latched this frame as the
+					// IADF_MENU_TOGGLE action (mapped to Escape by default).
+					// Clear it here so the escape menu doesn't immediately pop
+					// open right after the cutscene closes.
+					inputMapping_removeState(IADF_MENU_TOGGLE);
 				}
 			}
-						
+
 			if (!escapeMenu_isOpen() && !pda_isOpen() && !cutscene_isPlaying())
 			{
 				handleGeneralInput();
@@ -650,7 +657,7 @@ namespace TFE_DarkForces
 				Vec3f palFxGpu = { 0 };
 				TFE_Jedi::renderer_setPalFx(&lumMaskGpu, &palFxGpu);
 			}
-			
+
 			// Move this out of handleGeneralInput so that the HUD is properly copied.			
 			if (escapeMenu_isOpen() && !cutscene_isPlaying())
 			{
@@ -744,7 +751,7 @@ namespace TFE_DarkForces
 			sector_changeGlobalLightLevel();
 		}
 	}
-	
+
 	// Convert the palette to 32 bit color and then send to the render backend.
 	// This is functionally similar to loading the palette into VGA registers.
 	void setPalette(u8* pal)
@@ -759,7 +766,7 @@ namespace TFE_DarkForces
 		}
 		vfb_setPalette(palette);
 	}
-				
+
 	void blitLoadingScreen()
 	{
 		// Moddable loading screen
@@ -780,7 +787,7 @@ namespace TFE_DarkForces
 		{
 			s_loadScreen = s_defaultLoadScreen;
 		}
-		
+
 		if (!s_loadScreen) { return; }
 		blitTextureToScreen(s_loadScreen, (DrawRect*)vfb_getScreenRect(VFB_RECT_UI), 0/*x0*/, 0/*y0*/, s_framebuffer, JFALSE, JTRUE);
 	}
@@ -825,7 +832,7 @@ namespace TFE_DarkForces
 		s_cheatInputCount = 0;
 		s_queuedCheatID = CHEAT_NONE;
 	}
-		
+
 	void setScreenBrightness(fixed16_16 brightness)
 	{
 		if (brightness != s_screenBrightness)
@@ -856,7 +863,7 @@ namespace TFE_DarkForces
 			s_lumMaskChanged = JTRUE;
 		}
 	}
-		
+
 	void handlePaletteFx()
 	{
 		JBool useFramePal   = JFALSE;
@@ -1026,7 +1033,7 @@ namespace TFE_DarkForces
 		s_flatLighting = JFALSE;
 		s_visionFxEndCountdown = 3;
 	}
-		
+
 	void disableNightVision()
 	{
 		disableNightVisionInternal();
@@ -1066,7 +1073,7 @@ namespace TFE_DarkForces
 		s_wearingCleats = JTRUE;
 		hud_sendTextMessage(22);
 	}
-		
+
 	void disableMask()
 	{
 		if (!s_wearingGasmask)
@@ -1132,7 +1139,7 @@ namespace TFE_DarkForces
 		pickupSupercharge();
 		hud_sendTextMessage(701);
 	}
-	
+
 	void cheat_toggleData()
 	{
 		hud_toggleDataDisplay();
@@ -1306,7 +1313,7 @@ namespace TFE_DarkForces
 			} break;
 		}
 	}
-		
+
 	void handleBufferedInput()
 	{
 		const char* bufferedText = TFE_Input::getBufferedText();

--- a/TheForceEngine/TheForceEngine.vcxproj
+++ b/TheForceEngine/TheForceEngine.vcxproj
@@ -414,6 +414,7 @@ echo ^)";
     <ClInclude Include="TFE_DarkForces\hud.h" />
     <ClInclude Include="TFE_DarkForces\item.h" />
     <ClInclude Include="TFE_DarkForces\Landru\cutscene.h" />
+	<ClInclude Include="TFE_DarkForces\Landru\modcutscene.h" />
     <ClInclude Include="TFE_DarkForces\Landru\cutsceneList.h" />
     <ClInclude Include="TFE_DarkForces\Landru\cutscene_film.h" />
     <ClInclude Include="TFE_DarkForces\Landru\cutscene_player.h" />
@@ -838,6 +839,7 @@ echo ^)";
     <ClCompile Include="TFE_DarkForces\hud.cpp" />
     <ClCompile Include="TFE_DarkForces\item.cpp" />
     <ClCompile Include="TFE_DarkForces\Landru\cutscene.cpp" />
+	<ClCompile Include="TFE_DarkForces\Landru\modcutscene.cpp" />
     <ClCompile Include="TFE_DarkForces\Landru\cutsceneList.cpp" />
     <ClCompile Include="TFE_DarkForces\Landru\cutscene_film.cpp" />
     <ClCompile Include="TFE_DarkForces\Landru\cutscene_player.cpp" />

--- a/TheForceEngine/TheForceEngine.vcxproj.filters
+++ b/TheForceEngine/TheForceEngine.vcxproj.filters
@@ -802,6 +802,9 @@
     <ClInclude Include="TFE_DarkForces\Landru\cutscene.h">
       <Filter>Source\TFE_DarkForces\Landru</Filter>
     </ClInclude>
+    <ClInclude Include="TFE_DarkForces\Landru\modcutscene.h">
+      <Filter>Source\TFE_DarkForces\Landru</Filter>
+    </ClInclude>	
     <ClInclude Include="TFE_DarkForces\Landru\cutscene_film.h">
       <Filter>Source\TFE_DarkForces\Landru</Filter>
     </ClInclude>
@@ -2019,6 +2022,9 @@
     <ClCompile Include="TFE_DarkForces\Landru\cutscene.cpp">
       <Filter>Source\TFE_DarkForces\Landru</Filter>
     </ClCompile>
+	<ClCompile Include="TFE_DarkForces\Landru\modcutscene.cpp">
+      <Filter>Source\TFE_DarkForces\Landru</Filter>
+    </ClCompile>	
     <ClCompile Include="TFE_DarkForces\Landru\cutscene_film.cpp">
       <Filter>Source\TFE_DarkForces\Landru</Filter>
     </ClCompile>


### PR DESCRIPTION
You should now be able to control cutscenes through cutscene.txt. It's controlled by intro/outro per mission and also for the entire game. 

Ex:
```
{
  "game": {
    "intro": "logo",
    "outro": "arcfly"
  },
  "secbase": {
    "intro": "kflyby",
    "outro": "sw_cooking"
  },
  "talay": {
    "intro": "jabescp",
  },
  "sewers": {
    "outro": "gromas1"
  }
}
```