### PR TITLE
Adding POSIX requirement for building on MacOS

### DIFF
--- a/TheForceEngine/TFE_System/system.cpp
+++ b/TheForceEngine/TFE_System/system.cpp
@@ -19,7 +19,7 @@
 #include <synchapi.h>
 #undef min
 #undef max
-#elif defined __linux__
+#elif defined __linux__ || defined __APPLE__
 #include <sys/types.h>
 #include <unistd.h>
 #include <sys/wait.h>


### PR DESCRIPTION
TO get it to build in MACOS I had to add a POSIX requirment for __APPLE__, it built after this just fine. Before It would not finish the build.