### PR TITLE
Undo / redo for level INF data

### DIFF
--- a/TheForceEngine/TFE_Editor/LevelEditor/levelDataSnapshot.cpp
+++ b/TheForceEngine/TFE_Editor/LevelEditor/levelDataSnapshot.cpp
@@ -2,6 +2,7 @@
 #include "levelDataSnapshot.h"
 #include "sharedState.h"
 #include "guidelines.h"
+#include "levelEditorInf.h"
 #include <TFE_Editor/snapshotReaderWriter.h>
 #include <TFE_Editor/history.h>
 #include <TFE_Editor/errorMessages.h>
@@ -205,6 +206,135 @@ namespace LevelEditor
 		writeData(guideline->offsets.data(), sizeof(f32) * offsetCount);
 	}
 
+	void writeInfElevatorToSnapshot(const Editor_InfElevator* infElevator)
+	{
+		const s32 slaveCount = (s32)infElevator->slaves.size();
+		const s32 stopCount = (s32)infElevator->stops.size();
+
+		writeU32(infElevator->classId);
+		writeU32(infElevator->type);
+		writeU32(infElevator->overrideSet);
+		writeS32(infElevator->start);
+		writeF32(infElevator->speed);
+		writeF32(infElevator->angle);
+		writeU32(infElevator->flags);
+		writeData(infElevator->key, sizeof(KeyItem) * 2);
+		writeData(&infElevator->center, sizeof(Vec2f));
+		writeString(infElevator->sounds[0]);
+		writeString(infElevator->sounds[1]);
+		writeString(infElevator->sounds[2]);
+		writeU8(infElevator->master);
+		writeS32(infElevator->eventMask);
+		writeS32(infElevator->entityMask);
+		writeS32(slaveCount);
+		writeS32(stopCount);
+
+		// Each slave & stop is of variable length
+		for (s32 i = 0; i < slaveCount; i++)
+		{
+			writeString(infElevator->slaves[i].name);
+			writeF32(infElevator->slaves[i].angleOffset);
+		}
+
+		for (s32 i = 0; i < stopCount; i++)
+		{
+			const s32 adjoinCount = (s32)infElevator->stops[i].adjoinCmd.size();
+			const s32 textureCount = (s32)infElevator->stops[i].textureCmd.size();
+			const s32 messageCount = (s32)infElevator->stops[i].msg.size();
+			const s32 scriptCount = (s32)infElevator->stops[i].scriptCall.size();
+			writeU32(infElevator->stops[i].overrideSet);
+			writeU8(infElevator->stops[i].relative);
+			writeF32(infElevator->stops[i].value);
+			writeString(infElevator->stops[i].fromSectorFloor);
+			writeU32(infElevator->stops[i].delayType);
+			writeF32(infElevator->stops[i].delay);
+			writeString(infElevator->stops[i].page);
+			writeS32(adjoinCount);
+			writeS32(textureCount);
+			writeS32(messageCount);
+			writeS32(scriptCount);
+			for (s32 j = 0; j < adjoinCount; j++)
+			{
+				writeString(infElevator->stops[i].adjoinCmd[j].sector0);
+				writeString(infElevator->stops[i].adjoinCmd[j].sector1);
+				writeS32(infElevator->stops[i].adjoinCmd[j].wallIndex0);
+				writeS32(infElevator->stops[i].adjoinCmd[j].wallIndex1);
+			}
+			for (s32 j = 0; j < textureCount; j++)
+			{
+				writeString(infElevator->stops[i].textureCmd[j].donorSector);
+				writeU8(infElevator->stops[i].textureCmd[j].fromCeiling);
+			}
+			for (s32 j = 0; j < messageCount; j++)
+			{
+				writeString(infElevator->stops[i].msg[j].targetSector);
+				writeS32(infElevator->stops[i].msg[j].targetWall);
+				writeU32(infElevator->stops[i].msg[j].type);
+				writeU32(infElevator->stops[i].msg[j].eventFlags);
+				writeU32(infElevator->stops[i].msg[j].arg[0]);
+				writeU32(infElevator->stops[i].msg[j].arg[1]);
+			}
+			for (s32 j = 0; j < scriptCount; j++)
+			{
+				writeString(infElevator->stops[i].scriptCall[j].funcName);
+				writeString(infElevator->stops[i].scriptCall[j].arg[0].value);
+				writeString(infElevator->stops[i].scriptCall[j].arg[1].value);
+				writeString(infElevator->stops[i].scriptCall[j].arg[2].value);
+				writeString(infElevator->stops[i].scriptCall[j].arg[3].value);
+			}
+		}
+	}
+
+	void writeInfTriggerToSnapshot(const Editor_InfTrigger* infTrigger)
+	{
+		writeU32(infTrigger->classId);
+		writeU32(infTrigger->type);
+		writeU32(infTrigger->overrideSet);
+		const s32 clientCount = (s32)infTrigger->clients.size();
+		writeS32(clientCount);
+		for (s32 i = 0; i < clientCount; i++)
+		{
+			writeString(infTrigger->clients[i].targetSector);
+			writeS32(infTrigger->clients[i].targetWall);
+			writeS32(infTrigger->clients[i].eventMask);
+		}
+		writeU32(infTrigger->cmd);
+		writeData(&infTrigger->arg, sizeof(u32) * 2);
+		writeString(infTrigger->sound);
+		writeU8(infTrigger->master);
+		writeU32(infTrigger->textId);
+		writeS32(infTrigger->eventMask);
+		writeS32(infTrigger->entityMask);
+		writeU32(infTrigger->event);
+	}
+
+	void writeInfTeleporterToSnapshot(const Editor_InfTeleporter* infTeleporter)
+	{
+		writeU32(infTeleporter->classId);
+		writeU32(infTeleporter->type);
+		writeString(infTeleporter->target);
+		writeData(&infTeleporter->dstPos, sizeof(Vec3f));
+		writeF32(infTeleporter->dstAngle);
+	}
+
+	void writeInfItemToSnapshot(const Editor_InfItem* infItem)
+	{
+		const s32 classCount = (s32)infItem->classData.size();
+
+		writeString(infItem->name);
+		writeS32(infItem->wallNum);
+		writeS32(classCount);
+		for (s32 i = 0; i < classCount; i++)
+		{
+			// classData are ptrs to heap data. Store the index for snapshotting, ref new ptr addresses when unpacking.
+			Editor_InfClass* classPtr = infItem->classData[i];
+			s32 classIndex = getClassIndex(classPtr->classId, classPtr);
+			assert(classIndex >= 0);
+			writeU32(infItem->classData[i]->classId);
+			writeS32(classIndex);
+		}
+	}
+
 	void readEntityFromSnapshot(Entity* entity)
 	{
 		entity->id = readS32();
@@ -302,5 +432,123 @@ namespace LevelEditor
 		readData(guideline->offsets.data(), sizeof(f32) * offsetCount);
 
 		guideline_computeSubdivision(guideline);
+	}
+
+	void readInfItemFromSnapshot(Editor_InfItem* infItem)
+	{
+		readString(infItem->name);
+		infItem->wallNum = readS32();
+		s32 classCount = readS32();
+		infItem->classData.resize(classCount);
+	}
+
+	void readInfElevatorFromSnapshot(Editor_InfElevator* infElevator)
+	{
+		infElevator->classId = (Editor_InfItemClass)readU32();
+		infElevator->type = (Editor_InfElevType)readU32();
+		infElevator->overrideSet = (Editor_InfElevatorOverride)readU32();
+		infElevator->start = readS32();
+		infElevator->speed = readF32();
+		infElevator->angle = readF32();
+		infElevator->flags = readU32();
+		readData(infElevator->key, sizeof(KeyItem) * 2);
+		readData(&infElevator->center, sizeof(Vec2f));
+		readString(infElevator->sounds[0]);
+		readString(infElevator->sounds[1]);
+		readString(infElevator->sounds[2]);
+		infElevator->master = (bool)readU8();
+		infElevator->eventMask = readS32();
+		infElevator->entityMask = readS32();
+		const s32 slaveCount = readS32();
+		const s32 stopCount = readS32();
+		infElevator->slaves.resize(slaveCount);
+		infElevator->stops.resize(stopCount);
+		
+		// Each slave & stop is of variable length
+		for (s32 i = 0; i < slaveCount; i++)
+		{
+			readString(infElevator->slaves[i].name);
+			infElevator->slaves[i].angleOffset = readF32();
+		}
+
+		for (s32 i = 0; i < stopCount; i++)
+		{
+			infElevator->stops[i].overrideSet = readU32();
+			infElevator->stops[i].relative = (bool)readU8();
+			infElevator->stops[i].value = readF32();
+			readString(infElevator->stops[i].fromSectorFloor);
+			infElevator->stops[i].delayType = (Editor_InfStopDelayType)readU32();
+			infElevator->stops[i].delay = readF32();
+			readString(infElevator->stops[i].page);
+			const s32 adjoinCount = readS32();
+			const s32 textureCount = readS32();
+			const s32 messageCount = readS32();
+			const s32 scriptCount = readS32();
+			infElevator->stops[i].adjoinCmd.resize(adjoinCount);
+			infElevator->stops[i].textureCmd.resize(textureCount);
+			infElevator->stops[i].msg.resize(messageCount);
+			infElevator->stops[i].scriptCall.resize(scriptCount);
+			for (s32 j = 0; j < adjoinCount; j++)
+			{
+				readString(infElevator->stops[i].adjoinCmd[j].sector0);
+				readString(infElevator->stops[i].adjoinCmd[j].sector1);
+				infElevator->stops[i].adjoinCmd[j].wallIndex0 = readS32();
+				infElevator->stops[i].adjoinCmd[j].wallIndex1 = readS32();
+			}
+			for (s32 j = 0; j < textureCount; j++)
+			{
+				readString(infElevator->stops[i].textureCmd[j].donorSector);
+				infElevator->stops[i].textureCmd[j].fromCeiling = (bool)readU8();
+			}
+			for (s32 j = 0; j < messageCount; j++)
+			{
+				readString(infElevator->stops[i].msg[j].targetSector);
+				infElevator->stops[i].msg[j].targetWall = readS32();
+				infElevator->stops[i].msg[j].type = (Editor_InfMessageType)readU32();
+				infElevator->stops[i].msg[j].eventFlags = readU32();
+				infElevator->stops[i].msg[j].arg[0] = readU32();
+				infElevator->stops[i].msg[j].arg[1] = readU32();
+			}
+			for (s32 j = 0; j < scriptCount; j++)
+			{
+				readString(infElevator->stops[i].scriptCall[j].funcName);
+				readString(infElevator->stops[i].scriptCall[j].arg[0].value);
+				readString(infElevator->stops[i].scriptCall[j].arg[1].value);
+				readString(infElevator->stops[i].scriptCall[j].arg[2].value);
+				readString(infElevator->stops[i].scriptCall[j].arg[3].value);
+			}
+		}
+	}
+
+	void readInfTriggerFromSnapshot(Editor_InfTrigger* infTrigger)
+	{
+		infTrigger->classId = (Editor_InfItemClass)readU32();
+		infTrigger->type = (TriggerType)readU32();
+		infTrigger->overrideSet = readU32();
+		const s32 clientCount = readS32();
+		infTrigger->clients.resize(clientCount);
+		for (s32 i = 0; i < clientCount; i++)
+		{
+			readString(infTrigger->clients[i].targetSector);
+			infTrigger->clients[i].targetWall = readS32();
+			infTrigger->clients[i].eventMask = readS32();
+		}
+		infTrigger->cmd = (Editor_InfMessageType)readU32();
+		readData(&infTrigger->arg, sizeof(u32) * 2);
+		readString(infTrigger->sound);
+		infTrigger->master = (bool)readU8();
+		infTrigger->textId = readU32();
+		infTrigger->eventMask = readS32();
+		infTrigger->entityMask = readS32();
+		infTrigger->event = readU32();
+	}
+
+	void readInfTeleporterFromSnapshot(Editor_InfTeleporter* infTeleporter)
+	{
+		infTeleporter->classId = (Editor_InfItemClass)readU32();
+		infTeleporter->type = (TeleportType)readU32();
+		readString(infTeleporter->target);
+		readData(&infTeleporter->dstPos, sizeof(Vec3f));
+		infTeleporter->dstAngle = readF32();
 	}
 }

--- a/TheForceEngine/TFE_Editor/LevelEditor/levelDataSnapshot.h
+++ b/TheForceEngine/TFE_Editor/LevelEditor/levelDataSnapshot.h
@@ -10,6 +10,7 @@
 #include "entity.h"
 #include "groups.h"
 #include "note.h"
+#include "levelEditorInf.h"
 #include <TFE_Editor/EditorAsset/editorAsset.h>
 #include <TFE_Editor/EditorAsset/editorTexture.h>
 #include <TFE_Editor/editorProject.h>
@@ -39,10 +40,18 @@ namespace LevelEditor
 	void writeSectorAttribSnapshot(const EditorSector* sector);
 	void writeLevelNoteToSnapshot(const LevelNote* note);
 	void writeGuidelineToSnapshot(const Guideline* guideline);
+	void writeInfElevatorToSnapshot(const Editor_InfElevator* infElevator);
+	void writeInfTriggerToSnapshot(const Editor_InfTrigger* infTrigger);
+	void writeInfTeleporterToSnapshot(const Editor_InfTeleporter* infTeleporter);
+	void writeInfItemToSnapshot(const Editor_InfItem* infItem);
 
 	void readEntityFromSnapshot(Entity* entity);
 	void readSectorFromSnapshot(EditorSector* sector);
 	void readFromSectorAttribSnapshot(EditorSector* sector);
 	void readLevelNoteFromSnapshot(LevelNote* note);
 	void readGuidelineFromSnapshot(Guideline* guideline);
+	void readInfElevatorFromSnapshot(Editor_InfElevator* infElevator);
+	void readInfTriggerFromSnapshot(Editor_InfTrigger* infTrigger);
+	void readInfTeleporterFromSnapshot(Editor_InfTeleporter* infTeleporter);
+	void readInfItemFromSnapshot(Editor_InfItem* infItem);
 }

--- a/TheForceEngine/TFE_Editor/LevelEditor/levelEditor.cpp
+++ b/TheForceEngine/TFE_Editor/LevelEditor/levelEditor.cpp
@@ -2502,10 +2502,12 @@ namespace LevelEditor
 	{
 		if (isShortcutPressed(SHORTCUT_UNDO))
 		{
+			if (isPopupOpen()) return; // Avoid problems with INF UI
 			levHistory_undo();
 		}
 		else if (isShortcutPressed(SHORTCUT_REDO))
 		{
+			if (isPopupOpen()) return; // Avoid problems with INF UI
 			levHistory_redo();
 		}
 		if (isShortcutPressed(SHORTCUT_SHOW_ALL_LABELS))

--- a/TheForceEngine/TFE_Editor/LevelEditor/levelEditorData.cpp
+++ b/TheForceEngine/TFE_Editor/LevelEditor/levelEditorData.cpp
@@ -98,6 +98,7 @@ namespace LevelEditor
 
 	static s32 s_curSnapshotId = -1;
 	static EditorLevel s_curSnapshot;
+	static Editor_LevelInf s_infSnapshot;
 
 	EditorLevel s_level = {};
 
@@ -5098,7 +5099,158 @@ namespace LevelEditor
 			sector->ceilTex = attrib.ceilTex;
 		}
 	}
-		
+
+	void clearInfData(Editor_LevelInf* levelInf)
+	{
+		for (size_t i = 0; i < levelInf->elevator.size(); i++)
+		{
+			delete levelInf->elevator[i];
+		}
+
+		for (size_t i = 0; i < levelInf->trigger.size(); i++)
+		{
+			delete levelInf->trigger[i];
+		}
+
+		for (size_t i = 0; i < levelInf->teleport.size(); i++)
+		{
+			delete levelInf->teleport[i];
+		}
+
+		levelInf->item.clear();
+		levelInf->elevator.clear();
+		levelInf->trigger.clear();
+		levelInf->teleport.clear();
+	}
+
+	// Reimplemention of getClassIndex() for the snapshot
+	s32 getClassIndexSnapshot(Editor_InfItemClass classId, const void* classPtr)
+	{
+		s32 index = -1;
+		if (classId == IIC_ELEVATOR)
+		{
+			const s32 count = (s32)s_infSnapshot.elevator.size();
+			const Editor_InfElevator* const* list = s_infSnapshot.elevator.data();
+			for (s32 i = 0; i < count; i++)
+			{
+				if (classPtr == list[i])
+				{
+					index = i;
+					break;
+				}
+			}
+		}
+		else if (classId == IIC_TRIGGER)
+		{
+			const s32 count = (s32)s_infSnapshot.trigger.size();
+			const Editor_InfTrigger* const* list = s_infSnapshot.trigger.data();
+			for (s32 i = 0; i < count; i++)
+			{
+				if (classPtr == list[i])
+				{
+					index = i;
+					break;
+				}
+			}
+		}
+		else if (classId == IIC_TELEPORTER)
+		{
+			const s32 count = (s32)s_infSnapshot.teleport.size();
+			const Editor_InfTeleporter* const* list = s_infSnapshot.teleport.data();
+			for (s32 i = 0; i < count; i++)
+			{
+				if (classPtr == list[i])
+				{
+					index = i;
+					break;
+				}
+			}
+		}
+		assert(index >= 0);
+		return index;
+	}
+
+	void copyInfData(Editor_LevelInf* infFrom, Editor_LevelInf* infTo)
+	{
+		clearInfData(infTo);
+
+		size_t elevCount = infFrom->elevator.size();
+		infTo->elevator.resize(elevCount);
+		Editor_InfElevator* elevFrom;
+		Editor_InfElevator* elevTo;
+		for (size_t i = 0; i < elevCount; i++)
+		{
+			// Create new object, assign the pointer then copy struct data
+			elevFrom = infFrom->elevator[i];
+			elevTo = new Editor_InfElevator();
+			infTo->elevator[i] = elevTo;
+			*elevTo = *elevFrom; // Copy the struct, not the pointer
+		}
+
+		size_t trigCount = infFrom->trigger.size();
+		infTo->trigger.resize(trigCount);
+		Editor_InfTrigger* trigFrom;
+		Editor_InfTrigger* trigTo;
+		for (size_t i = 0; i < trigCount; i++)
+		{
+			trigFrom = infFrom->trigger[i];
+			trigTo = new Editor_InfTrigger();
+			infTo->trigger[i] = trigTo;
+			*trigTo = *trigFrom;
+		}
+
+		size_t teleCount = infFrom->teleport.size();
+		infTo->teleport.resize(teleCount);
+		Editor_InfTeleporter* teleFrom;
+		Editor_InfTeleporter* teleTo;
+		for (size_t i = 0; i < teleCount; i++)
+		{
+			teleFrom = infFrom->teleport[i];
+			teleTo = new Editor_InfTeleporter();
+			infTo->teleport[i] = teleTo;
+			*teleTo = *teleFrom;
+		}
+
+		// If everything went correctly, the calculated indexes should be 
+		// the same for both source and destination
+		size_t itemCount = infFrom->item.size();
+		infTo->item.resize(itemCount);
+		for (size_t i = 0; i < itemCount; i++)
+		{
+			Editor_InfItem* itemTo = &infTo->item[i];
+			Editor_InfItem* itemFrom = &infFrom->item[i];			
+			itemTo->name = itemFrom->name;
+			itemTo->wallNum = itemFrom->wallNum;
+
+			size_t classCount = itemFrom->classData.size();
+			itemTo->classData.resize(classCount);
+			for (size_t j = 0; j < classCount; j++)
+			{
+				Editor_InfClass* infClass = itemFrom->classData[j];
+				Editor_InfItemClass classId = infClass->classId;
+				if (classId == IIC_ELEVATOR)
+				{
+					s32 index = getClassIndexSnapshot(classId, infClass);
+					itemTo->classData[j] = (Editor_InfClass*)infTo->elevator[index];
+				}
+				else if (classId == IIC_TRIGGER)
+				{
+					s32 index = getClassIndexSnapshot(classId, infClass);
+					itemTo->classData[j] = (Editor_InfClass*)infTo->trigger[index];
+				}
+				else if (classId == IIC_TELEPORTER)
+				{
+					s32 index = getClassIndexSnapshot(classId, infClass);
+					itemTo->classData[j] = (Editor_InfClass*)infTo->teleport[index];
+				}
+				else
+				{
+					assert(0);
+				}
+			}
+		}
+	}
+
 	void level_createSnapshot(SnapshotBuffer* buffer)
 	{
 		assert(buffer);
@@ -5121,6 +5273,7 @@ namespace LevelEditor
 		const u32 entityCount = (u32)s_level.entities.size();
 		const u32 levelNoteCount = (s32)s_level.notes.size();
 		const u32 guidelineCount = (s32)s_level.guidelines.size();
+
 		writeU32(texCount);
 		writeU32(sectorCount);
 		writeU32(entityCount);
@@ -5160,6 +5313,44 @@ namespace LevelEditor
 		for (u32 g = 0; g < guidelineCount; g++, guideline++)
 		{
 			writeGuidelineToSnapshot(guideline);
+		}
+
+		// Inf data.
+		const u32 infElevatorCount = (s32)s_levelInf.elevator.size();
+		const u32 infTriggerCount = (s32)s_levelInf.trigger.size();
+		const u32 infTeleporterCount = (s32)s_levelInf.teleport.size();
+		const u32 infItemCount = (s32)s_levelInf.item.size();
+		writeU32(infElevatorCount);
+		writeU32(infTriggerCount);
+		writeU32(infTeleporterCount);
+		writeU32(infItemCount);
+
+		// Inf Elevators
+		Editor_InfElevator** infElevator = s_levelInf.elevator.data();
+		for (u32 i = 0; i < infElevatorCount; i++, infElevator++)
+		{
+			writeInfElevatorToSnapshot(*infElevator);
+		}
+
+		// Inf Triggers
+		Editor_InfTrigger** infTrigger = s_levelInf.trigger.data();
+		for (u32 i = 0; i < infTriggerCount; i++, infTrigger++)
+		{
+			writeInfTriggerToSnapshot(*infTrigger);
+		}
+
+		// Inf Teleporters
+		Editor_InfTeleporter** infTeleporter = s_levelInf.teleport.data();
+		for (u32 i = 0; i < infTeleporterCount; i++, infTeleporter++)
+		{
+			writeInfTeleporterToSnapshot(*infTeleporter);
+		}
+
+		// Inf Items
+		const Editor_InfItem* infItem = s_levelInf.item.data();
+		for (u32 i = 0; i < infItemCount; i++, infItem++)
+		{
+			writeInfItemToSnapshot(infItem);
 		}
 	}
 
@@ -5237,9 +5428,80 @@ namespace LevelEditor
 			{
 				readGuidelineFromSnapshot(guideline);
 			}
+
+			// Restore Inf data
+			clearInfData(&s_infSnapshot);
+
+			const u32 infElevatorCount = readU32();
+			const u32 infTriggerCount = readU32();
+			const u32 infTeleporterCount = readU32();
+			const u32 infItemCount = readU32();
+
+			// Don't use existing alloc functions as those are tied to s_levelInf.
+			// elevators
+			for (u32 i = 0; i < infElevatorCount; i++)
+			{
+				Editor_InfElevator* elev = new Editor_InfElevator();
+				s_infSnapshot.elevator.push_back(elev);
+				elev->classId = IIC_ELEVATOR;
+				readInfElevatorFromSnapshot(elev);
+			}
+
+			// triggers
+			for (u32 i = 0; i < infTriggerCount; i++)
+			{
+				Editor_InfTrigger* trig = new Editor_InfTrigger();
+				s_infSnapshot.trigger.push_back(trig);
+				trig->classId = IIC_TRIGGER;
+				readInfTriggerFromSnapshot(trig);
+			}
+
+			// teleporters
+			for (u32 i = 0; i < infTeleporterCount; i++)
+			{
+				Editor_InfTeleporter* tele = new Editor_InfTeleporter();
+				s_infSnapshot.teleport.push_back(tele);
+				tele->classId = IIC_TELEPORTER;
+				readInfTeleporterFromSnapshot(tele);
+			}
+
+			// items
+			for (u32 i = 0; i < infItemCount; i++)
+			{
+				Editor_InfItem item;
+				readInfItemFromSnapshot(&item);
+				
+				// the rest of the classData are stored as indexes in the snapshot data.
+				// these need conversion to the memory address, recast as an Editor_InfClass*.
+				for (size_t i = 0; i < item.classData.size(); i++)
+				{
+					Editor_InfItemClass itemClass = (Editor_InfItemClass)readU32();
+					s32 itemIndex = readS32();
+					if (itemClass == IIC_ELEVATOR)
+					{
+						assert((s32)s_infSnapshot.elevator.size() > itemIndex);
+						item.classData[i] = ((Editor_InfClass*)s_infSnapshot.elevator[itemIndex]);
+					}
+					else if (itemClass == IIC_TRIGGER)
+					{
+						assert((s32)s_infSnapshot.trigger.size() > itemIndex);
+						item.classData[i] = ((Editor_InfClass*)s_infSnapshot.trigger[itemIndex]);
+					}
+					else if (itemClass == IIC_TELEPORTER)
+					{
+						assert((s32)s_infSnapshot.teleport.size() > itemIndex);
+						item.classData[i] = ((Editor_InfClass*)s_infSnapshot.teleport[itemIndex]);
+					}
+				}
+				s_infSnapshot.item.push_back(item);
+			}
 		}
+
 		// Then copy the snapshot to the level data itself. Its the new state.
 		s_level = s_curSnapshot;
+
+		// Repopulate the Inf struct
+		copyInfData(&s_infSnapshot, &s_levelInf);
 
 		// For now until the way snapshot memory is handled is refactored, to avoid duplicate code that will be removed later.
 		// TODO: Handle edit state properly here too.

--- a/TheForceEngine/TFE_Editor/LevelEditor/levelEditorData.cpp
+++ b/TheForceEngine/TFE_Editor/LevelEditor/levelEditorData.cpp
@@ -508,10 +508,7 @@ namespace LevelEditor
 	void levelClear()
 	{
 		// Clear the INF data.
-		s_levelInf.item.clear();
-		s_levelInf.elevator.clear();
-		s_levelInf.teleport.clear();
-		s_levelInf.trigger.clear();
+		editor_infDestroy();
 
 		// Clear selection state.
 		selection_clear();
@@ -530,10 +527,7 @@ namespace LevelEditor
 		FileUtil::stripExtension(asset->name.c_str(), slotName);
 
 		// Clear the INF data.
-		s_levelInf.item.clear();
-		s_levelInf.elevator.clear();
-		s_levelInf.teleport.clear();
-		s_levelInf.trigger.clear();
+		editor_infDestroy();
 
 		// Clear selection state.
 		selection_clear();

--- a/TheForceEngine/TFE_Editor/LevelEditor/levelEditorData.cpp
+++ b/TheForceEngine/TFE_Editor/LevelEditor/levelEditorData.cpp
@@ -5586,6 +5586,204 @@ namespace LevelEditor
 		}
 	}
 
+	void level_createInfItemModifySnapshot(SnapshotBuffer* buffer, u32 itemIndex)
+	{
+		setSnapshotWriteBuffer(buffer);
+		
+		Editor_InfItem* infItem = &s_levelInf.item[itemIndex];
+		u32 classCount = (u32)infItem->classData.size();
+		writeU32(itemIndex);
+		writeU32(classCount);
+		s32 deletedSize = (s32)s_infModified.deleteIndexes.size();
+		s32 modifiedSize = (s32)s_infModified.modifiedIndexes.size();
+		s32 newSize = (s32)s_infModified.newIndexes.size();
+		writeS32(deletedSize);
+		writeS32(modifiedSize);
+		writeS32(newSize);
+		writeData(s_infModified.deleteIndexes.data(), deletedSize);
+		writeData(s_infModified.modifiedIndexes.data(), modifiedSize);
+		writeData(s_infModified.newIndexes.data(), newSize);
+
+		for (s32 i = 0; i < modifiedSize; i++)
+		{
+			Editor_InfClass* infClass = infItem->classData[s_infModified.modifiedIndexes[i]];
+			Editor_InfItemClass infItemClass = infClass->classId;
+			writeU32((u32)infItemClass);
+			if (infItemClass == IIC_ELEVATOR)
+			{
+				writeInfElevatorToSnapshot((Editor_InfElevator*)infClass);
+			}
+			else if (infItemClass == IIC_TRIGGER)
+			{
+				writeInfTriggerToSnapshot((Editor_InfTrigger*)infClass);
+			}
+			else if (infItemClass == IIC_TELEPORTER)
+			{
+				writeInfTeleporterToSnapshot((Editor_InfTeleporter*)infClass);
+			}
+		}
+
+		for (s32 i = 0; i < newSize; i++)
+		{
+			Editor_InfClass* infClass = infItem->classData[s_infModified.newIndexes[i]];
+			Editor_InfItemClass infItemClass = infClass->classId;
+			writeU32((u32)infItemClass);
+			if (infItemClass == IIC_ELEVATOR)
+			{
+				writeInfElevatorToSnapshot((Editor_InfElevator*)infClass);
+			}
+			else if (infItemClass == IIC_TRIGGER)
+			{
+				writeInfTriggerToSnapshot((Editor_InfTrigger*)infClass);
+			}
+			else if (infItemClass == IIC_TELEPORTER)
+			{
+				writeInfTeleporterToSnapshot((Editor_InfTeleporter*)infClass);
+			}
+		}
+	}
+
+	void level_unpackInfItemModifySnapshot(u32 size, void* data)
+	{
+		setSnapshotReadBuffer((u8*)data, size);
+
+		const u32 itemIndex = readU32();
+		assert(itemIndex < (u32)s_levelInf.item.size());
+		Editor_InfItem* infItem = &s_levelInf.item[itemIndex];
+		const u32 classCount = readU32();
+
+		const s32 deletedIndexCount = readS32(); // Existing item.classData indexes
+		const s32 modifiedIndexCount = readS32();
+		const s32 newIndexCount = readS32();
+
+		std::vector<s32> deletedIndexes;
+		std::vector<s32> modifiedIndexes;
+		std::vector<s32> newIndexes;
+		deletedIndexes.resize(deletedIndexCount);
+		modifiedIndexes.resize(modifiedIndexCount);
+		newIndexes.resize(newIndexCount);
+		
+		readData(deletedIndexes.data(), deletedIndexCount);
+		readData(modifiedIndexes.data(), modifiedIndexCount);
+		readData(newIndexes.data(), newIndexCount);
+
+		for (s32 i = 0; i < deletedIndexCount; i++) // Assumed to be reverse order
+		{
+			freeInfClass(infItem->classData[deletedIndexes[i]]);
+			for (s32 j = deletedIndexes[i]; j < infItem->classData.size() - 1; j++) // Delete and shuffle back
+			{
+				infItem->classData[j] = infItem->classData[j + 1];
+			}
+			infItem->classData.pop_back();
+		}
+
+		for (s32 i = 0; i < modifiedIndexCount; i++)
+		{
+			Editor_InfItemClass classId = (Editor_InfItemClass)readU32();
+			Editor_InfClass* modifiedClass = infItem->classData[modifiedIndexes[i]];
+			if (classId == IIC_ELEVATOR)
+			{
+				readInfElevatorFromSnapshot((Editor_InfElevator*)modifiedClass);
+			}
+			else if (classId == IIC_TRIGGER)
+			{
+				readInfTriggerFromSnapshot((Editor_InfTrigger*)modifiedClass);
+			}
+			else if (classId == IIC_TELEPORTER)
+			{
+				readInfTeleporterFromSnapshot((Editor_InfTeleporter*)modifiedClass);
+			}
+		}
+
+		for (s32 i = 0; i < newIndexCount; i++)
+		{
+			Editor_InfItemClass classId = (Editor_InfItemClass)readU32();
+			if (classId == IIC_ELEVATOR)
+			{
+				Editor_InfElevator* elev = allocElev(infItem);
+				readInfElevatorFromSnapshot(elev);
+			}
+			else if (classId == IIC_TRIGGER)
+			{
+				Editor_InfTrigger* trig = allocTrigger(infItem);
+				readInfTriggerFromSnapshot(trig);
+			}
+			else if (classId == IIC_TELEPORTER)
+			{
+				Editor_InfTeleporter* tele = allocTeleporter(infItem);
+				readInfTeleporterFromSnapshot(tele);
+			}
+		}
+	}
+
+	void level_createInfItemSnapshot(SnapshotBuffer* buffer)
+	{
+		setSnapshotWriteBuffer(buffer);
+		Editor_InfItem* newItem = &s_levelInf.item.back();
+		u32 classCount = (u32)newItem->classData.size();
+		writeString(newItem->name);
+		writeS32(newItem->wallNum);
+		writeU32(classCount);
+		for (u32 i = 0; i < classCount; i++)
+		{
+			Editor_InfClass* itemClass = newItem->classData[i];
+			if (itemClass->classId == IIC_ELEVATOR)
+			{
+				writeU32(IIC_ELEVATOR);
+				writeInfElevatorToSnapshot((Editor_InfElevator*)itemClass);
+			}
+			else if (itemClass->classId == IIC_TRIGGER)
+			{
+				writeU32(IIC_TRIGGER);
+				writeInfTriggerToSnapshot((Editor_InfTrigger*)itemClass);
+			}
+			else if (itemClass->classId == IIC_TELEPORTER)
+			{
+				writeU32(IIC_TELEPORTER);
+				writeInfTeleporterToSnapshot((Editor_InfTeleporter*)itemClass);
+			}
+		}
+	}
+
+	void level_unpackCreateInfSnapshot(u32 size, void* data)
+	{
+		setSnapshotReadBuffer((u8*)data, size);
+		s_levelInf.item.push_back({});
+		Editor_InfItem* infItem = &s_levelInf.item.back();
+		readString(infItem->name);
+		infItem->wallNum = readS32();
+		const u32 classCount = readU32();
+
+		for (u32 i = 0; i < classCount; i++)
+		{
+			Editor_InfItemClass itemClass = (Editor_InfItemClass)readU32();
+			if (itemClass == IIC_ELEVATOR)
+			{
+				Editor_InfElevator* infElevator = new Editor_InfElevator();
+				s_levelInf.elevator.push_back(infElevator);
+				infElevator->classId = IIC_ELEVATOR;
+				readInfElevatorFromSnapshot(infElevator);
+				infItem->classData.push_back((Editor_InfClass*)infElevator);
+			}
+			else if (itemClass == IIC_TRIGGER)
+			{
+				Editor_InfTrigger* infTrigger = new Editor_InfTrigger();
+				s_levelInf.trigger.push_back(infTrigger);
+				infTrigger->classId = IIC_TRIGGER;
+				readInfTriggerFromSnapshot(infTrigger);
+				infItem->classData.push_back((Editor_InfClass*)infTrigger);
+			}
+			else if (itemClass == IIC_TELEPORTER)
+			{
+				Editor_InfTeleporter* infTeleporter = new Editor_InfTeleporter();
+				s_levelInf.teleport.push_back(infTeleporter);
+				infTeleporter->classId = IIC_TELEPORTER;
+				readInfTeleporterFromSnapshot(infTeleporter);
+				infItem->classData.push_back((Editor_InfClass*)infTeleporter);
+			}
+		}
+	}
+
 	// Find a sector based on DF rules.
 	EditorSector* findSectorDf(const Vec3f pos)
 	{

--- a/TheForceEngine/TFE_Editor/LevelEditor/levelEditorData.cpp
+++ b/TheForceEngine/TFE_Editor/LevelEditor/levelEditorData.cpp
@@ -5500,6 +5500,12 @@ namespace LevelEditor
 		// Then copy the snapshot to the level data itself. Its the new state.
 		s_level = s_curSnapshot;
 
+		// ACAC: test
+		//if (!compareLevelInfs(s_infSnapshot, s_levelInf))
+		//{
+		//	LE_WARNING("INF NO MATCH");
+		//}
+
 		// Repopulate the Inf struct
 		copyInfData(&s_infSnapshot, &s_levelInf);
 

--- a/TheForceEngine/TFE_Editor/LevelEditor/levelEditorData.h
+++ b/TheForceEngine/TFE_Editor/LevelEditor/levelEditorData.h
@@ -338,6 +338,8 @@ namespace LevelEditor
 	void level_createGuidelineSnapshot(TFE_Editor::SnapshotBuffer* buffer);
 	void level_createLevelNoteSnapshot(TFE_Editor::SnapshotBuffer* buffer);
 	void level_createSingleGuidelineSnapshot(TFE_Editor::SnapshotBuffer* buffer, s32 index);
+	void level_createInfItemSnapshot(TFE_Editor::SnapshotBuffer* buffer);
+	void level_createInfItemModifySnapshot(TFE_Editor::SnapshotBuffer* buffer, u32 itemIndex);
 
 	void level_createLevelSectorSnapshotSameAssets(std::vector<EditorSector>& sectors);
 	void level_getLevelSnapshotDelta(std::vector<s32>& modifiedSectors, const std::vector<EditorSector>& sectorSnapshot);
@@ -351,6 +353,8 @@ namespace LevelEditor
 	void level_unpackGuidelineSnapshot(u32 size, void* data);
 	void level_unpackSingleGuidelineSnapshot(u32 size, void* data);
 	void level_unpackLevelNoteSnapshot(u32 size, void* data);
+	void level_unpackCreateInfSnapshot(u32 size, void* data);
+	void level_unpackInfItemModifySnapshot(u32 size, void* data);
 	
 	// Spatial Queries
 	s32  findSectorByName(const char* name, s32 excludeId = -1);

--- a/TheForceEngine/TFE_Editor/LevelEditor/levelEditorHistory.cpp
+++ b/TheForceEngine/TFE_Editor/LevelEditor/levelEditorHistory.cpp
@@ -30,6 +30,9 @@ namespace LevelEditor
 		LCmd_Guideline_Snapshot,
 		LCmd_Guideline_Snapshot_Single,
 		LCmd_LevelNote_Snapshot,
+		LCmd_Inf_Create_Snapshot,
+		LCmd_Inf_Modify_Snapshot,
+		//LCmd_Inf_Delete_Snapshot,
 		LCmd_Count
 	};
 
@@ -48,6 +51,8 @@ namespace LevelEditor
 	void cmd_applyGuidelineSnapshot();
 	void cmd_applyGuidelineSingleSnapshot();
 	void cmd_applyLevelNoteSnapshot();
+	void cmd_applyInfCreateSnapshot();
+	void cmd_applyInfModifySnapshot();
 
 	///////////////////////////////////
 	// API
@@ -64,6 +69,8 @@ namespace LevelEditor
 		history_registerCommand(LCmd_Guideline_Snapshot, cmd_applyGuidelineSnapshot);
 		history_registerCommand(LCmd_Guideline_Snapshot_Single, cmd_applyGuidelineSingleSnapshot);
 		history_registerCommand(LCmd_LevelNote_Snapshot, cmd_applyLevelNoteSnapshot);
+		history_registerCommand(LCmd_Inf_Create_Snapshot, cmd_applyInfCreateSnapshot);
+		history_registerCommand(LCmd_Inf_Modify_Snapshot, cmd_applyInfModifySnapshot);
 
 		history_registerName(LName_MoveVertex, "Move Vertice(s)");
 		history_registerName(LName_SetVertex, "Set Vertex Position");
@@ -107,6 +114,9 @@ namespace LevelEditor
 		history_registerName(LName_LevelNote_Delete, "Delete Note");
 		history_registerName(LName_LevelNote_Move, "Move Note");
 		history_registerName(LName_LevelNote_Change, "Change Note");
+		history_registerName(LName_Inf_Create, "Create INF Item");
+		history_registerName(LName_Inf_Change, "Edit INF Item");
+		history_registerName(LName_Inf_Delete, "Delete INF Item");
 	}
 
 	void levHistory_destroy()
@@ -347,6 +357,47 @@ namespace LevelEditor
 		}
 		CMD_END();
 	}
+
+	void cmd_infCreateSnapshot(u32 name)
+	{
+		s_workBuffer[0].clear();
+		s_workBuffer[1].clear();
+		level_createInfItemSnapshot(&s_workBuffer[0]);
+		if (s_workBuffer[0].empty()) { return; }
+
+		const u32 uncompressedSize = (u32)s_workBuffer[0].size();
+		const u32 compressedSize = compressBuffer();
+		if (!compressedSize) { return; }
+
+		CMD_BEGIN(LCmd_Inf_Create_Snapshot, name);
+		{
+			hBuffer_addU32(uncompressedSize);
+			hBuffer_addU32(compressedSize);
+			hBuffer_addArrayU8(compressedSize, s_workBuffer[1].data());
+		}
+		CMD_END();
+
+	}
+
+	void cmd_infModifySnapshot(u32 name, s32 index)
+	{
+		s_workBuffer[0].clear();
+		s_workBuffer[1].clear();
+		level_createInfItemModifySnapshot(&s_workBuffer[0], index);
+		if (s_workBuffer[0].empty()) { return; }
+
+		const u32 uncompressedSize = (u32)s_workBuffer[0].size();
+		const u32 compressedSize = compressBuffer();
+		if (!compressedSize) { return; }
+
+		CMD_BEGIN(LCmd_Inf_Modify_Snapshot, name);
+		{
+			hBuffer_addU32(uncompressedSize);
+			hBuffer_addU32(compressedSize);
+			hBuffer_addArrayU8(compressedSize, s_workBuffer[1].data());
+		}
+		CMD_END();
+	}
 		
 	////////////////////////////////
 	// History Commands
@@ -452,6 +503,32 @@ namespace LevelEditor
 		if (zstd_decompress(s_workBuffer[0].data(), uncompressedSize, compressedData, compressedSize))
 		{
 			level_unpackLevelNoteSnapshot(uncompressedSize, s_workBuffer[0].data());
+		}
+	}
+
+	void cmd_applyInfCreateSnapshot()
+	{
+		const u32 uncompressedSize = hBuffer_getU32();
+		const u32 compressedSize = hBuffer_getU32();
+		const u8* compressedData = hBuffer_getArrayU8(compressedSize);
+
+		s_workBuffer[0].resize(uncompressedSize);
+		if (zstd_decompress(s_workBuffer[0].data(), uncompressedSize, compressedData, compressedSize))
+		{
+			level_unpackCreateInfSnapshot(uncompressedSize, s_workBuffer[0].data());
+		}
+	}
+
+	void cmd_applyInfModifySnapshot()
+	{
+		const u32 uncompressedSize = hBuffer_getU32();
+		const u32 compressedSize = hBuffer_getU32();
+		const u8* compressedData = hBuffer_getArrayU8(compressedSize);
+
+		s_workBuffer[0].resize(uncompressedSize);
+		if (zstd_decompress(s_workBuffer[0].data(), uncompressedSize, compressedData, compressedSize))
+		{
+			level_unpackInfItemModifySnapshot(uncompressedSize, s_workBuffer[0].data());
 		}
 	}
 

--- a/TheForceEngine/TFE_Editor/LevelEditor/levelEditorHistory.h
+++ b/TheForceEngine/TFE_Editor/LevelEditor/levelEditorHistory.h
@@ -50,6 +50,9 @@ namespace LevelEditor
 		LName_LevelNote_Delete,
 		LName_LevelNote_Move,
 		LName_LevelNote_Change,
+		LName_Inf_Create,
+		LName_Inf_Change,
+		LName_Inf_Delete,
 		LName_Count
 	};
 
@@ -71,4 +74,7 @@ namespace LevelEditor
 	void cmd_guidelineSnapshot(u32 name);
 	void cmd_levelNoteSnapshot(u32 name, bool idChanged);
 	void cmd_guidelineSingleSnapshot(u32 name, s32 index, bool idChanged);
+	void cmd_infCreateSnapshot(u32 name);
+	void cmd_infModifySnapshot(u32 name, s32 itemIndex);
+	// void cmd_infDeleteSnapshot(u32 name, u32 itemIndex);
 }

--- a/TheForceEngine/TFE_Editor/LevelEditor/levelEditorInf.cpp
+++ b/TheForceEngine/TFE_Editor/LevelEditor/levelEditorInf.cpp
@@ -244,8 +244,11 @@ namespace LevelEditor
 		ITRIGGER_SINGLE
 	};
 
+	//static Editor_LevelInf s_levelInfTemp = {}; // Copy of state prior to editing
+	static Editor_InfItemHistory s_infItemTemp = {};
 	static InfEditor s_infEditor = {};
 	static InfEditorState s_infEditorState;
+	InfModified s_infModified = {};
 
 	static ImVec2 s_popupPos;
 	static s32 s_restorePos = 0;
@@ -380,6 +383,22 @@ namespace LevelEditor
 			s_levelInf.teleport[i] = s_levelInf.teleport[i + 1];
 		}
 		s_levelInf.teleport.pop_back();
+	}
+
+	void freeInfClass(Editor_InfClass* infClass)
+	{
+		if (infClass->classId == IIC_ELEVATOR)
+		{
+			freeElevator((Editor_InfElevator*)infClass);
+		}
+		else if (infClass->classId == IIC_TRIGGER)
+		{
+			freeTrigger((Editor_InfTrigger*)infClass);
+		}
+		else if (infClass->classId == IIC_TELEPORTER)
+		{
+			freeTeleporter((Editor_InfTeleporter*)infClass);
+		}
 	}
 		
 	Editor_InfElevator* getElevFromClassData(Editor_InfClass* data)
@@ -559,6 +578,203 @@ namespace LevelEditor
 		client->targetSector = arg;
 	}
 
+	bool isInfElevatorEqual(Editor_InfElevator* lElev, Editor_InfElevator* rElev)
+	{
+		if (lElev->slaves.size() != rElev->slaves.size() ||
+			lElev->stops.size() != rElev->stops.size())
+		{
+			LE_WARNING("elev slave/stop count mismatch");
+			return false;
+		}
+
+		if (lElev->classId != rElev->classId ||
+			lElev->type != rElev->type ||
+			lElev->overrideSet != rElev->overrideSet ||
+			lElev->start != rElev->start ||
+			lElev->speed != rElev->speed ||
+			lElev->angle != rElev->angle ||
+			lElev->flags != rElev->flags ||
+			(lElev->key[0] != rElev->key[0] || lElev->key[1] != rElev->key[1]) ||
+			(lElev->center.x != rElev->center.x || lElev->center.z != rElev->center.z) ||
+			(lElev->sounds[0] != rElev->sounds[0] || lElev->sounds[1] != rElev->sounds[1] || lElev->sounds[2] != rElev->sounds[2]) ||
+			lElev->master != rElev->master ||
+			lElev->eventMask != rElev->eventMask ||
+			lElev->entityMask != rElev->entityMask)
+		{
+			LE_WARNING("elevs don't match");
+			return false;
+		}
+
+		for (size_t j = 0; j < lElev->slaves.size(); j++)
+		{
+			if (lElev->slaves[j].name != rElev->slaves[j].name ||
+				lElev->slaves[j].angleOffset != rElev->slaves[j].angleOffset)
+			{
+				LE_WARNING("elev slave index %zu don't match", j);
+				return false;
+			}
+		}
+
+		for (size_t j = 0; j < lElev->stops.size(); j++)
+		{
+			Editor_InfStop* lStop = &lElev->stops[j];
+			Editor_InfStop* rStop = &rElev->stops[j];
+			if (lStop->adjoinCmd.size() != rStop->adjoinCmd.size() ||
+				lStop->textureCmd.size() != rStop->textureCmd.size() ||
+				lStop->msg.size() != rStop->msg.size() ||
+				lStop->scriptCall.size() != rStop->scriptCall.size())
+			{
+				LE_WARNING("elev stop index %zu cmd vecs dont match", j);
+				return false;
+			}
+
+			if (lStop->overrideSet != rStop->overrideSet ||
+				lStop->relative != rStop->relative ||
+				lStop->value != rStop->value ||
+				lStop->fromSectorFloor != rStop->fromSectorFloor ||
+				lStop->delayType != rStop->delayType ||
+				lStop->delay != rStop->delay ||
+				lStop->page != rStop->page)
+			{
+				LE_WARNING("elev stop index %zu data dont match", j);
+				return false;
+			}
+
+			for (size_t k = 0; k < lStop->adjoinCmd.size(); k++)
+			{
+				Editor_InfAdjoinCmd* lAdj = &lStop->adjoinCmd[k];
+				Editor_InfAdjoinCmd* rAdj = &rStop->adjoinCmd[k];
+				if (lAdj->sector0 != rAdj->sector0 ||
+					lAdj->sector1 != rAdj->sector1 ||
+					lAdj->wallIndex0 != rAdj->wallIndex0 ||
+					lAdj->wallIndex1 != rAdj->wallIndex1)
+				{
+					LE_WARNING("elev stop index %zu adj index %zu data dont match", j, k);
+					return false;
+				}
+			}
+
+			for (size_t k = 0; k < lStop->textureCmd.size(); k++)
+			{
+				Editor_InfTextureCmd* lTex = &lStop->textureCmd[k];
+				Editor_InfTextureCmd* rTex = &rStop->textureCmd[k];
+				if (lTex->donorSector != rTex->donorSector ||
+					lTex->fromCeiling != rTex->fromCeiling)
+				{
+					LE_WARNING("elev stop index %zu tex index %zu data dont match", j, k);
+					return false;
+				}
+			}
+
+			for (size_t k = 0; k < lStop->msg.size(); k++)
+			{
+				Editor_InfMessage* lMsg = &lStop->msg[k];
+				Editor_InfMessage* rMsg = &rStop->msg[k];
+				if (lMsg->targetSector != rMsg->targetSector ||
+					lMsg->targetWall != rMsg->targetWall ||
+					lMsg->type != rMsg->type ||
+					lMsg->eventFlags != rMsg->eventFlags ||
+					(lMsg->arg[0] != rMsg->arg[0] || lMsg->arg[1] != rMsg->arg[1]))
+				{
+					LE_WARNING("elev index %zu stop index %zu msg index %zu data dont match", j, k);
+					return false;
+				}
+			}
+
+			for (size_t k = 0; k < lStop->scriptCall.size(); k++)
+			{
+				Editor_ScriptCall* lCall = &lStop->scriptCall[k];
+				Editor_ScriptCall* rCall = &rStop->scriptCall[k];
+				if (lCall->funcName != rCall->funcName ||
+					lCall->arg[0].value != rCall->arg[0].value ||
+					lCall->arg[1].value != rCall->arg[1].value ||
+					lCall->arg[2].value != rCall->arg[2].value ||
+					lCall->arg[3].value != rCall->arg[3].value)
+				{
+					LE_WARNING("elev stop index %zu script index %zu data dont match", j, k);
+					return false;
+				}
+			}
+		}
+
+		return true;
+	}
+
+	bool isInfTriggerEqual(Editor_InfTrigger* lTrig, Editor_InfTrigger* rTrig)
+	{
+		if (lTrig->clients.size() != rTrig->clients.size())
+		{
+			LE_WARNING("trig client size not match");
+			return false;
+		}
+		if (lTrig->classId != rTrig->classId ||
+			lTrig->type != rTrig->type ||
+			lTrig->overrideSet != rTrig->overrideSet ||
+			lTrig->cmd != rTrig->cmd ||
+			(lTrig->arg[0] != rTrig->arg[0] || lTrig->arg[1] != rTrig->arg[1]) ||
+			lTrig->sound != rTrig->sound ||
+			lTrig->master != rTrig->master ||
+			lTrig->textId != rTrig->textId ||
+			lTrig->eventMask != rTrig->eventMask ||
+			lTrig->entityMask != rTrig->entityMask ||
+			lTrig->event != rTrig->event)
+		{
+			LE_WARNING("trig data not match");
+			return false;
+		}
+
+		for (size_t j = 0; j < lTrig->clients.size(); j++)
+		{
+			Editor_InfClient* lClient = &lTrig->clients[j];
+			Editor_InfClient* rClient = &rTrig->clients[j];
+			if (lClient->targetSector != rClient->targetSector ||
+				lClient->targetWall != rClient->targetWall ||
+				lClient->eventMask != rClient->eventMask)
+			{
+				LE_WARNING("trig client index %zu data not match", j);
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	bool isInfTeleporterEqual(Editor_InfTeleporter* lTele, Editor_InfTeleporter* rTele)
+	{
+		if (lTele->classId != rTele->classId ||
+			lTele->type != rTele->type ||
+			lTele->target != rTele->target ||
+			(lTele->dstPos.x != rTele->dstPos.x || lTele->dstPos.y != rTele->dstPos.y || lTele->dstPos.z != rTele->dstPos.z) ||
+			lTele->dstAngle != rTele->dstAngle)
+		{
+			LE_WARNING("tele data not match");
+			return false;
+		}
+
+		return true;
+	}
+
+	bool isInfClassEqual(Editor_InfClass* lClass, Editor_InfClass* rClass)
+	{
+		if (lClass->classId == rClass->classId)
+		{
+			if (lClass->classId == IIC_ELEVATOR)
+			{
+				return isInfElevatorEqual((Editor_InfElevator*)lClass, (Editor_InfElevator*)rClass);
+			}
+			else if (lClass->classId == IIC_TRIGGER)
+			{
+				return isInfTriggerEqual((Editor_InfTrigger*)lClass, (Editor_InfTrigger*)rClass);
+			}
+			else if (lClass->classId == IIC_TELEPORTER)
+			{
+				return isInfTeleporterEqual((Editor_InfTeleporter*)lClass, (Editor_InfTeleporter*)rClass);
+			}
+		}
+		assert(0); // Hard fail to catch mismatched class types. Something has gone wrong.
+		return false;
+	}
+
 	// Walk each member of two Editor_LevelInf structs testing for equality. Inf undo is scary.
 	bool compareLevelInfs(Editor_LevelInf& left, Editor_LevelInf& right)
 	{	
@@ -586,176 +802,33 @@ namespace LevelEditor
 			Editor_InfElevator* lElev = left.elevator[i];
 			Editor_InfElevator* rElev = right.elevator[i];
 
-			if (lElev->slaves.size() != rElev->slaves.size() ||
-				lElev->stops.size() != rElev->stops.size())
+			if (!isInfElevatorEqual(lElev, rElev))
 			{
-				LE_WARNING("compareLevelInfs(): elev index %zu slave/stop count mismatch", i);
+				LE_WARNING("Elev index: %zu", i);
 				return false;
 			}
-
-
-			if (lElev->classId != rElev->classId ||
-				lElev->type != rElev->type ||
-				lElev->overrideSet != rElev->overrideSet ||
-				lElev->start != rElev->start ||
-				lElev->speed != rElev->speed ||
-				lElev->angle != rElev->angle ||
-				lElev->flags != rElev->flags ||
-				(lElev->key[0] != rElev->key[0] || lElev->key[1] != rElev->key[1]) ||
-				(lElev->center.x != rElev->center.x || lElev->center.z != rElev->center.z) ||
-				(lElev->sounds[0] != rElev->sounds[0] || lElev->sounds[1] != rElev->sounds[1] || lElev->sounds[2] != rElev->sounds[2]) ||
-				lElev->master != rElev->master ||
-				lElev->eventMask != rElev->eventMask ||
-				lElev->entityMask != rElev->entityMask)
-			{
-				LE_WARNING("compareLevelInfs(): elev index %zu don't match", i);
-				return false;
-			}
-
-			for (size_t j = 0; j < lElev->slaves.size(); j++)
-			{
-				if (lElev->slaves[j].name != rElev->slaves[j].name ||
-					lElev->slaves[j].angleOffset != rElev->slaves[j].angleOffset)
-				{
-					LE_WARNING("compareLevelInfs(): elev index %zu slave index %zu don't match", i, j);
-					return false;
-				}
-			}
-
-			for (size_t j = 0; j < lElev->stops.size(); j++)
-			{
-				Editor_InfStop* lStop = &lElev->stops[j];
-				Editor_InfStop* rStop = &rElev->stops[j];
-				if (lStop->adjoinCmd.size() != rStop->adjoinCmd.size() ||
-					lStop->textureCmd.size() != rStop->textureCmd.size() ||
-					lStop->msg.size() != rStop->msg.size() ||
-					lStop->scriptCall.size() != rStop->scriptCall.size())
-				{
-					LE_WARNING("compareLevelInfs(): elev index %zu stop index %zu cmd vecs dont match", i, j);
-					return false;
-				}
-				
-				if (lStop->overrideSet != rStop->overrideSet ||
-					lStop->relative != rStop->relative ||
-					lStop->value != rStop->value ||
-					lStop->fromSectorFloor != rStop->fromSectorFloor ||
-					lStop->delayType != rStop->delayType ||
-					lStop->delay != rStop->delay ||
-					lStop->page != rStop->page)
-				{
-					LE_WARNING("compareLevelInfs(): elev index %zu stop index %zu data dont match", i, j);
-					return false;
-				}
-
-				for (size_t k = 0; k < lStop->adjoinCmd.size(); k++)
-				{
-					Editor_InfAdjoinCmd* lAdj = &lStop->adjoinCmd[k];
-					Editor_InfAdjoinCmd* rAdj = &rStop->adjoinCmd[k];
-					if (lAdj->sector0 != rAdj->sector0 ||
-						lAdj->sector1 != rAdj->sector1 ||
-						lAdj->wallIndex0 != rAdj->wallIndex0 ||
-						lAdj->wallIndex1 != rAdj->wallIndex1)
-					{
-						LE_WARNING("compareLevelInfs(): elev index %zu stop index %zu adj index %zu data dont match", i, j, k);
-						return false;
-					}
-				}
-
-				for (size_t k = 0; k < lStop->textureCmd.size(); k++)
-				{
-					Editor_InfTextureCmd* lTex = &lStop->textureCmd[k];
-					Editor_InfTextureCmd* rTex = &rStop->textureCmd[k];
-					if (lTex->donorSector != rTex->donorSector ||
-						lTex->fromCeiling != rTex->fromCeiling)
-					{
-						LE_WARNING("compareLevelInfs(): elev index %zu stop index %zu tex index %zu data dont match", i, j, k);
-						return false;
-					}
-				}
-
-				for (size_t k = 0; k < lStop->msg.size(); k++)
-				{
-					Editor_InfMessage* lMsg = &lStop->msg[k];
-					Editor_InfMessage* rMsg = &rStop->msg[k];
-					if (lMsg->targetSector != rMsg->targetSector ||
-						lMsg->targetWall != rMsg->targetWall ||
-						lMsg->type != rMsg->type ||
-						lMsg->eventFlags != rMsg->eventFlags ||
-						(lMsg->arg[0] != rMsg->arg[0] || lMsg->arg[1] != rMsg->arg[1]))
-					{
-						LE_WARNING("compareLevelInfs(): elev index %zu stop index %zu msg index %zu data dont match", i, j, k);
-						return false;
-					}
-				}
-
-				for (size_t k = 0; k < lStop->scriptCall.size(); k++)
-				{
-					Editor_ScriptCall* lCall = &lStop->scriptCall[k];
-					Editor_ScriptCall* rCall = &rStop->scriptCall[k];
-					if (lCall->funcName != rCall->funcName ||
-						lCall->arg[0].value != rCall->arg[0].value ||
-						lCall->arg[1].value != rCall->arg[1].value ||
-						lCall->arg[2].value != rCall->arg[2].value ||
-						lCall->arg[3].value != rCall->arg[3].value)
-					{
-						LE_WARNING("compareLevelInfs(): elev index %zu stop index %zu script index %zu data dont match", i, j, k);
-						return false;
-					}
-				}
-			} // for elev stops
-		} // for elev
+		}
 
 		for (size_t i = 0; i < left.trigger.size(); i++)
 		{
 			Editor_InfTrigger* lTrig = left.trigger[i];
 			Editor_InfTrigger* rTrig = right.trigger[i];
 
-			if (lTrig->clients.size() != rTrig->clients.size())
+			if (!isInfTriggerEqual(lTrig, rTrig))
 			{
-				LE_WARNING("compareLevelInfs(): trig index %zu client size not match", i);
+				LE_WARNING("Trig index: %zu", i);
 				return false;
 			}
-			if (lTrig->classId != rTrig->classId ||
-				lTrig->type != rTrig->type ||
-				lTrig->overrideSet != rTrig->overrideSet ||
-				lTrig->cmd != rTrig->cmd ||
-				(lTrig->arg[0] != rTrig->arg[0] || lTrig->arg[1] != rTrig->arg[1]) ||
-				lTrig->sound != rTrig->sound ||
-				lTrig->master != rTrig->master ||
-				lTrig->textId != rTrig->textId ||
-				lTrig->eventMask != rTrig->eventMask ||
-				lTrig->entityMask != rTrig->entityMask ||
-				lTrig->event != rTrig->event)
-			{
-				LE_WARNING("compareLevelInfs(): trig index %zu data not match", i);
-				return false;
-			}
-
-			for (size_t j = 0; j < lTrig->clients.size(); j++)
-			{
-				Editor_InfClient* lClient = &lTrig->clients[j];
-				Editor_InfClient* rClient = &rTrig->clients[j];
-				if (lClient->targetSector != rClient->targetSector ||
-					lClient->targetWall != rClient->targetWall ||
-					lClient->eventMask != rClient->eventMask)
-				{
-					LE_WARNING("compareLevelInfs(): trig index %zu client index %zu data not match", i, j);
-					return false;
-				}
-			}
-		} // for trig
+		}
 
 		for (size_t i = 0; i < left.teleport.size(); i++)
 		{
 			Editor_InfTeleporter* lTele = left.teleport[i];
 			Editor_InfTeleporter* rTele = right.teleport[i];
-			if (lTele->classId != rTele->classId ||
-				lTele->type != rTele->type ||
-				lTele->target != rTele->target ||
-				(lTele->dstPos.x != rTele->dstPos.x || lTele->dstPos.y != rTele->dstPos.y || lTele->dstPos.z != rTele->dstPos.z) ||
-				lTele->dstAngle != rTele->dstAngle)
+	
+			if (!isInfTeleporterEqual(lTele, rTele))
 			{
-				LE_WARNING("compareLevelInfs(): tele index %zu data not match", i);
+				LE_WARNING("Tele index: %zu", i);
 				return false;
 			}
 		}
@@ -1734,9 +1807,218 @@ namespace LevelEditor
 		}
 	}
 
+	bool isClassIndexesMatched()
+	{
+		for (const IndexPair pair : s_infModified.matches)
+		{
+			if (pair.i0 != pair.i1)
+			{
+				return false;
+			}
+		}
+		return true;
+	}
+
+	void clearInfItemTemp()
+	{
+		for (s32 i = (s32)s_infItemTemp.classData.size() - 1; i >= 0; i--)
+		{
+			Editor_InfClass* itemClass = s_infItemTemp.classData[i];
+			if (itemClass->classId == IIC_ELEVATOR)
+			{
+				Editor_InfElevator* elev = (Editor_InfElevator*)itemClass;
+				delete elev;
+			}
+			else if (itemClass->classId == IIC_TRIGGER)
+			{
+				Editor_InfTrigger* trig = (Editor_InfTrigger*)itemClass;
+				delete trig;
+			}
+			else if (itemClass->classId == IIC_TELEPORTER)
+			{
+				Editor_InfTeleporter* tele = (Editor_InfTeleporter*)itemClass;
+				delete tele;
+			}
+		}
+		s_infItemTemp = {};
+	}
+
+	void setInfItemTemp(Editor_InfItem* infItem)
+	{
+		s_infItemTemp.name = s_infEditor.item->name;
+		s_infItemTemp.wallNum = s_infEditor.item->wallNum;
+
+		// doing another set of allocs to compare against later feels a bit silly
+		for (size_t i = 0; i < s_infEditor.item->classData.size(); i++)
+		{
+			Editor_InfClass* infClass = s_infEditor.item->classData[i];
+			s_infItemTemp.classPtr.push_back((void*)infClass);
+			if (infClass->classId == IIC_ELEVATOR)
+			{
+				Editor_InfElevator* elev = new Editor_InfElevator();
+				elev->classId = IIC_ELEVATOR;
+				s_infItemTemp.classData.push_back((Editor_InfClass*)elev);
+				*elev = *(Editor_InfElevator*)s_infEditor.item->classData[i];
+
+			}
+			else if (infClass->classId == IIC_TRIGGER)
+			{
+				Editor_InfTrigger* trig = new Editor_InfTrigger();
+				trig->classId = IIC_TRIGGER;
+				s_infItemTemp.classData.push_back((Editor_InfClass*)trig);
+				*trig = *(Editor_InfTrigger*)s_infEditor.item->classData[i];
+			}
+			else if (infClass->classId == IIC_TELEPORTER)
+			{
+				Editor_InfTeleporter* tele = new Editor_InfTeleporter();
+				tele->classId = IIC_TELEPORTER;
+				s_infItemTemp.classData.push_back((Editor_InfClass*)tele);
+				*tele = *(Editor_InfTeleporter*)s_infEditor.item->classData[i];
+			}
+		}
+	}
+
+	void findInfChangesForHistory()
+	{
+		// INF class definitions and each item's reference to it are behind heap allocated
+		// pointers. Fine while in memory but for serialisation we need indexes instead.
+		// For saving to TFL export that's easy just capture the order at point in time.
+		
+		// For history functions, we assume all changes are limited in scope
+		// to the Editor_InfItem that the UI is pointing to, and its classData[]. Within
+		// that scope, capture the changes. Actions within here will change the index of
+		// classData members around it, so being able to identify which classData before editing
+		// matches which classData after editing is essential. As there is, currently, no
+		// unique identifier within each INF class, the next best thing to match on 
+		// is the pointer address.
+
+		// We can't just clone the pointers into a new Editor_InfItem and compare later
+		// because those pointers will also point to the modified future state which doesn't
+		// work. This is why Editor_InfItemHistory was made, to take coipes the pointer addresses
+		// and save to classPtr[]. Then we can manually alloc copies of the original data
+		// and do deep comparisons to test for modifications later.
+
+		// FIXME: Possible bug if allocElev/Trig allocs the same address while in the UI?
+		// Maybe this is a good reason for a uniqueId/serial in the class itself?
+
+
+		if (s_infEditor.item == nullptr)
+		{
+			return; // FIXME: deletions?
+		}
+
+		void* classPtr = nullptr;
+		Editor_InfItem* infItem = s_levelInf.item.data();
+
+		std::vector<IndexPair> currentClasses;
+
+		s32 currentItemIndex = -1;
+		s32 index = 0;
+		
+		s_infModified.matches.clear();
+		s_infModified.deleteIndexes.clear();
+		s_infModified.modifiedIndexes.clear();
+		s_infModified.newIndexes.clear();
+		
+
+		if (s_infEditor.item != nullptr)
+		{
+			currentItemIndex = (s32)(s_infEditor.item - s_levelInf.item.data());
+			if (currentItemIndex >= s_infItemTemp.infCount)
+			{
+				// New item. Any class data is assumed new entries.
+				cmd_infCreateSnapshot(LName_Inf_Create);
+			}
+			else
+			{
+				// Modified item.
+				// 1. Test for deletions.
+				Editor_InfClass* beforeItemClass;
+				Editor_InfClass* afterItemClass;
+				void* beforeItemPtr;
+				void* afterItemPtr;
+
+				bool found = false;
+				s32 oldClassDataSize = (s32)s_infItemTemp.classData.size();
+				s32 newClassDataSize = (s32)s_levelInf.item[currentItemIndex].classData.size();
+				for (s32 oldClassIndex = oldClassDataSize - 1; oldClassIndex >= 0; oldClassIndex--) // Store in the vec in descending order
+				{
+					found = false;
+					beforeItemPtr = s_infItemTemp.classPtr[oldClassIndex];
+					for (s32 newClassIndex = 0; newClassIndex < newClassDataSize; newClassIndex++)
+					{
+						afterItemPtr = (void*)s_levelInf.item[currentItemIndex].classData[newClassIndex];
+						
+						// There is no unique identifier within each class. So the only way to find matching
+						// classes before and after, assuming the index can shuffle around, is by comparing 
+						// the pointer addresses.
+						if (beforeItemPtr == afterItemPtr) 
+						{
+							assert(oldClassIndex >= newClassIndex); // Deletions may demote order in classData, but should never be higher.
+							s_infModified.matches.push_back({ oldClassIndex, newClassIndex });
+							found = true;
+							break;
+						}
+					}
+					if (!found)
+					{
+						s_infModified.deleteIndexes.push_back(oldClassIndex);
+					}
+				}
+				
+				// 2. Test for equality of matches
+				for (s32 i = 0; i < s_infModified.matches.size(); i++)
+				{
+					beforeItemClass = s_infItemTemp.classData[s_infModified.matches[i].i0];
+					afterItemClass = s_levelInf.item[currentItemIndex].classData[s_infModified.matches[i].i1];
+					if (!isInfClassEqual(beforeItemClass, afterItemClass))
+					{
+						s_infModified.modifiedIndexes.push_back(s_infModified.matches[i].i1);
+					}
+				}
+
+				// 3. Test for additions. classData in after that wasn't in before.
+				for (s32 newClassIndex = 0; newClassIndex < newClassDataSize; newClassIndex++)
+				{
+					afterItemPtr = (void*)s_levelInf.item[currentItemIndex].classData[newClassIndex];
+					found = false;
+					for (s32 oldClassIndex = 0; oldClassIndex < oldClassDataSize; oldClassIndex++)
+					{
+						beforeItemPtr = s_infItemTemp.classPtr[oldClassIndex];
+						if (afterItemPtr == beforeItemPtr)
+						{
+							found = true;
+							break;
+						}
+					}
+
+					if (!found)
+					{
+						// Addition
+						s_infModified.newIndexes.push_back(newClassIndex);
+					}
+				}
+
+				if (s_infModified.deleteIndexes.size() == 0 && s_infModified.modifiedIndexes.size() == 0 && s_infModified.newIndexes.size() == 0)
+				{
+					assert(isClassIndexesMatched());
+					return; // no changes
+				}
+				
+				cmd_infModifySnapshot(LName_Inf_Change, currentItemIndex);
+			}
+		}
+		else
+		{
+			// Test for delete case
+		}
+	}
+
 	void editor_infEditEnd()
 	{
 		modifySectorGeometry();
+		findInfChangesForHistory();
+		clearInfItemTemp();
 	}
 
 	const char* c_infElevFlagNames[] =
@@ -4376,7 +4658,7 @@ namespace LevelEditor
 			}
 		}
 	}
-		
+
 	bool editor_infEdit()
 	{
 		DisplayInfo info;
@@ -4401,6 +4683,18 @@ namespace LevelEditor
 		ImGui::PushStyleColor(ImGuiCol_ModalWindowDimBg, { 0.80f, 0.80f, 0.80f, 0.15f });
 
 		bool wasPopupOpen = ImGui::IsPopupOpen("Edit INF");
+		if (!wasPopupOpen) // Runs once on open
+		{
+			// Init history things
+			clearInfItemTemp();
+			s_infItemTemp.infCount = (s32)s_levelInf.item.size();
+			if (s_infEditor.item)
+			{
+				setInfItemTemp(s_infEditor.item);
+			}
+			
+		}
+
 		if (ImGui::BeginPopupModal("Edit INF", &active, window_flags))
 		{
 			// Popups need multiple frames to "accept" the new position due to the way the imGui window position logic works.

--- a/TheForceEngine/TFE_Editor/LevelEditor/levelEditorInf.cpp
+++ b/TheForceEngine/TFE_Editor/LevelEditor/levelEditorInf.cpp
@@ -559,6 +559,210 @@ namespace LevelEditor
 		client->targetSector = arg;
 	}
 
+	// Walk each member of two Editor_LevelInf structs testing for equality. Inf undo is scary.
+	bool compareLevelInfs(Editor_LevelInf& left, Editor_LevelInf& right)
+	{	
+		if (left.item.size() != right.item.size() ||
+			left.elevator.size() != right.elevator.size() ||
+			left.trigger.size() != right.trigger.size() ||
+			left.teleport.size() != right.teleport.size())
+		{
+			LE_WARNING("compareLevelInfs(): vec sizes don't match");
+			return false;
+		}
+
+		for (size_t i = 0; i < left.item.size(); i++)
+		{
+			if ((left.item[i].name != right.item[i].name) ||
+				(left.item[i].wallNum != right.item[i].wallNum))
+			{
+				LE_WARNING("compareLevelInfs(): item index %zu don't match", i);
+				return false;
+			}
+		}
+
+		for (size_t i = 0; i < left.elevator.size(); i++)
+		{
+			Editor_InfElevator* lElev = left.elevator[i];
+			Editor_InfElevator* rElev = right.elevator[i];
+
+			if (lElev->slaves.size() != rElev->slaves.size() ||
+				lElev->stops.size() != rElev->stops.size())
+			{
+				LE_WARNING("compareLevelInfs(): elev index %zu slave/stop count mismatch", i);
+				return false;
+			}
+
+
+			if (lElev->classId != rElev->classId ||
+				lElev->type != rElev->type ||
+				lElev->overrideSet != rElev->overrideSet ||
+				lElev->start != rElev->start ||
+				lElev->speed != rElev->speed ||
+				lElev->angle != rElev->angle ||
+				lElev->flags != rElev->flags ||
+				(lElev->key[0] != rElev->key[0] || lElev->key[1] != rElev->key[1]) ||
+				(lElev->center.x != rElev->center.x || lElev->center.z != rElev->center.z) ||
+				(lElev->sounds[0] != rElev->sounds[0] || lElev->sounds[1] != rElev->sounds[1] || lElev->sounds[2] != rElev->sounds[2]) ||
+				lElev->master != rElev->master ||
+				lElev->eventMask != rElev->eventMask ||
+				lElev->entityMask != rElev->entityMask)
+			{
+				LE_WARNING("compareLevelInfs(): elev index %zu don't match", i);
+				return false;
+			}
+
+			for (size_t j = 0; j < lElev->slaves.size(); j++)
+			{
+				if (lElev->slaves[j].name != rElev->slaves[j].name ||
+					lElev->slaves[j].angleOffset != rElev->slaves[j].angleOffset)
+				{
+					LE_WARNING("compareLevelInfs(): elev index %zu slave index %zu don't match", i, j);
+					return false;
+				}
+			}
+
+			for (size_t j = 0; j < lElev->stops.size(); j++)
+			{
+				Editor_InfStop* lStop = &lElev->stops[j];
+				Editor_InfStop* rStop = &rElev->stops[j];
+				if (lStop->adjoinCmd.size() != rStop->adjoinCmd.size() ||
+					lStop->textureCmd.size() != rStop->textureCmd.size() ||
+					lStop->msg.size() != rStop->msg.size() ||
+					lStop->scriptCall.size() != rStop->scriptCall.size())
+				{
+					LE_WARNING("compareLevelInfs(): elev index %zu stop index %zu cmd vecs dont match", i, j);
+					return false;
+				}
+				
+				if (lStop->overrideSet != rStop->overrideSet ||
+					lStop->relative != rStop->relative ||
+					lStop->value != rStop->value ||
+					lStop->fromSectorFloor != rStop->fromSectorFloor ||
+					lStop->delayType != rStop->delayType ||
+					lStop->delay != rStop->delay ||
+					lStop->page != rStop->page)
+				{
+					LE_WARNING("compareLevelInfs(): elev index %zu stop index %zu data dont match", i, j);
+					return false;
+				}
+
+				for (size_t k = 0; k < lStop->adjoinCmd.size(); k++)
+				{
+					Editor_InfAdjoinCmd* lAdj = &lStop->adjoinCmd[k];
+					Editor_InfAdjoinCmd* rAdj = &rStop->adjoinCmd[k];
+					if (lAdj->sector0 != rAdj->sector0 ||
+						lAdj->sector1 != rAdj->sector1 ||
+						lAdj->wallIndex0 != rAdj->wallIndex0 ||
+						lAdj->wallIndex1 != rAdj->wallIndex1)
+					{
+						LE_WARNING("compareLevelInfs(): elev index %zu stop index %zu adj index %zu data dont match", i, j, k);
+						return false;
+					}
+				}
+
+				for (size_t k = 0; k < lStop->textureCmd.size(); k++)
+				{
+					Editor_InfTextureCmd* lTex = &lStop->textureCmd[k];
+					Editor_InfTextureCmd* rTex = &rStop->textureCmd[k];
+					if (lTex->donorSector != rTex->donorSector ||
+						lTex->fromCeiling != rTex->fromCeiling)
+					{
+						LE_WARNING("compareLevelInfs(): elev index %zu stop index %zu tex index %zu data dont match", i, j, k);
+						return false;
+					}
+				}
+
+				for (size_t k = 0; k < lStop->msg.size(); k++)
+				{
+					Editor_InfMessage* lMsg = &lStop->msg[k];
+					Editor_InfMessage* rMsg = &rStop->msg[k];
+					if (lMsg->targetSector != rMsg->targetSector ||
+						lMsg->targetWall != rMsg->targetWall ||
+						lMsg->type != rMsg->type ||
+						lMsg->eventFlags != rMsg->eventFlags ||
+						(lMsg->arg[0] != rMsg->arg[0] || lMsg->arg[1] != rMsg->arg[1]))
+					{
+						LE_WARNING("compareLevelInfs(): elev index %zu stop index %zu msg index %zu data dont match", i, j, k);
+						return false;
+					}
+				}
+
+				for (size_t k = 0; k < lStop->scriptCall.size(); k++)
+				{
+					Editor_ScriptCall* lCall = &lStop->scriptCall[k];
+					Editor_ScriptCall* rCall = &rStop->scriptCall[k];
+					if (lCall->funcName != rCall->funcName ||
+						lCall->arg[0].value != rCall->arg[0].value ||
+						lCall->arg[1].value != rCall->arg[1].value ||
+						lCall->arg[2].value != rCall->arg[2].value ||
+						lCall->arg[3].value != rCall->arg[3].value)
+					{
+						LE_WARNING("compareLevelInfs(): elev index %zu stop index %zu script index %zu data dont match", i, j, k);
+						return false;
+					}
+				}
+			} // for elev stops
+		} // for elev
+
+		for (size_t i = 0; i < left.trigger.size(); i++)
+		{
+			Editor_InfTrigger* lTrig = left.trigger[i];
+			Editor_InfTrigger* rTrig = right.trigger[i];
+
+			if (lTrig->clients.size() != rTrig->clients.size())
+			{
+				LE_WARNING("compareLevelInfs(): trig index %zu client size not match", i);
+				return false;
+			}
+			if (lTrig->classId != rTrig->classId ||
+				lTrig->type != rTrig->type ||
+				lTrig->overrideSet != rTrig->overrideSet ||
+				lTrig->cmd != rTrig->cmd ||
+				(lTrig->arg[0] != rTrig->arg[0] || lTrig->arg[1] != rTrig->arg[1]) ||
+				lTrig->sound != rTrig->sound ||
+				lTrig->master != rTrig->master ||
+				lTrig->textId != rTrig->textId ||
+				lTrig->eventMask != rTrig->eventMask ||
+				lTrig->entityMask != rTrig->entityMask ||
+				lTrig->event != rTrig->event)
+			{
+				LE_WARNING("compareLevelInfs(): trig index %zu data not match", i);
+				return false;
+			}
+
+			for (size_t j = 0; j < lTrig->clients.size(); j++)
+			{
+				Editor_InfClient* lClient = &lTrig->clients[j];
+				Editor_InfClient* rClient = &rTrig->clients[j];
+				if (lClient->targetSector != rClient->targetSector ||
+					lClient->targetWall != rClient->targetWall ||
+					lClient->eventMask != rClient->eventMask)
+				{
+					LE_WARNING("compareLevelInfs(): trig index %zu client index %zu data not match", i, j);
+					return false;
+				}
+			}
+		} // for trig
+
+		for (size_t i = 0; i < left.teleport.size(); i++)
+		{
+			Editor_InfTeleporter* lTele = left.teleport[i];
+			Editor_InfTeleporter* rTele = right.teleport[i];
+			if (lTele->classId != rTele->classId ||
+				lTele->type != rTele->type ||
+				lTele->target != rTele->target ||
+				(lTele->dstPos.x != rTele->dstPos.x || lTele->dstPos.y != rTele->dstPos.y || lTele->dstPos.z != rTele->dstPos.z) ||
+				lTele->dstAngle != rTele->dstAngle)
+			{
+				LE_WARNING("compareLevelInfs(): tele index %zu data not match", i);
+				return false;
+			}
+		}
+
+		return true;
+	}
+
 	bool editor_parseElevatorCommand(s32 argCount, KEYWORD action, bool seqEnd, Editor_InfElevator* elev, s32& addon)
 	{
 		char* endPtr = nullptr;

--- a/TheForceEngine/TFE_Editor/LevelEditor/levelEditorInf.h
+++ b/TheForceEngine/TFE_Editor/LevelEditor/levelEditorInf.h
@@ -329,6 +329,10 @@ namespace LevelEditor
 
 	void editor_infGetViewportControl(Editor_InfVpControl* ctrl);
 
+	s32 getClassIndex(Editor_InfItemClass classId, const void* classPtr);
+
+	bool compareLevelInfs(Editor_LevelInf& left, Editor_LevelInf& right);
+
 	const Editor_InfElevator* getElevFromClassData(const Editor_InfClass* data);
 	const Editor_InfTrigger* getTriggerFromClassData(const Editor_InfClass* data);
 	const Editor_InfTeleporter* getTeleporterFromClassData(const Editor_InfClass* data);

--- a/TheForceEngine/TFE_Editor/LevelEditor/levelEditorInf.h
+++ b/TheForceEngine/TFE_Editor/LevelEditor/levelEditorInf.h
@@ -312,6 +312,7 @@ namespace LevelEditor
 
 	extern Editor_LevelInf s_levelInf;
 
+	void editor_infDestroy();
 	bool loadLevelInfFromAsset(const TFE_Editor::Asset* asset);
 	void editor_infEditBegin(const char* sectorName, s32 wallIndex = -1);
 	void editor_infEditEnd();

--- a/TheForceEngine/TFE_Editor/LevelEditor/levelEditorInf.h
+++ b/TheForceEngine/TFE_Editor/LevelEditor/levelEditorInf.h
@@ -292,6 +292,24 @@ namespace LevelEditor
 		std::vector<Editor_InfTeleporter*>    teleport;
 	};
 
+	struct Editor_InfItemHistory
+	{
+		std::string name;
+		s32 wallNum = -1;
+		s32 infCount = -1;
+		std::vector<Editor_InfClass*> classData;
+		std::vector<void*> classPtr; // Pointers to original data for testing equality
+	};
+
+	// Modify INF history, index tracking
+	struct InfModified
+	{
+		std::vector<IndexPair>matches;
+		std::vector<s32>deleteIndexes; // temp var refs
+		std::vector<s32>modifiedIndexes; // s_levelInf refs
+		std::vector<s32>newIndexes; //s_levelInf refs
+	};
+
 	enum InfVpControlType
 	{
 		InfVpControl_None = 0,
@@ -311,6 +329,7 @@ namespace LevelEditor
 	};
 
 	extern Editor_LevelInf s_levelInf;
+	extern InfModified s_infModified;
 
 	void editor_infDestroy();
 	bool loadLevelInfFromAsset(const TFE_Editor::Asset* asset);
@@ -336,4 +355,9 @@ namespace LevelEditor
 	const Editor_InfElevator* getElevFromClassData(const Editor_InfClass* data);
 	const Editor_InfTrigger* getTriggerFromClassData(const Editor_InfClass* data);
 	const Editor_InfTeleporter* getTeleporterFromClassData(const Editor_InfClass* data);
+
+	void freeInfClass(Editor_InfClass* infClass);
+	Editor_InfElevator* allocElev(Editor_InfItem* item);
+	Editor_InfTrigger* allocTrigger(Editor_InfItem* item);
+	Editor_InfTeleporter* allocTeleporter(Editor_InfItem* item);
 }


### PR DESCRIPTION
Undo / redo for level INF data

Details of the changes are in each commit, grouped into reasonable chunks.

It's a bit convoluted due to the way INF is stored in memory inside of a Editor_LevelInf.

INF delete not yet implemented.